### PR TITLE
Make RxJsonSchema type optional

### DIFF
--- a/typings/rx-schema.d.ts
+++ b/typings/rx-schema.d.ts
@@ -61,7 +61,7 @@ export declare class RxJsonSchema {
      * we have to allows all string because the 'object'-literal is not recognized
      * retry this in later typescript-versions
      */
-    type: 'object' | string;
+    type?: 'object' | string;
     properties: { [key: string]: RxJsonSchemaTopLevel };
     required?: string[];
     compoundIndexes?: string[] | string[][];


### PR DESCRIPTION
It seems like pouchdb deprecates it, so it should be optional for smooth migrations.

## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR
schema type is deprecated in pouchdb
