### PR TITLE
doc: fix putAttachment example

### DIFF
--- a/docs-src/rx-attachment.md
+++ b/docs-src/rx-attachment.md
@@ -32,11 +32,11 @@ const myCollection = await myDatabase.collection({
 Adds an attachment to a `RxDocument`. Returns a Promise with the new attachment.
 
 ```javascript
-const attachment = await myDocument.putAttachment(
+const attachment = await myDocument.putAttachment({
     id,     // string, name of the attachment like 'cat.jpg'
     data,   // (string|Blob|Buffer) data of the attachment
     type    // (string) type of the attachment-data like 'image/jpeg'
-);
+});
 ```
 
 ## getAttachment()


### PR DESCRIPTION
according to https://github.com/pubkey/rxdb/blob/master/src/plugins/attachments.js#L161-L165 we need to use an object here
