### PR TITLE
Safari launcher

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -22,7 +22,7 @@ const configuration = {
         postDetection: function(availableBrowser) {
             // return ['Firefox']; // comment in to test specific browser
             const browsers = availableBrowser
-                .filter(b => !['PhantomJS', 'FirefoxAurora', 'FirefoxNightly'].includes(b))
+                .filter(b => !['PhantomJS', 'FirefoxAurora', 'FirefoxNightly', 'ChromeCanary'].includes(b))
                 .map(b => {
                     if (b === 'Chrome') return 'Chrome_travis_ci';
                     else return b;

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -37,6 +37,7 @@ const configuration = {
         'karma-browserify',
         'karma-chrome-launcher',
         'karma-edge-launcher',
+        'karma-safari-launcher',
         'karma-firefox-launcher',
         'karma-ie-launcher',
         'karma-opera-launcher',

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "karma-ie-launcher": "1.0.0",
     "karma-mocha": "1.3.0",
     "karma-opera-launcher": "1.0.0",
-    "karma-safari-launcher": "1.0.0",
+    "karma-safari-launcher": "^1.0.0",
     "leveldown": "4.0.1",
     "memdown": "3.0.0",
     "mocha": "5.2.0",


### PR DESCRIPTION
- Prevents Chrome Canary from being run in tests -as the browser itself is unstable, like Firefox nightly.
- Adds karma-safari-launcher to devDependencies & karma loaded plugins so tests run in macOS.