### PR TITLE
Added explicit any return for PouchDB info

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -199,7 +199,7 @@ destroy(): void;
 
 declare class PouchDB {
     constructor(name: string, options: { adapter: string });
-    info();
+    info(): any;
 }
 
 


### PR DESCRIPTION
Allows usage of TypeScript compiler flag "noImplicitAny", this was the only place no explicit return type was provided for a function.