### PR TITLE
Fix CSP Issue by use z-schema as validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "clone": "^2.1.1",
     "crypto-js": "^3.1.8",
     "deep-equal": "^1.0.1",
-    "is-my-json-valid": "^2.16.0",
     "modifyjs": "0.3.1",
     "object-path": "0.11.4",
     "pouchdb-core": "6.3.4",
@@ -72,7 +71,8 @@
     "random-token": "0.0.8",
     "spark-md5": "^3.0.0",
     "unload": "^1.3.5",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "z-schema": "^3.18.2"
   },
   "devDependencies": {
     "assert": "1.4.1",

--- a/src/RxSchema.js
+++ b/src/RxSchema.js
@@ -1,7 +1,7 @@
 import objectPath from 'object-path';
 import clone from 'clone';
 
-const ZSchema = require("z-schema");
+const ZSchema = require('z-schema');
 const validator = new ZSchema();
 
 import * as util from './util';

--- a/src/RxSchema.js
+++ b/src/RxSchema.js
@@ -1,10 +1,11 @@
 import objectPath from 'object-path';
 import clone from 'clone';
 
-const validator = require('is-my-json-valid');
+const ZSchema = require("z-schema");
+const validator = new ZSchema();
 
 import * as util from './util';
-import RxDocument from './RxDocument';
+import * as RxDocument from './RxDocument';
 
 export class RxSchema {
     constructor(jsonID) {
@@ -117,10 +118,10 @@ export class RxSchema {
                     error: 'does the field ' + schemaPath + ' exist in your schema?'
                 }));
             }
-            this._validators[schemaPath] = validator(schemaPart);
+            this._validators[schemaPath] = schemaPart;
         }
-        const useValidator = this._validators[schemaPath];
-        const isValid = useValidator(obj);
+        const schemaPart = this._validators[schemaPath];
+        const isValid = validator.validate(obj, schemaPart);
         if (isValid) return obj;
         else {
             throw new Error(JSON.stringify({
@@ -508,16 +509,3 @@ export function isInstanceOf(obj) {
     return obj instanceof RxSchema;
 }
 
-export default {
-    RxSchema,
-    getEncryptedPaths,
-    hasCrypt,
-    getIndexes,
-    getPrimary,
-    checkFieldNameRegex,
-    validateFieldsDeep,
-    checkSchema,
-    normalize,
-    create,
-    isInstanceOf
-};


### PR DESCRIPTION
## This PR contains:
A BUGFIX
## Describe the problem you have without this PR
JSON Schema Validator fails when running on a server with content security policy enabled, error sample:
**EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive**

related issue #235 
