### PR TITLE
Improve typings for collections and queries

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -168,12 +168,12 @@ declare class RxCollection<RxDocumentType> {
     schema: RxSchema;
 
     $: Observable<RxChangeEvent>;
-    insert(json: any): Promise<RxDocument>;
-    newDocument(json: any): RxDocument;
-    upsert(json: any): Promise<RxDocument>;
-    atomicUpsert(json: any): Promise<RxDocument>;
-    find(queryObj?: any): RxQuery<RxDocumentType>;
-    findOne(queryObj?: any): RxQuery<RxDocumentType>;
+    insert(json: any): Promise<IRxDocument<RxDocumentType>>;
+    newDocument(json: any): IRxDocument<RxDocumentType>;
+    upsert(json: any): Promise<IRxDocument<RxDocumentType>>;
+    atomicUpsert(json: any): Promise<IRxDocument<RxDocumentType>>;
+    find(queryObj?: any): RxQuery<IRxDocument<RxDocumentType>[]>;
+    findOne(queryObj?: any): RxQuery<IRxDocument<RxDocumentType>>;
 
     dump(decrytped: boolean): Promise<any>;
     importDump(exportedJSON: any): Promise<Boolean>;
@@ -236,14 +236,16 @@ declare class RxQuery<RxDocumentType>{
     // TODO fix attribute-types of this function
     mod(p1: any, p2: any, p3: any): RxQuery<RxDocumentType>;
 
-    exec(): Promise<RxDocumentType[] | RxDocumentType>;
-    $: Observable<RxDocumentType[] | RxDocumentType>;
-    remove(): Promise<RxDocumentType | RxDocumentType[]>;
-    update(updateObj: any): Promise<RxDocumentType | RxDocumentType[]>;
+    exec(): Promise<RxDocumentType>;
+    $: Observable<RxDocumentType>;
+    remove(): Promise<RxDocumentType>;
+    update(updateObj: any): Promise<RxDocumentType>;
 }
 
-declare class RxDocument {
-    collection: RxCollection<RxDocument>;
+type IRxDocument<T> = RxDocument<T> & T;
+
+declare class RxDocument<T> {
+    collection: RxCollection<T>;
     deleted: boolean;
 
     $: Observable<any>;
@@ -254,14 +256,14 @@ declare class RxDocument {
     primary: string;
     get$(path: string): Observable<any>;
     get(objPath: string): any;
-    set(objPath: string, value: any): RxDocument;
+    set(objPath: string, value: any): IRxDocument<T>;
     save(): Promise<boolean>;
     remove(): Promise<boolean>;
-    populate(objPath: string): Promise<RxDocument | any>;
+    populate(objPath: string): Promise<IRxDocument<T> | any>;
     update(updateObj: any): Promise<any>;
-    atomicUpdate(fun: Function): Promise<RxDocument>;
+    atomicUpdate(fun: Function): Promise<IRxDocument<T>>;
 
-    toJSON(): any;
+    toJSON(): T;
     destroy(): void;
 }
 


### PR DESCRIPTION
## This PR contains:
IMPROVED typings

## Describe the problem you have without this PR
Let's start with a code example:
```ts
    // this.collection refers to RxCollection<Customer>
    const customers = await this.collection.find().exec();
    customers.forEach(customer => {
       // do something
    });
```

Without this PR, I would have the following issues/inconveniences:

#### ( 1 ) - Issues with `find` and `findOne` methods. 
**Problem**: IDE/Compiler will complain that `.forEach` does not exist on type `Customer | Customer[]`. The `|` operator in TypeScript works as expected when we're writing data that follows an interface/type. However, it doesn't work the same way when we're reading data. 

**Solution**: We can pass a type to `RxQuery` from the `RxCollection` class. This type will be used as a return type for the query when we run `.exec()`. `findOne` can pass `Customer` and `find` can pass `Customer[]`. This way the IDE/Compiler knows that the method will return either a single document or an array. 

#### ( 2 ) - `.exec` returns an `RxDocument`, but the typing says it returns `RxDocumentType`
**Problem**: I understand you are using `RxDocumentType` as a return type so we can access the properties of our model right away. This is not the best way to handle it though, because the real object we're getting back is a mix of `RxDocument` and `RxDocumentType`. 

** Solution**: I created a type called `IRxDocument` that accepts a type as a param. It returns back `RxDocument & T`. Now the IDE/Compiler knows that when we call `.exec` we will get both `RxDocument & T`, and when we call `toJSON` we get `T`. 


## TODO
- I did not follow the naming conventions you have in the typings. I will leave it up to you to decide what you wanna name `IRxDocument`. I just used the first thing that came to mind, to get things working.
- Need to export `IRxDocument` if you decide to merge my other PR #320 