### PR TITLE
Improve query change detector for REMOVE events

### DIFF
--- a/src/query-change-detector.js
+++ b/src/query-change-detector.js
@@ -109,41 +109,40 @@ class QueryChangeDetector {
 
         if (changeEvent.data.op === 'REMOVE') {
             // R1 (never matched)
-            if (!wasDocInResults && !doesMatchNow) {
+            if (!wasDocInResults) {
                 DEBUG && this._debugMessage('R1', docData);
                 return false;
             }
 
             // R2 sorted before got removed but results not filled
-            if (options.skip && doesMatchNow && sortBefore() && !isFilled) {
+            if (options.skip && sortBefore() && !isFilled) {
                 DEBUG && this._debugMessage('R2', docData);
                 results.shift();
                 return results;
             }
 
             // R3 (was in results and got removed)
-            if (doesMatchNow && wasDocInResults && !isFilled) {
+            if (!isFilled) {
                 DEBUG && this._debugMessage('R3', docData);
                 results = results.filter(doc => doc[this.primaryKey] !== docData[this.primaryKey]);
                 return results;
             }
 
             // R3.05 was in findOne-result and got removed
-            if (options.limit === 1 && !doesMatchNow && wasDocInResults) {
+            if (options.limit === 1) {
                 DEBUG && this._debugMessage('R3.05', docData);
                 return true;
             }
 
             // R3.1 was in results and got removed, no limit, no skip
-            if (doesMatchNow && wasDocInResults && !options.limit && !options.skip) {
+            if (!options.limit && !options.skip) {
                 DEBUG && this._debugMessage('R3.1', docData);
                 results = results.filter(doc => doc[this.primaryKey] !== docData[this.primaryKey]);
                 return results;
             }
 
-
             // R4 matching but after results got removed
-            if (doesMatchNow && options.limit && sortAfter()) {
+            if (options.limit && sortAfter()) {
                 DEBUG && this._debugMessage('R4', docData);
                 return false;
             }


### PR DESCRIPTION
## This PR contains:

 - A BUGFIX

## Describe the problem you have without this PR

We found that sometimes a query subscriber isn't called when a document is deleted, only when RxDB.QueryChangeDetector is enabled. It seems that the `handleSingleChange` method isn't setting variables correctly when handling "REMOVE" events.

The main bug was fixed in https://github.com/pubkey/rxdb/issues/754 but I think it can be simpler: if the document previously matched the query but has now been removed, then it should always be removed from the results regardless of whether it now matches the query.

This allows the query change detector to handle deleted documents that no longer match the query as they don't have any of their previous properties.

I've tried to update the code to match the comments that were already there, but I'm not sure how correct the comments were, or how best to test the asynchronous query subscribers.

## Todos
- [ ] Tests
- [ ] Changelog
