### PR TITLE
Disables pouchdb-adapter-websql tests in Edge

### DIFF
--- a/test/unit/PouchDB-integration.test.js
+++ b/test/unit/PouchDB-integration.test.js
@@ -91,8 +91,9 @@ describe('PouchDB-integration.test.js', () => {
                 if (platform.isNode()) return;
                 if (/Firefox/.test(window.navigator.userAgent)) return;
 
-                // no websql in internet explorer
+                // no websql in internet explorer nor Edge
                 if (platform.name == 'IE') return;
+                if (platform.name == 'Microsoft Edge') return;
 
                 RxDB.plugin(require('pouchdb-adapter-websql'));
                 const db = await RxDB.create({


### PR DESCRIPTION
Microsoft Edge, just like Internet Explorer [does *not* support websql](http://caniuse.com/#feat=sql-storage). Tests fail on MS Edge when importing `pouchdb-adapter-websql`.

Here's the stack trace for the offending test:
```
Edge 14.14393.0 (Windows 10 0.0.0) PouchDB-integration.test.js websql positive should work after adding the adapter FAILED
        Error: Adapter websql not added.
                         Use RxDB.plugin(require('pouchdb-adapter-websql');
           at _callee9$ (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:3499:25)
           at tryCatch (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:213390:7)
           at invoke (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:213625:9)
           at prototype[method] (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:213442:9)
           at step (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:3592:172)
           at Anonymous function (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:3592:430)
           at Promise (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:35872:7)
           at Anonymous function (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:3592:92)
           at create (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:3548:9)
           at _callee$ (C:/Users/Jacek/AppData/Local/Temp/9bb33e79b3ffd33b7098ebe86521016c.browserify:6010:25)
```