### PR TITLE
Fix TypeScript Definitions for RxQuery

### DIFF
--- a/src/typings/rx-collection.d.ts
+++ b/src/typings/rx-collection.d.ts
@@ -62,7 +62,7 @@ export interface SyncOptions {
     },
     // for options see https://pouchdb.com/api.html#replication
     options?: PouchReplicationOptions,
-    query?: RxQuery<any>
+    query?: RxQuery<any, any>
 }
 
 export declare class RxCollection<RxDocumentType> {

--- a/src/typings/rx-collection.d.ts
+++ b/src/typings/rx-collection.d.ts
@@ -75,8 +75,8 @@ export declare class RxCollection<RxDocumentType> {
     newDocument(json: Partial<RxDocumentType>): RxDocument<RxDocumentType>;
     upsert(json: Partial<RxDocumentType>): Promise<RxDocument<RxDocumentType>>;
     atomicUpsert(json: Partial<RxDocumentType>): Promise<RxDocument<RxDocumentType>>;
-    find(queryObj?: any): RxQuery<RxDocument<RxDocumentType>[]>;
-    findOne(queryObj?: any): RxQuery<RxDocument<RxDocumentType>>;
+    find(queryObj?: any): RxQuery<RxDocumentType, RxDocument<RxDocumentType>[]>;
+    findOne(queryObj?: any): RxQuery<RxDocumentType, RxDocument<RxDocumentType>>;
 
     dump(decrytped: boolean): Promise<any>;
     importDump(exportedJSON: any): Promise<Boolean>;

--- a/src/typings/rx-query.d.ts
+++ b/src/typings/rx-query.d.ts
@@ -28,35 +28,35 @@ export type RxQueryObject<T> = keyof T & { [P in keyof T]?: T[P] | RxQueryOption
     $and: RxQueryObject<T>[];
 };
 
-export declare class RxQuery<RxDocumentType> {
+export declare class RxQuery<RxDocumentType, RxQueryResult> {
     readonly collection: RxCollection<RxDocumentType>;
 
-    where(queryObj: RxQueryObject<RxDocumentType>): RxQuery<RxDocumentType>;
-    equals(queryObj: any): RxQuery<RxDocumentType>;
-    eq(queryObj: any): RxQuery<RxDocumentType>;
-    or(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType>;
-    nor(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType>;
-    and(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType>;
-    gt(queryObj: any): RxQuery<RxDocumentType>;
-    gte(queryObj: any): RxQuery<RxDocumentType>;
-    lt(queryObj: any): RxQuery<RxDocumentType>;
-    lte(queryObj: any): RxQuery<RxDocumentType>;
-    ne(queryObj: any): RxQuery<RxDocumentType>;
-    in(queryObj: any[]): RxQuery<RxDocumentType>;
-    nin(queryObj: any[]): RxQuery<RxDocumentType>;
-    all(queryObj: any): RxQuery<RxDocumentType>;
-    regex(queryObj: RegExp): RxQuery<RxDocumentType>;
-    exists(queryObj: any): RxQuery<RxDocumentType>;
-    elemMatch(queryObj: any): RxQuery<RxDocumentType>;
-    sort(params: any): RxQuery<RxDocumentType>;
-    limit(amount: number): RxQuery<RxDocumentType>;
-    skip(amount: number): RxQuery<RxDocumentType>;
+    where(queryObj: RxQueryObject<RxDocumentType>): RxQuery<RxDocumentType, RxQueryResult>;
+    equals(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    eq(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    or(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
+    nor(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
+    and(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
+    gt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    gte(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    lt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    lte(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    ne(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    in(queryObj: any[]): RxQuery<RxDocumentType, RxQueryResult>;
+    nin(queryObj: any[]): RxQuery<RxDocumentType, RxQueryResult>;
+    all(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    regex(queryObj: RegExp): RxQuery<RxDocumentType, RxQueryResult>;
+    exists(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    elemMatch(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
+    sort(params: any): RxQuery<RxDocumentType, RxQueryResult>;
+    limit(amount: number): RxQuery<RxDocumentType, RxQueryResult>;
+    skip(amount: number): RxQuery<RxDocumentType, RxQueryResult>;
 
     // TODO fix attribute-types of this function
-    mod(p1: any, p2: any, p3: any): RxQuery<RxDocumentType>;
+    mod(p1: any, p2: any, p3: any): RxQuery<RxDocumentType, RxQueryResult>;
 
-    exec(): Promise<RxDocumentType>;
-    readonly $: Observable<RxDocumentType>;
-    remove(): Promise<RxDocumentType>;
-    update(updateObj: any): Promise<RxDocumentType>;
+    exec(): Promise<RxQueryResult>;
+    readonly $: Observable<RxQueryResult>;
+    remove(): Promise<RxQueryResult>;
+    update(updateObj: any): Promise<RxQueryResult>;
 }

--- a/src/typings/rx-query.d.ts
+++ b/src/typings/rx-query.d.ts
@@ -31,12 +31,12 @@ export type RxQueryObject<T> = keyof T & { [P in keyof T]?: T[P] | RxQueryOption
 export declare class RxQuery<RxDocumentType, RxQueryResult> {
     readonly collection: RxCollection<RxDocumentType>;
 
-    where(queryObj: RxQueryObject<RxDocumentType> | keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
+    where(queryObj: RxQueryObject<RxDocumentType> | keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
     equals(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     eq(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
-    or(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
-    nor(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
-    and(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
+    or(queryObj: keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
+    nor(queryObj: keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
+    and(queryObj: keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
     gt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     gte(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     lt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;

--- a/src/typings/rx-query.d.ts
+++ b/src/typings/rx-query.d.ts
@@ -31,7 +31,7 @@ export type RxQueryObject<T> = keyof T & { [P in keyof T]?: T[P] | RxQueryOption
 export declare class RxQuery<RxDocumentType, RxQueryResult> {
     readonly collection: RxCollection<RxDocumentType>;
 
-    where(queryObj: RxQueryObject<RxDocumentType>): RxQuery<RxDocumentType, RxQueryResult>;
+    where(queryObj: RxQueryObject<RxDocumentType> | keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;
     equals(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     eq(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     or(queryObj: keyof RxDocumentType): RxQuery<RxDocumentType, RxQueryResult>;


### PR DESCRIPTION
RxQuery must differ between model and result to get typeof working. And `where` also allows a key from the model.