### PR TITLE
Update docs - clarify collection selection from database.

### DIFF
--- a/docs-src/rx-collection.md
+++ b/docs-src/rx-collection.md
@@ -26,11 +26,14 @@ You can pass settings directly to the [pouchdb database create options](https://
 To get an existing collection from the database, call the collection name directly on the database:
 
 ```javascript
+// newly created collection
 const collection = await db.collection({
   name: 'heroes',
   schema: mySchema
 });
 const collection2 = db.heroes;
+// or
+// const collection2 = db['heroes']
 
 console.log(collection == collection2);
 // true


### PR DESCRIPTION
## This PR contains:
Improved docs

## Describe the problem you have without this PR
Further clarification on collection select in docs. Mentioned it on Gitter, fixed here: https://github.com/pubkey/rxdb/commit/01b8e9fd6d6a5e8c266ffd1154a59f57fd0e4db0

Code just underneath `Get a collection from the database` might suggest that first line is a way to get collection, not create it. It looked like two alternative methods for accessing collection. Might be to specific though, leaving decision to maintainer.