### PR TITLE
Update rx-collection.html; Fixed typo

### DIFF
--- a/docs/rx-collection.html
+++ b/docs/rx-collection.html
@@ -1301,7 +1301,7 @@ myCollection.importDump(json)
 <pre><code class="lang-js">myDatabase.destroy();
 </code></pre>
 <h3 id="sync">sync()</h3>
-<p>This method allows you to replicate data between other RxCollections, pouchdb instances or remove servers which support the couchdb-sync-protocol.
+<p>This method allows you to replicate data between other RxCollections, pouchdb instances or remote servers which support the couchdb-sync-protocol.
 Full documentation on how to use replication is <a href="replication.html">here</a>.</p>
 <h3 id="remove">remove()</h3>
 <p>Removes all known data of the collection and its previous versions.


### PR DESCRIPTION
## This PR contains: IMPROVED DOCS: typo

## Describe the problem you have without this PR
There was a typo:
was _pouchdb instances or remo_ *v* _e servers which_
fix _pouchdb instances or remo_ *t* _e servers which_