### PR TITLE
Tutorial "Using RxDB with Typescript" incorrect RxCollection type definition.

### DIFF
--- a/docs-src/tutorials/typescript.md
+++ b/docs-src/tutorials/typescript.md
@@ -59,7 +59,7 @@ type HeroCollectionMethods = {
 }
 
 // and then merge all our types
-type HeroCollection = RxCollection<HeroDocType, HeroDocMethods>;
+type HeroCollection = RxCollection<HeroDocType, HeroDocMethods, HeroCollectionMethods>;
 ```
 
 


### PR DESCRIPTION
## This PR contains:
 - Improved docs

## Describe the problem you have without this PR
- Tutorial "Using RxDB with Typescript" incorrect `RxCollection` type definition.

## Description
The documentation tutorial page "Using RxDB with Typescript" defines `HeroCollection` incorrectly as `RxCollection<HeroDocType, HeroDocMethods>` when it should be defined as `RxCollection<HeroDocType, HeroDocMethods, HeroCollectionMethods>` to provide typing for the static methods.