### PR TITLE
Markdown formatting fix.

### DIFF
--- a/docs-src/install.md
+++ b/docs-src/install.md
@@ -14,13 +14,13 @@ You also need to install the peer-dependency `rxjs` if you not have installed it
 
 ## polyfills
 
-RxDB is coded with es8 and transpiled to es5\. This means you have to install [polyfills](https://en.wikipedia.org/wiki/Polyfill_(programming)) to support older browsers. For example you can use the babel-polyfills with:
+RxDB is coded with es8 and transpiled to es5\. This means you have to install [polyfills](<https://en.wikipedia.org/wiki/Polyfill_(programming)>) to support older browsers. For example you can use the babel-polyfills with:
 
 `npm i babel-polyfill --save`
 
 ## Latest
 
-If you need the latest develop-state of RxDB, add it as git-dependency into your `package.json`.
+If you need the latest development state of RxDB, add it as git-dependency into your `package.json`.
 
 ```json
   "dependencies": {


### PR DESCRIPTION
The closing ')' in the Wikipedia link broke the Markdown rendered on the docs site (not inside GitHub).
Also, a minor grammar tweak.

## This PR contains:
<!--
 - IMPROVED DOCS
-->

## Describe the problem you have without this PR
Minor doc issues.
