### PR TITLE
fix typings of SchemaJSON#properties

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,7 +59,7 @@ interface SchemaJSON {
     description?: string;
     version: number;
     type: string;
-    properties: JsonSchema;
+    properties: { [key: string]: JsonSchema };
     required?: Array<string>;
     compoundIndexes?: Array<string | Array<string>>;
     disableKeyCompression?: boolean;


### PR DESCRIPTION
So I am not 100% sure about this one, so it comes as a separate pull request.  Problem: 

```js
           db.collection({
                name: 'accounts',
                schema: {
                    title: 'accounts schema',
                    version: 0,
                    type: 'object',
                    properties: {
                        name: {
                            type: 'string',
                            primary: true
                        },
                        type: {
                            type: 'string'
                        },
                        banking: {
                            type: 'object'
                        }
                    }
                }
            });
```

is not valid, due to properties being set to type `JsonSchema`, which requires `type` to be a string.
I think the change in the pull request would not be correct if `schema.type` is set to s.th. like `string`, but must use-cases are probably `object`, for which properties is a key-schema map.

I might have not actually created this pull request if the invalid field was just `type`, but with properties set to `JsonSchema` the problem occurs also with other fields in `JsonSchema`, e.g. `description` ( I currently just want to store two models in rxdb, accounts having a type and transactions having a description, so I hit both definition problems :D).

I would also like to adjust the `schema.type` from `string` to actual `JsonSchemaTypes`, but I need your feedback there since I just discovered rxdb today: under schema.type, are all `JsonSchemaTypes` valid, or is it really just `'object'`?

for reference: 

    type JsonSchemaTypes = "array" | "boolean" | "integer" | "number" | "null" | "object" | "string";