### PR TITLE
doc(schema): fix misspelling in RxJsonSchemaTopLevel attribute

### DIFF
--- a/docs-src/rx-schema.md
+++ b/docs-src/rx-schema.md
@@ -48,7 +48,7 @@ In this example-schema we define a hero-collection with the following settings:
             "type": "array",
             "maxItems": 5,
             "uniqueItems": true,
-            "item": {
+            "items": {
                 "type": "object",
                 "properties": {
                     "name": {


### PR DESCRIPTION

## This PR contains:

 - IMPROVED DOCS

## Describe the problem you have without this PR

Wrong RxJsonSchemaTopLevel attribute name.