### PR TITLE
Remove babel-polyfill from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lint"
   ],
   "peerDependencies": {
-    "babel-polyfill": "^6.26.0",
     "rxjs": "^5.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
Since babel-polyfill isn't always needed, it shouldn't be listed in the peerDependencies. 