### PR TITLE
Change JSONSchema validator from is-my-json-valid to ajv

### DIFF
--- a/docs-src/custom-build.md
+++ b/docs-src/custom-build.md
@@ -21,7 +21,7 @@ Some parts of RxDB are not in the core, but are required. This means they must a
 ### validate
 
 The validation-module does the schema-validation when you insert or update a `RxDocument`. To use RxDB you always have to add a validation-module.
-This one is using [is-my-json-valid](https://www.npmjs.com/package/is-my-json-valid) but you can also use your own validator instead. To import the default validation-module, do this:
+This one is using [ajv](https://www.npmjs.com/package/ajv) but you can also use your own validator instead. To import the default validation-module, do this:
 
 ```javascript
 // es6-import

--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
   },
   "dependencies": {
     "@types/core-js": "0.9.43",
+    "ajv": "^5.5.1",
     "babel-runtime": "^6.26.0",
     "clone": "^2.1.1",
     "crypto-js": "^3.1.8",
     "custom-idle-queue": "1.0.0",
     "deep-equal": "^1.0.1",
-    "is-my-json-valid": "2.16.1",
     "modifyjs": "0.3.1",
     "object-path": "0.11.4",
     "pouchdb-core": "6.3.4",

--- a/test/unit/reactive-query.test.js
+++ b/test/unit/reactive-query.test.js
@@ -256,9 +256,9 @@ describe('reactive-query.test.js', () => {
                     },
                     state: {
                         type: 'object',
-                        required: true
                     }
-                }
+                },
+                required: ['state']
             };
             const name = util.randomCouchString(10);
             const db = await RxDB.create({

--- a/test/unit/rx-collection.test.js
+++ b/test/unit/rx-collection.test.js
@@ -409,7 +409,7 @@ describe('rx-collection.test.js', () => {
                             age: 20
                         }),
                         Error,
-                        'is required'
+                        'required'
                     );
                     db.destroy();
                 });

--- a/test/unit/rx-document.test.js
+++ b/test/unit/rx-document.test.js
@@ -343,12 +343,24 @@ describe('rx-document.test.js', () => {
         describe('negative', () => {
             it('should throw if schema does not match', async () => {
                 const schema = {
-                    $id: '#child-def',
+                    $id: '/root.json',
                     version: 0,
+                    definitions: {
+                        single: {
+                            $id: '#child',
+                            type: 'object',
+                            properties: {
+                                childProperty: {
+                                    type: 'string',
+                                    enum: ['A', 'B', 'C']
+                                }
+                            }
+                        }
+                    },
                     properties: {
-                        childProperty: {
-                            type: 'string',
-                            enum: ['A', 'B', 'C']
+                        children: {
+                            type: 'array',
+                            items: { $ref: '#child' }
                         }
                     }
                 };
@@ -363,12 +375,16 @@ describe('rx-document.test.js', () => {
 
                 // on doc
                 const doc = await col.insert({
-                    childProperty: 'A'
+                    children: [
+                        { childProperty: 'A' },
+                        { childProperty: 'B' }
+                    ]
                 });
+
                 await AsyncTestUtil.assertThrows(
                     () => doc.update({
                         $set: {
-                            childProperty: 'Z'
+                            'children.0.childProperty': 'Z'
                         }
                     }),
                     Error,

--- a/test/unit/rx-schema.test.js
+++ b/test/unit/rx-schema.test.js
@@ -413,6 +413,50 @@ describe('rx-schema.test.js', () => {
             });
         });
         describe('.validate()', () => {
+            describe('error format', () => {
+                it('required', () => {
+                    const schema = RxSchema.create(schemas.human);
+                    const obj = schemaObjects.human();
+                    delete obj.firstName;
+                    let hasThrown = false;
+                    try {
+                        schema.validate(obj);
+                    } catch (err) {
+                        const deepParam = err.parameters.errors[0].field;
+                        assert.equal(deepParam, 'data.firstName');
+                        hasThrown = true;
+                    }
+                    assert.ok(hasThrown);
+                });
+                it('additional property', () => {
+                    const schema = RxSchema.create(schemas.human);
+                    const obj = schemaObjects.human();
+                    obj['nonExistentProperty'] = 1;
+                    let hasThrown = false;
+                    try {
+                        schema.validate(obj);
+                    } catch (err) {
+                        const deepParam = err.parameters.errors[0].field;
+                        assert.equal(deepParam, 'data');
+                        hasThrown = true;
+                    }
+                    assert.ok(hasThrown);
+                });
+                it('unique items', () => {
+                    const schema = RxSchema.create(schemas.simpleArrayHero);
+                    const obj = schemaObjects.heroArray();
+                    obj.skills.push(obj.skills[0]);
+                    let hasThrown = false;
+                    try {
+                        schema.validate(obj);
+                    } catch (err) {
+                        const deepParam = err.parameters.errors[0].field;
+                        assert.equal(deepParam, 'data.skills');
+                        hasThrown = true;
+                    }
+                    assert.ok(hasThrown);
+                });
+            });
             describe('positive', () => {
                 it('validate one human', () => {
                     const schema = RxSchema.create(schemas.human);


### PR DESCRIPTION
## This PR contains:
Potentially breaking change, few new tests, package change

## Describe the problem you have without this PR
At the moment, is-my-json-valid is not validating schemas with definitions properly. It causes invalid schemas to pass validation where it shouldn't. Ajv is faster and better maintained, much better coming into the future of the project.

Extra parsing function added for backward compatibility of errors.