### PR TITLE
Adds option for providing `_id` when inserting documents, adds tests.

### DIFF
--- a/src/plugins/error-messages.js
+++ b/src/plugins/error-messages.js
@@ -68,6 +68,7 @@ const CODES = {
     COL16: 'given static method is not a function',
     COL17: 'RxCollection.ORM: statics-name not allowed',
     COL18: 'collection-method not allowed because fieldname is in the schema',
+    COL19: 'RxCollection.insert() you must provide ._id when options.provideId is truthy',
 
     // rx-document.js
     DOC1: 'RxDocument.get$ cannot get observable of in-array fields because order cannot be guessed',

--- a/src/rx-collection.js
+++ b/src/rx-collection.js
@@ -313,17 +313,23 @@ export class RxCollection {
         json = util.clone(json);
         json = this.schema.fillObjectWithDefaults(json);
 
-        if (json._id) {
-            throw RxError.newRxError('COL2', {
-                data: json
-            });
-        }
+        if (this.schema.primaryPath === '_id') {
+            if (json._id && !this.options.provideId) {
+                throw RxError.newRxError('COL2', {
+                    data: json
+                });
+            }
 
-        // fill _id
-        if (
-            this.schema.primaryPath === '_id' &&
-            !json._id
-        ) json._id = util.generateId();
+            if (!json._id) {
+                if (this.options.provideId) {
+                    throw RxError.newRxError('COL19', {
+                        data: json
+                    });
+                }
+                // fill _id
+                json._id = util.generateId();
+            }
+        }
 
         await this._runHooks('pre', 'insert', json);
 

--- a/test/unit/rx-collection.test.js
+++ b/test/unit/rx-collection.test.js
@@ -325,6 +325,27 @@ config.parallel('rx-collection.test.js', () => {
 
                     db.destroy();
                 });
+                it('should insert when _id given (with options.provideId=true)', async () => {
+                    const db = await RxDatabase.create({
+                        name: util.randomCouchString(10),
+                        adapter: 'memory'
+                    });
+                    const collection = await db.collection({
+                        name: 'human',
+                        schema: schemas.human,
+                        options: {
+                            provideId: true
+                        }
+                    });
+                    const human = schemaObjects.human();
+                    const _id = 'Human:' + util.randomCouchString(20);
+                    human._id = _id;
+                    await collection.insert(human);
+                    const doc = await collection.findOne().exec();
+                    assert.equal(doc._id, _id);
+
+                    db.destroy();
+                });
             });
             describe('negative', () => {
                 it('should not insert broken human (required missing)', async () => {
@@ -410,6 +431,26 @@ config.parallel('rx-collection.test.js', () => {
                         }),
                         Error,
                         'is required'
+                    );
+                    db.destroy();
+                });
+                it('should not insert when _id is missing (with options.provideId=true)', async () => {
+                    const db = await RxDatabase.create({
+                        name: util.randomCouchString(10),
+                        adapter: 'memory'
+                    });
+                    const collection = await db.collection({
+                        name: 'human',
+                        schema: schemas.human,
+                        options: {
+                            provideId: true
+                        }
+                    });
+                    const human = schemaObjects.human();
+                    await AsyncTestUtil.assertThrows(
+                        () => collection.insert(human),
+                        Error,
+                        'you must provide ._id when options.provideId is truthy'
                     );
                     db.destroy();
                 });


### PR DESCRIPTION
## This PR contains:
 - an option to the `RxCollection` ctor allowing `_id` to be user defined

Is there a reason `_id` cannot be user defined?

I looked through the git history and seems that at one point this was an optional argument to `RxCollection.insert()`.

Is there a reason it was removed? A per-collection option suits my use case but passing an argument to `insert()` wouldn't be the end of the world.

I believe there is already a `positive` test for inserting a doc without `_id`, and a `negative` test for inserting a doc with `_id`.

I've added a test for each of those cases but with this option set.

If this is a change you're happy with I can make changes/add docs etc.