### PR TITLE
Remove babel-polyfill from the Angular example

### DIFF
--- a/examples/angular2/app/polyfills.ts
+++ b/examples/angular2/app/polyfills.ts
@@ -4,7 +4,6 @@
 
 // import 'core-js/es6';
 // Added parts of es6 which are necessary for your project or your browser support requirements.
-import 'babel-polyfill';
 import 'core-js/es6/symbol';
 import 'core-js/es6/object';
 import 'core-js/es6/function';

--- a/examples/angular2/package.json
+++ b/examples/angular2/package.json
@@ -29,7 +29,6 @@
     "@angular/platform-browser-dynamic": "2.4.8",
     "@angular/platform-server": "2.4.8",
     "@angular/router": "3.4.8",
-    "babel-polyfill": "6.23.0",
     "concurrently": "3.3.0",
     "core-js": "2.4.1",
     "hammerjs": "2.0.8",


### PR DESCRIPTION
The RxDB source can now be used as a module directly in Angular, without the need to use the transpiled library from the `dist` folder. This makes `babel-polyfill` no longer required by the example, as the provided core.js polyfills are sufficient.

This PR removes `babel-polyfill` from the example.