### PR TITLE
Add support to specify location and iosDatabaseLocation

### DIFF
--- a/src/rx-database.js
+++ b/src/rx-database.js
@@ -31,13 +31,14 @@ const USED_COMBINATIONS = {};
 let DB_COUNT = 0;
 
 export class RxDatabase {
-    constructor(name, adapter, password, multiInstance, options) {
+    constructor(name, adapter, password, multiInstance, options, pouchSettings) {
         if (typeof name !== 'undefined') DB_COUNT++;
         this.name = name;
         this.adapter = adapter;
         this.password = password;
         this.multiInstance = multiInstance;
         this.options = options;
+        this.pouchSettings = pouchSettings;
         this.idleQueue = new IdleQueue();
         this.token = randomToken(10);
 
@@ -57,13 +58,13 @@ export class RxDatabase {
 
     get _adminPouch() {
         if (!this.__adminPouch)
-            this.__adminPouch = _internalAdminPouch(this.name, this.adapter, this.options);
+            this.__adminPouch = _internalAdminPouch(this.name, this.adapter, this.pouchSettings);
         return this.__adminPouch;
     }
 
     get _collectionsPouch() {
         if (!this.__collectionsPouch)
-            this.__collectionsPouch = _internalCollectionsPouch(this.name, this.adapter, this.options);
+            this.__collectionsPouch = _internalCollectionsPouch(this.name, this.adapter, this.pouchSettings);
         return this.__collectionsPouch;
     }
 
@@ -127,7 +128,7 @@ export class RxDatabase {
      * @type {Object}
      */
     _spawnPouchDB(collectionName, schemaVersion, pouchSettings = {}) {
-        return _spawnPouchDB(this.name, this.adapter, collectionName, schemaVersion, pouchSettings, this.options);
+        return _spawnPouchDB(this.name, this.adapter, collectionName, schemaVersion, pouchSettings, this.pouchSettings);
     }
 
     get isLeader() {
@@ -485,7 +486,8 @@ export async function create({
     password,
     multiInstance = true,
     ignoreDuplicate = false,
-    options = {}
+    options = {},
+    pouchSettings = {}
 }) {
     util.validateCouchDBString(name);
 
@@ -518,7 +520,7 @@ export async function create({
     USED_COMBINATIONS[name].push(adapter);
 
 
-    const db = new RxDatabase(name, adapter, password, multiInstance, options);
+    const db = new RxDatabase(name, adapter, password, multiInstance, options, pouchSettings);
     await db.prepare();
 
     runPluginHooks('createRxDatabase', db);
@@ -526,14 +528,14 @@ export async function create({
 }
 
 
-function _spawnPouchDB(dbName, adapter, collectionName, schemaVersion, pouchSettings = {}, options = {}) {
+function _spawnPouchDB(dbName, adapter, collectionName, schemaVersion, pouchSettings = {}, pouchSettingsFromRxDatabaseCreator = {}) {
     const pouchLocation = dbName + '-rxdb-' + schemaVersion + '-' + collectionName;
     const pouchDbParameters = {
         location: pouchLocation,
         adapter: util.adapterObject(adapter),
         settings: pouchSettings
     };
-    const pouchDBOptions = Object.assign({}, pouchDbParameters.adapter, options);
+    const pouchDBOptions = Object.assign({}, pouchDbParameters.adapter, pouchSettingsFromRxDatabaseCreator);
     runPluginHooks('preCreatePouchDb', pouchDbParameters);
     return new PouchDB(
         pouchDbParameters.location,
@@ -542,18 +544,18 @@ function _spawnPouchDB(dbName, adapter, collectionName, schemaVersion, pouchSett
     );
 }
 
-function _internalAdminPouch(name, adapter, options = {}) {
+function _internalAdminPouch(name, adapter, pouchSettingsFromRxDatabaseCreator = {}) {
     return _spawnPouchDB(name, adapter, '_admin', 0, {
         auto_compaction: false, // no compaction because this only stores local documents
         revs_limit: 1
-    }, options);
+    }, pouchSettingsFromRxDatabaseCreator);
 }
 
-function _internalCollectionsPouch(name, adapter, options = {}) {
+function _internalCollectionsPouch(name, adapter, pouchSettingsFromRxDatabaseCreator = {}) {
     return _spawnPouchDB(name, adapter, '_collections', 0, {
         auto_compaction: false, // no compaction because this only stores local documents
         revs_limit: 1
-    }, options);
+    }, pouchSettingsFromRxDatabaseCreator);
 }
 
 export async function removeDatabase(databaseName, adapter) {

--- a/src/typings/pouch.d.ts
+++ b/src/typings/pouch.d.ts
@@ -31,7 +31,9 @@ export interface PouchSettings {
     auth?: any,
     skip_setup?: boolean,
     storage?: any,
-    size?: number
+    size?: number,
+    location?: string,
+    iosDatabaseLocation?: string
 }
 
 export declare class PouchDB {

--- a/src/typings/rx-database.d.ts
+++ b/src/typings/rx-database.d.ts
@@ -10,6 +10,9 @@ import {
 import {
     RxChangeEvent
 } from './rx-change-event';
+import {
+    PouchSettings
+} from "./pouch";
 
 export interface RxDatabaseCreator {
     name: string;
@@ -18,6 +21,7 @@ export interface RxDatabaseCreator {
     multiInstance?: boolean;
     ignoreDuplicate?: boolean;
     options?: any;
+    pouchSettings?: PouchSettings;
 }
 
 export declare class RxDatabase {
@@ -27,6 +31,7 @@ export declare class RxDatabase {
     readonly password: string;
     readonly collections: any;
     options?: any;
+    pouchSettings?: PouchSettings;
 
     readonly $: Observable<RxChangeEvent>;
 

--- a/test/unit/rx-database.test.js
+++ b/test/unit/rx-database.test.js
@@ -109,6 +109,21 @@ config.parallel('rx-database.test.js', () => {
                 assert.equal(db.options.foo, 'bar');
                 db.destroy();
             });
+            it('should not forget the pouchSettings', async () => {
+                const name = util.randomCouchString(10);
+                const password = util.randomCouchString(12);
+                const db = await RxDatabase.create({
+                    name,
+                    adapter: 'memory',
+                    password,
+                    ignoreDuplicate: true,
+                    pouchSettings: {
+                        foo: 'bar'
+                    }
+                });
+                assert.equal(db.pouchSettings.foo, 'bar');
+                db.destroy();
+            });
         });
         describe('negative', () => {
             it('should crash with invalid token', async () => {


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
When using 'cordova-sqlite' adapter (which uses native Cordova SQLite as its backing store) we need RxDB to create an instance of PouchDb with specified **location** or **iosDatabaseLocation** (these are required by cordoa sqlite plugin).
So an instance of PouchDb should be created like this:
```
new PouchDB('dbname', {adapter: 'cordova-sqlite', location: 'default'})
```
or this
```
new PouchDB('dbname', {adapter: 'cordova-sqlite', iosDatabaseLocation: 'default'})
```
The current implementation of RxDB let us specify only adapter.
This PR will give the possibility to specify location or iosDatabaseLocation in options property when creating database
```
await RxDB.create({
  name: 'dbname',
  adapter: 'cordova-sqlite',
  password: 'passwordPasswordPassword',
  options: { location: 'default' }
});
```

## Todos
- [ ] Documentation