### PR TITLE
Make it possible to findOne by id if you have a default PrimaryPath

### DIFF
--- a/src/RxQuery.js
+++ b/src/RxQuery.js
@@ -120,7 +120,7 @@ class RxQuery {
 
             // selector
             json.selector._id = json.selector[primPath];
-            delete json.selector[primPath];
+            if(primPath !== '_id') delete json.selector[primPath]; 
         }
 
         return json;


### PR DESCRIPTION
Right now doing `findOne('id')` returns all of the documents in the collection if you're using the default primaryPath

Making sure that the primPath isn't `_id` before deleting it from the selectors inside of `toJSON` in Query seems to fix it