### PR TITLE
Typescript fix

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -186,7 +186,7 @@ declare class RxCollection {
     }>;
     migratePromise(batchSize: number): Promise<any>;
 
-    sync(SyncOptions): RxReplicationState;
+    sync(syncOptions: SyncOptions): RxReplicationState;
     // if you do custom-sync, use this
     createRxReplicationState(): RxReplicationState;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,3 @@
-import {Promise} from "es6-promise";
 import {Observable} from "rxjs";
 
 declare class RxSchema {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR
In typescript declaration, leave it to typescript/webpack compiler and not forcefully polyfill `Promise`. Project not using `es6-promise` polyfill experiences typing error, having two mis-matched versions of `Promise`.

Fixed an argument declaration.
