### PR TITLE
Test case and fix for default value bug

### DIFF
--- a/src/rx-schema.js
+++ b/src/rx-schema.js
@@ -90,7 +90,7 @@ export class RxSchema {
         if (!this._defaultValues) {
             this._defaultValues = {};
             Object.entries(this.normalized.properties)
-                .filter(entry => entry[1].default)
+                .filter(entry => entry[1].default !== null)
                 .forEach(entry => this._defaultValues[entry[0]] = entry[1].default);
         }
         return this._defaultValues;

--- a/test/unit/bug-report.test.js
+++ b/test/unit/bug-report.test.js
@@ -35,6 +35,10 @@ describe('bug-report.test.js', () => {
                     type: 'integer',
                     minimum: 0,
                     maximum: 150
+                },
+                weight: {
+                    type: 'number',
+                    default: 0
                 }
             }
         };
@@ -88,7 +92,7 @@ describe('bug-report.test.js', () => {
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.equal(myDocument.age, 56);
+        assert.equal(myDocument.weight, 0);
 
         // you can also wait for events
         const emitted = [];


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS
 - A BUGFIX

## Describe the problem you have without this PR
A default value of 0 is ignored
I'm assuming the expected behavior is for the default value to be stored regardless of its value, except when its null/undefined or limited by the "type"