### PR TITLE
Awaits Promise.all in RxDB.removeDatabase

### DIFF
--- a/src/rx-database.js
+++ b/src/rx-database.js
@@ -688,32 +688,32 @@ function _internalCollectionsPouch(name, adapter, pouchSettingsFromRxDatabaseCre
  *
  * @return {Promise}
  */
-export function removeDatabase(databaseName, adapter) {
+export async function removeDatabase(databaseName, adapter) {
     const adminPouch = _internalAdminPouch(databaseName, adapter);
     const collectionsPouch = _internalCollectionsPouch(databaseName, adapter);
 
-    return collectionsPouch.allDocs({
+    const collectionsData = await collectionsPouch.allDocs({
         include_docs: true
-    }).then(collectionsData => {
-        // remove collections
-        Promise.all(
-            collectionsData.rows
-            .map(colDoc => colDoc.id)
-            .map(id => {
-                const split = id.split('-');
-                const name = split[0];
-                const version = parseInt(split[1], 10);
-                const pouch = _spawnPouchDB(databaseName, adapter, name, version);
-                return pouch.destroy();
-            })
-        );
-
-        // remove internals
-        return Promise.all([
-            collectionsPouch.destroy(),
-            adminPouch.destroy()
-        ]);
     });
+
+    // remove collections
+    await Promise.all(
+        collectionsData.rows
+        .map(colDoc => colDoc.id)
+        .map(id => {
+            const split = id.split('-');
+            const name = split[0];
+            const version = parseInt(split[1], 10);
+            const pouch = _spawnPouchDB(databaseName, adapter, name, version);
+            return pouch.destroy();
+        })
+    );
+
+    // remove internals
+    return Promise.all([
+        collectionsPouch.destroy(),
+        adminPouch.destroy()
+    ]);
 }
 
 /**


### PR DESCRIPTION
There was a `Promise.all` that was not being awaited.

I don't know if the ordering is important.

e.g. that the collections are destroyed before the internal admin/collections collection.

However it should be awaited somehow so that `removeDatabase` doesn't return before the `.destroy()` calls have finished.