### PR TITLE
Improve RxChangeEvent typing

### DIFF
--- a/src/typings/rx-change-event.d.ts
+++ b/src/typings/rx-change-event.d.ts
@@ -11,7 +11,7 @@ export interface RxChangeEventData<T = {}> {
   readonly v?: T;
 }
 
-export declare class RxChangeEvent<T> {
+export declare class RxChangeEvent<T = {}> {
     data: RxChangeEventData<T>;
     toJSON(): RxChangeEventData<T>;
 }

--- a/src/typings/rx-change-event.d.ts
+++ b/src/typings/rx-change-event.d.ts
@@ -1,17 +1,17 @@
-import { RxDocument } from '../../src/typings/rx-document';
+export type RxChangeEventOperation = 'INSERT' | 'UPDATE' | 'REMOVE'
 
-export interface RxChangeEventData {
+export interface RxChangeEventData<T = {}> {
   readonly col?: string;
   readonly db: string;
-  readonly doc?: RxDocument<object>;
+  readonly doc?: string;
   readonly isLocal?: boolean;
   readonly it: string;
-  readonly op: 'INSERT' | 'UPDATE' | 'REMOVE';
+  readonly op: RxChangeEventOperation;
   readonly t: number;
-  readonly v?: any;
+  readonly v?: T;
 }
 
-export declare class RxChangeEvent {
-    data: RxChangeEventData;
-    toJSON(): RxChangeEventData;
+export declare class RxChangeEvent<T> {
+    data: RxChangeEventData<T>;
+    toJSON(): RxChangeEventData<T>;
 }


### PR DESCRIPTION
This contains some improvements to the RxChangeEvent typing for things that were missed in https://github.com/pubkey/rxdb/pull/606

* Use a named type for the operation strings.
* Allow the type of the `v` object to be defined, optionally.
* `doc` is a string (the primary key), not a document.