### PR TITLE
Skip defining getter and setter when property not defined in schema

### DIFF
--- a/src/rx-document.js
+++ b/src/rx-document.js
@@ -229,6 +229,9 @@ export class RxDocument {
         if (valueObj === null) return;
 
         let pathProperties = this.collection.schema.getSchemaByObjectPath(objPath);
+
+        if (!pathProperties) return;
+
         if (pathProperties.properties) pathProperties = pathProperties.properties;
 
         Object.keys(pathProperties)


### PR DESCRIPTION
## This PR contains:

A BUGFIX?

## Describe the problem you have without this PR

I'm using RxDB in an app that defines only a minimal schema for each object, as there are lots of different types of object stored in the same collection. I've found that calling `get(x)` on a document, when the property at `x` is an object or array, calls `_defineGetterSetter` which tries to get the schema for the property, which is null when there's no schema defined for this path, causing an exception to be thrown.
