### PR TITLE
Export all interfaces

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -309,15 +309,21 @@ export function isRxQuery(obj: any): boolean;
 export function isRxSchema(obj: any): boolean;
 
 export {
-    RxDatabase as RxDatabase,
-    RxCollection as RxCollection,
-    RxQuery as RxQuery,
-    RxSchema as RxSchema,
-    RxDocument as RxDocument,
-    RxChangeEvent as RxChangeEvent,
-    PouchDB as PouchDB,
-    RxCollectionCreator as RxCollectionCreator,
-    RxError as RxError
+    RxDatabase,
+    RxCollection,
+    RxQuery,
+    RxSchema,
+    RxDocument,
+    RxChangeEvent,
+    PouchDB,
+    RxCollectionCreator,
+    RxError,
+    JsonSchemaTypes,
+    JsonSchema,
+    SchemaJSON,
+    PouchSettings,
+    PouchReplicationOptions,
+    SyncOptions
 };
 
 export default {


### PR DESCRIPTION
## This PR contains: 
Improved Typings

## Describe the problem you have without this PR
Development with strong types is easier when all the used interfaces are available to the developer. 

For instance, look at this file I wrote for one of my collections:
```ts
 import { RxCollectionCreator, RxSchema } from 'rxdb';

export interface IExpenseType {
  id?: string;
  name?: string;
}

export const ExpenseTypeSchema = {
  type: 'object',
  version: 0,
  disableKeyCompression: true,
  properties: {
    id: {
      type: 'string',
      primary: true
    },
    name: {
      type: 'string'
    }
  }
};

export const ExpenseTypeCollection: RxCollectionCreator = {
  name: 'expense-type',
  schema: RxSchema.create(ExpenseTypeSchema)
};
```

If I had access to the `SchemaJSON` interface, I would be able to assign it as a type for `ExpenseTypeSchema`. This will make my IDE let me know as soon as I've made a mistake and wrote something that doesn't follow the interface. 

Without having that interface exported, my IDE will only throw an error when I pass that object to `RxSchema.create(...)`.