### PR TITLE
Fix RxChangeEvent typings

### DIFF
--- a/src/typings/rx-change-event.d.ts
+++ b/src/typings/rx-change-event.d.ts
@@ -1,6 +1,17 @@
+import { RxDocument } from 'rxdb/src/typings/rx-document';
+
+export interface RxChangeEventData {
+  readonly col?: string;
+  readonly db: string;
+  readonly doc?: RxDocument<object>;
+  readonly isLocal?: boolean;
+  readonly it: string;
+  readonly op: 'INSERT' | 'UPDATE' | 'REMOVE';
+  readonly t: number;
+  readonly v?: object;
+}
+
 export declare class RxChangeEvent {
-    data: {
-        readonly type: 'INSERT' | 'UPDATE' | 'REMOVE';
-    };
-    toJSON(): any;
+    data: RxChangeEventData;
+    toJSON(): RxChangeEventData;
 }


### PR DESCRIPTION
## This PR contains:

Improved typings.

This is a best guess at current typings for the [RxChangeEvent](https://github.com/pubkey/rxdb/blob/master/src/rx-change-event.js) class.