### PR TITLE
Refactor mquery to use ES6 module syntax and enable usage of the untranspiled source as a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",
   "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "types": "./src/index.d.ts",
   "scripts": {
     "pretest": "npm run transpile",

--- a/src/mquery/mquery.js
+++ b/src/mquery/mquery.js
@@ -3,7 +3,7 @@
  * @link https://github.com/aheckmann/mquery/blob/master/lib/mquery.js
  */
 'use strict';
-const utils = require('./mquery_utils');
+import * as utils from './mquery_utils';
 import {
     default as clone
 } from 'clone';

--- a/src/mquery/mquery.js
+++ b/src/mquery/mquery.js
@@ -287,7 +287,6 @@ Query.prototype.elemMatch = function() {
 
 /**
  * Sets the sort order
-<<<<<<< HEAD
  * If an object is passed, values allowed are 'asc', 'desc', 'ascending', 'descending', 1, and -1.
  * If a string is passed, it must be a space delimited list of path names. The sort order of each path is ascending unless the path name is prefixed with `-` which will be treated as descending.
  * ####Example

--- a/src/mquery/mquery_utils.js
+++ b/src/mquery/mquery_utils.js
@@ -17,7 +17,7 @@ import {
  * @api private
  */
 
-const merge = exports.merge = function merge(to, from) {
+export function merge(to, from) {
     const keys = Object.keys(from);
     let i = keys.length;
     let key;
@@ -27,7 +27,7 @@ const merge = exports.merge = function merge(to, from) {
         if ('undefined' === typeof to[key])
             to[key] = from[key];
         else {
-            if (exports.isObject(from[key]))
+            if (isObject(from[key]))
                 merge(to[key], from[key]);
             else
                 to[key] = from[key];
@@ -42,7 +42,7 @@ const merge = exports.merge = function merge(to, from) {
  * @param {Object} from
  * @api private
  */
-const mergeClone = exports.mergeClone = function mergeClone(to, from) {
+export function mergeClone(to, from) {
     const keys = Object.keys(from);
     let i = keys.length;
     let key;
@@ -56,7 +56,7 @@ const mergeClone = exports.mergeClone = function mergeClone(to, from) {
                 retainKeyOrder: 1
             });
         } else {
-            if (exports.isObject(from[key]))
+            if (isObject(from[key]))
                 mergeClone(to[key], from[key]);
             else {
                 // make sure to retain key order here because of a bug handling the
@@ -75,7 +75,7 @@ const mergeClone = exports.mergeClone = function mergeClone(to, from) {
  */
 
 const _toString = Object.prototype.toString;
-const toString = exports.toString = function(arg) {
+export function toString(arg) {
     return _toString.call(arg);
 };
 
@@ -86,19 +86,19 @@ const toString = exports.toString = function(arg) {
  * @return {Boolean}
  */
 
-const isObject = exports.isObject = function(arg) {
-    return '[object Object]' == exports.toString(arg);
+export function isObject(arg) {
+    return '[object Object]' == toString(arg);
 };
 
 
-exports.create = Object.create;
+export const create = Object.create;
 
 
 /**
  * inheritance
  */
-exports.inherits = function(ctor, superCtor) {
-    ctor.prototype = exports.create(superCtor.prototype);
+export function inherits(ctor, superCtor) {
+    ctor.prototype = create(superCtor.prototype);
     ctor.prototype.constructor = ctor;
 };
 
@@ -110,6 +110,6 @@ exports.inherits = function(ctor, superCtor) {
  * @return {Boolean}
  */
 
-exports.isArgumentsObject = function(v) {
+export function isArgumentsObject(v) {
     return Object.prototype.toString.call(v) === '[object Arguments]';
 };


### PR DESCRIPTION
The included mquery library uses a non-standard export syntax. This makes webpack unable to transpile it in the angular2 build process. This PR updates the mquery exports.

With this fixed, angular2 will use the RxDB source files, transpile them in it's own build process, and will not require the babel-polyfill.

Additionally, I've added a `module` field to package.json, as [webpack 2.x doesn't use the provided `jsnext:main` field by default](https://webpack.js.org/configuration/resolve/#resolve-mainfields).

If this is merged, I'll update the included angular2 example.

BTW, I wasn't able to reliably run the tests - they seem to sometimes fail randomly for no apparent reason (I did manage to get 100% passes at least once ;) ).