### PR TITLE
Cleanup checkAdapter test databases after use

### DIFF
--- a/src/plugins/adapter-check.js
+++ b/src/plugins/adapter-check.js
@@ -28,6 +28,8 @@ export async function checkAdapter(adapter) {
         await pouch.remove(recoveredDoc);
     } catch (err) {
         return false;
+    } finally {
+        pouch && pouch.destroy && pouch.destroy()
     }
 
     if (recoveredDoc && recoveredDoc.value)


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
See #714 

How you would like to test this? You can't get a list of existing databases to compare to (at least for indexedDB), and the generated id isn't accessible.

## Todos
- [ ] Tests
- [ ] Changelog