### PR TITLE
Removing the preinstall script to support windows shells

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "module": "./dist/es/index.js",
   "types": "./src/typings/index.d.ts",
   "scripts": {
-    "preinstall": "rm -f ./package-lock.json",
     "pretest": "npm run transpile",
     "test": "gulp --gulpfile ./config/gulpfile.js test && karma start ./config/karma.conf.js",
     "test:fast": "npm run pretest && NODE_ENV=fast gulp --gulpfile ./config/gulpfile.js test",


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
The preinstall script assume that all dev got the rm commands on their system
But on the cmd, rm does not exist
In powershell the rm command exist but not the -f arguments

https://github.com/pubkey/rxdb/issues/558
