### PR TITLE
ADD RxJsonSchema generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-### comming soon
+### coming soon
 
 Typings:
   - `RxDocument.getAttachment()` and `RxDocument.allAttachments()` did not return promises
+  - ADD RxJsonSchema<T> generic for better TypeScript experience
 
 ### 8.1.0 (22 April 2019)
 

--- a/docs-src/tutorials/typescript.md
+++ b/docs-src/tutorials/typescript.md
@@ -94,7 +94,7 @@ const myDatabase: MyDatabase = await RxDB.create<MyDatabaseCollections>({
     adapter: 'memory'
 });
 
-const heroSchema: RxJsonSchema = {
+const heroSchema: RxJsonSchema<HeroDocType> = {
     title: 'human schema',
     description: 'describes a human being',
     version: 0,

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "faker": "4.1.0",
     "gitbook-cli": "2.3.2",
     "gzip-size-cli": "3.0.0",
-    "http-server": "0.11.1",
     "karma": "4.1.0",
     "karma-babel-preprocessor": "8.0.0",
     "karma-browserify": "6.0.0",

--- a/test/helper/schemas.js
+++ b/test/helper/schemas.js
@@ -724,3 +724,39 @@ export const point = {
     },
     required: ['x', 'y']
 };
+
+export const humanMinimal = {
+    title: 'human schema',
+    description: 'describes a human being',
+    version: 0,
+    keyCompression: true,
+    type: 'object',
+    properties: {
+        passportId: {
+            type: 'string',
+            index: true
+        },
+        age: {
+            type: 'integer'
+        }
+    },
+    required: ['passportId', 'age']
+};
+
+export const humanMinimalBroken = {
+    title: 'human schema',
+    description: 'describes a human being',
+    version: 0,
+    keyCompression: true,
+    type: 'object',
+    properties: {
+        passportId: {
+            type: 'string',
+            index: true
+        },
+        broken: {
+            type: 'integer'
+        }
+    },
+    required: ['passportId', 'broken']
+};

--- a/test/typings.test.js
+++ b/test/typings.test.js
@@ -197,6 +197,65 @@ describe('typings.test.js', function() {
 
         });
     });
+
+    config.parallel('schema', () => {
+        describe('positive', () => {
+            it('should allow creating generic schema based on a model', async () => {
+                const code = codeBase + `
+                    (async() => {
+                        const databaseCreator: RxDatabaseCreator = {
+                            name: 'mydb',
+                            adapter: 'memory',
+                            multiInstance: false,
+                            ignoreDuplicate: false
+                        };
+                        const myDb: RxDatabase = await create(databaseCreator);
+
+                        const minimalHuman: RxJsonSchema<DefaultDocType> = ${JSON.stringify(schemas.humanMinimal)};
+                        const myCollection: RxCollection<any> = await myDb.collection<DefaultDocType>({
+                            name: 'humans',
+                            schema: minimalHuman,
+                        });
+                        
+                        await myDb.destroy();
+                    })();
+                `;
+                await transpileCode(code);
+            });
+        });
+        describe('negative', () => {
+            it('should not allow wrong properties when passing a model', async () => {
+                const brokenCode = codeBase + `
+                    (async() => {
+                        const databaseCreator: RxDatabaseCreator = {
+                            name: 'mydb',
+                            adapter: 'memory',
+                            multiInstance: false,
+                            ignoreDuplicate: false
+                        };
+                        const myDb: RxDatabase = await create(databaseCreator);
+
+                        const minimalHuman: RxJsonSchema<DefaultDocType> = ${JSON.stringify(schemas.humanMinimalBroken)};
+                        const myCollection: RxCollection<any> = await myDb.collection<DefaultDocType>({
+                            name: 'humans',
+                            schema: minimalHuman,
+                        });
+
+                        await myDb.destroy();
+                    })();
+                `;
+                let thrown = false;
+                try {
+                    await transpileCode(brokenCode);
+                } catch (err) {
+                    thrown = true;
+                }
+                assert.ok(thrown);
+            });
+            
+        });
+    });
+
     config.parallel('collection', () => {
         describe('positive', () => {
             it('collection-creation', async () => {

--- a/typings/rx-schema.d.ts
+++ b/typings/rx-schema.d.ts
@@ -53,7 +53,7 @@ export interface RxJsonSchemaTopLevel extends JsonSchema {
     final?: boolean;
 }
 
-export declare class RxJsonSchema {
+export declare class RxJsonSchema<T = any> {
     title?: string;
     description?: string;
     version: number;
@@ -63,8 +63,8 @@ export declare class RxJsonSchema {
      * retry this in later typescript-versions
      */
     type: 'object' | string;
-    properties: { [key: string]: RxJsonSchemaTopLevel };
-    required?: string[];
+    properties: { [key in keyof T]: RxJsonSchemaTopLevel };
+    required?: (keyof T)[];
     compoundIndexes?: string[] | string[][];
     keyCompression?: boolean;
     /**
@@ -72,19 +72,19 @@ export declare class RxJsonSchema {
      */
     additionalProperties?: boolean;
     attachments?: {
-            encrypted?: boolean
+        encrypted?: boolean;
     };
 }
 
 export declare class RxSchema<T = any> {
-    readonly jsonID: RxJsonSchema;
+    readonly jsonID: RxJsonSchema<T>;
     getSchemaByObjectPath(path: keyof T): JsonSchema;
     readonly encryptedPaths: any;
     validate(obj: any, schemaPath?: string): void;
     readonly hash: string;
     readonly topLevelFields: keyof T[];
     readonly previousVersions: any[];
-    readonly defaultValues: { [P in keyof T]: T[P]; };
+    readonly defaultValues: { [P in keyof T]: T[P] };
 
-    static create(jsonSchema: RxJsonSchema): RxSchema;
+    static create<T>(jsonSchema: RxJsonSchema<T>): RxSchema;
 }


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR
Make RxJsonSchema optionally generic to have type checking on `properties` and `required`.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests
- [x] Documentation
- [x] Typings
- [x] Changelog

