### PR TITLE
Fix query change detector for REMOVE events

### DIFF
--- a/src/query-change-detector.js
+++ b/src/query-change-detector.js
@@ -107,26 +107,26 @@ class QueryChangeDetector {
 
         if (changeEvent.data.op === 'REMOVE') {
             // R1 (never matched)
-            if (!doesMatchNow) {
+            if (!wasDocInResults) {
                 DEBUG && this._debugMessage('R1', docData);
                 return false;
             }
 
             // R2 sorted before got removed but results not filled
-            if (options.skip && doesMatchNow && sortBefore() && !isFilled) {
+            if (options.skip && wasDocInResults && sortBefore() && !isFilled) {
                 DEBUG && this._debugMessage('R2', docData);
                 results.shift();
                 return results;
             }
 
             // R3 (was in results and got removed)
-            if (doesMatchNow && wasDocInResults && !isFilled) {
+            if (!doesMatchNow && wasDocInResults && !isFilled) {
                 DEBUG && this._debugMessage('R3', docData);
                 results = results.filter(doc => doc[this.primaryKey] !== docData[this.primaryKey]);
                 return results;
             }
             // R3.1 was in results and got removed, no limit, no skip
-            if (doesMatchNow && wasDocInResults && !options.limit && !options.skip) {
+            if (!doesMatchNow && wasDocInResults && !options.limit && !options.skip) {
                 DEBUG && this._debugMessage('R3.1', docData);
                 results = results.filter(doc => doc[this.primaryKey] !== docData[this.primaryKey]);
                 return results;
@@ -134,7 +134,7 @@ class QueryChangeDetector {
 
 
             // R4 matching but after results got removed
-            if (doesMatchNow && options.limit && sortAfter()) {
+            if (!doesMatchNow && wasDocInResults && options.limit && sortAfter()) {
                 DEBUG && this._debugMessage('R4', docData);
                 return false;
             }


### PR DESCRIPTION
## This PR contains:

 - A BUGFIX

## Describe the problem you have without this PR

We've found that sometimes a query subscriber isn't called when a document is deleted, only when RxDB.QueryChangeDetector is enabled. It seems that the `handleSingleChange` method isn't setting variables correctly when handling "REMOVE" events.

I've tried to update the code to match the comments that were already there, but I'm not sure how correct the comments were, or how best to test the asynchronous query subscribers.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog
