### PR TITLE
Revert "added update functionality"

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "deep-equal": "^1.0.1",
     "es6-promise": "^4.0.5",
     "is-my-json-valid": "^2.16.0",
-    "modifyjs": "^0.3.1",
     "object-path": "0.11.4",
     "pouchdb-core": "6.2.0",
     "pouchdb-find": "6.2.0",

--- a/src/RxCollection.js
+++ b/src/RxCollection.js
@@ -287,18 +287,6 @@ class RxCollection {
         }
     }
 
-  /**
-   * updates an object with a mongolike syntax
-   * @param  {object} queryObj
-   * @param  {object} updateObj
-   */
-
-    async update(queryObj, updateObj) {
-        const docs = await this.find(queryObj).exec();
-        for (let doc of docs)
-            await doc.update(updateObj);
-    }
-
     /**
      * takes a mongoDB-query-object and returns the documents
      * @param  {object} queryObj

--- a/src/RxDocument.js
+++ b/src/RxDocument.js
@@ -1,7 +1,6 @@
 import clone from 'clone';
 import objectPath from 'object-path';
 import deepEqual from 'deep-equal';
-import modify from 'modifyjs';
 
 import * as util from './util';
 import * as RxChangeEvent from './RxChangeEvent';
@@ -250,33 +249,6 @@ class RxDocument {
 
         return this;
     };
-
-    /**
-     * updates document
-     *  @param  {object} updateObj
-     */
-    async update(updateObj) {
-        const newDoc = modify(this._data, updateObj);
-
-        Object.keys(this._data).forEach((previousPropName) => {
-            if (newDoc[previousPropName]) {
-                // if we don't check inequality, it triggers an update attempt on fields that didn't really change,
-                // which causes problems with "readonly" fields
-                if (!deepEqual(this[previousPropName], newDoc[previousPropName]))
-                    this[previousPropName] = newDoc[previousPropName];
-
-            } else
-                delete this[previousPropName];
-
-        });
-        delete newDoc._rev;
-        delete newDoc._id;
-        Object.keys(newDoc).forEach(newPropName => {
-            if (!deepEqual(this[newPropName], newDoc[newPropName]))
-                this[newPropName] = newDoc[newPropName];
-        });
-        await this.save();
-    }
 
     /**
      * save document if its data has changed

--- a/src/RxQuery.js
+++ b/src/RxQuery.js
@@ -305,23 +305,6 @@ class RxQuery {
         return docs;
     }
 
-  /**
-   * updates all found documents
-   * @param  {object} updateObj
-   * @return {Promise(RxDocument|RxDocument[])} promise with updated documents
-   */
-    async update(updateObj) {
-        const docs = await this.exec();
-        if (Array.isArray(docs)) {
-            await Promise.all(
-                docs.map(doc => doc.update(updateObj))
-            );
-        } else {
-            // via findOne()
-            await docs.update(updateObj);
-        }
-        return docs;
-    }
 
     async exec() {
         return await this.$

--- a/test/unit/RxCollection.test.js
+++ b/test/unit/RxCollection.test.js
@@ -360,15 +360,6 @@ describe('RxCollection.test.js', () => {
                 });
             });
         });
-        describe('.update()', () => {
-            it('should update all documents matched by a query', async() => {
-                const c = await humansCollection.create();
-                await c.update({}, {$set: {firstName: 'new first name'}});
-                const docs = await c.find().exec();
-                for (let doc of docs)
-                    assert.equal(doc._data.firstName, 'new first name');
-            });
-        });
         describe('.find()', () => {
             describe('find all', () => {
                 describe('positive', () => {
@@ -805,16 +796,6 @@ describe('RxCollection.test.js', () => {
                     assert.equal(removed.deleted, true);
                     const docsAfter = await c.find().exec();
                     assert.equal(docsAfter.length, 9);
-                });
-            });
-            describe('.update()', () => {
-                it('should update all documents', async() => {
-                    const c = await humansCollection.create(10);
-                    const query = c.find();
-                    const updated = await query.update({$set: {firstName: 'new first name'}});
-                    const docsAfterUpdate = await c.find().exec();
-                    for (let doc of docsAfterUpdate)
-                        assert.equal(doc._data.firstName, 'new first name');
                 });
             });
         });

--- a/test/unit/RxDocument.test.js
+++ b/test/unit/RxDocument.test.js
@@ -261,27 +261,6 @@ describe('RxDocument.test.js', () => {
             });
         });
     });
-    describe('update', () => {
-        it('a value with a mongo like query', async() => {
-            const c = await humansCollection.createPrimary(1);
-            const doc = await c.findOne().exec();
-            await doc.update({$set: {firstName: 'new first name'}});
-            const updatedDoc = await c.findOne({firstName: 'new first name'}).exec();
-            assert.equal(updatedDoc.firstName, 'new first name');
-        });
-
-        it('unset a value', async() => {
-            const c = await humansCollection.createPrimary(1);
-            const doc = await c.findOne().exec();
-            await doc.update({
-                $unset: {
-                    firstName: ''
-                }
-            });
-            const updatedDoc = await c.findOne().exec();
-            assert.equal(updatedDoc.firstName, undefined);
-        });
-    });
     describe('pseudo-Proxy', () => {
         describe('get', () => {
             it('top-value', async() => {


### PR DESCRIPTION
Reverts pubkey/rxdb#153

Test not working:

```js
it('unset a value', async() => {
                const c = await humansCollection.createPrimary(1);
                const query = c.find();
                await query.update({
                    $unset: {
                        firstName: ''
                    }
                });
                const docs = await query.exec();
                for (let doc of docs)
                    assert.equal(doc._data.firstName, undefined);
                c.database.destroy();
            });
```