### PR TITLE
Update "try it out steps"

### DIFF
--- a/examples/angular2/README.md
+++ b/examples/angular2/README.md
@@ -4,10 +4,12 @@ This is an example usage of RxDB with Angular2. It implements a simple heroes-li
 
 # Try it out
 1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)
-2. go to this folder (examples/angular2)
-3. run "npm install"
-4. run "npm start"
-5. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**
+2. go into project `cd rxdb`
+3. run `npm install`
+4. go to this folder `cd examples/angular2`
+5. run `npm install`
+6. run `npm start`
+7. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**
 
 
 # Screenshot


### PR DESCRIPTION
The example requires the adapter-localstorage plugin from the main project. The adapter-localstorage is looking for pouchdb-adapter-leveldb-core and d64 humble-localstorage tiny-queue in it's relative node_modules or any parent directories that have node_modules subdirectory.  Therefore npm install 
(or npm install pouchdb-adapter-leveldb-core d64 humble-localstorage tiny-queue pouchdb-adapter-websql) needs to be run as well.

Additionally, pouchdb-adapter-websql is a dependency of the example, however the dependency graph will continue up into parent directories until it finds a "node_modules/pouchdb-adapter-websql".  Therefore the npm install on the project root will satisfy the dependency.  Alternatively you could go into the lib/adapter-localstorage directory and run npm install