### PR TITLE
Extend server plugin to reuse an existing app

### DIFF
--- a/src/plugins/server.js
+++ b/src/plugins/server.js
@@ -1,11 +1,9 @@
-import express from 'express';
+import expressApp from 'express';
 import ExpressPouchDB from 'express-pouchdb';
 import corsFn from 'cors';
 
 import PouchDB from '../pouch-db';
-import {
-    newRxError
-} from '../rx-error';
+import { newRxError } from '../rx-error';
 
 import Core from '../core';
 import ReplicationPlugin from './replication';
@@ -20,9 +18,9 @@ const PouchdbAllDbs = require('pouchdb-all-dbs');
 PouchdbAllDbs(PouchDB);
 
 const APP_OF_DB = new WeakMap();
+const SERVER_OF_APP = new WeakMap();
 const SERVERS_OF_DB = new WeakMap();
 const DBS_WITH_SERVER = new WeakSet();
-
 
 const normalizeDbName = function(db) {
     const splitted = db.name.split('/').filter(str => str !== '');
@@ -34,7 +32,7 @@ const getPrefix = function(db) {
     splitted.pop(); // last was the name
     if (splitted.length === 0) return '';
     let ret = splitted.join('/') + '/';
-    if(db.name.startsWith('/')) ret = '/' + ret;
+    if (db.name.startsWith('/')) ret = '/' + ret;
     return ret;
 };
 
@@ -46,46 +44,69 @@ function tunnelCollectionPath(db, path, app, colName) {
     app.use(path + '/' + colName, function(req, res, next) {
         if (req.baseUrl === path + '/' + colName) {
             const to = normalizeDbName(db) + '-rxdb-0-' + colName;
-            const toFull = req.originalUrl.replace('/db/' + colName, '/db/' + to);
+            const toFull = req.originalUrl.replace(
+                '/db/' + colName,
+                '/db/' + to
+            );
             req.originalUrl = toFull;
         }
         next();
     });
 }
 
+// https://github.com/pouchdb/pouchdb-server#api
+const defaultPouchServerOptions = {
+    inMemoryConfig: true, // don't automatically write the config.json file
+    logPath: '/dev/null' // don't write log.txt TODO: windows? could use "nul" file
+};
+
 export function spawnServer({
     path = '/db',
     port = 3000,
-    cors = false
+    cors = false,
+    express = null,
+    pouchServerOptions = {}
 }) {
+    pouchServerOptions = {
+        ...defaultPouchServerOptions,
+        ...pouchServerOptions
+    };
+
     const db = this;
-    if (!SERVERS_OF_DB.has(db))
-        SERVERS_OF_DB.set(db, []);
+    if (!SERVERS_OF_DB.has(db)) SERVERS_OF_DB.set(db, []);
 
     const pseudo = PouchDB.defaults({
         adapter: db.adapter,
         prefix: getPrefix(db)
     });
 
-    const app = express();
+    const shouldMakeApp = !express;
+    const app = shouldMakeApp ? expressApp() : express;
     APP_OF_DB.set(db, app);
 
     // tunnel requests so collection-names can be used as paths
-    Object.keys(db.collections).forEach(colName => tunnelCollectionPath(db, path, app, colName));
+    Object.keys(db.collections).forEach(colName =>
+        tunnelCollectionPath(db, path, app, colName)
+    );
 
     // show error if collection is created afterwards
     DBS_WITH_SERVER.add(db);
 
     if (cors) {
         ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS']
-        .map(method => method.toLowerCase())
+            .map(method => method.toLowerCase())
             .forEach(method => app[method]('*', corsFn()));
     }
 
-    app.use(path, ExpressPouchDB(pseudo));
+    // TODO: we could track to make sure this app isn't already configured
+    // to `use` this path.
+    app.use(path, ExpressPouchDB(pseudo, pouchServerOptions));
 
-    const server = app.listen(port);
+    const server = shouldMakeApp ? app.listen(port) : SERVER_OF_APP.get(app);
     SERVERS_OF_DB.get(db).push(server);
+    if (shouldMakeApp) {
+        SERVER_OF_APP.set(app, server);
+    }
 
     return {
         app,
@@ -98,12 +119,10 @@ export function spawnServer({
  */
 function ensureNoMoreCollections(args) {
     if (DBS_WITH_SERVER.has(args.database)) {
-        const err = newRxError(
-            'S1', {
-                collection: args.name,
-                database: args.database.name
-            }
-        );
+        const err = newRxError('S1', {
+            collection: args.name,
+            database: args.database.name
+        });
         throw err;
     }
 }
@@ -116,10 +135,9 @@ export function onDestroy(db) {
         SERVERS_OF_DB.get(db).forEach(server => server.close());
 }
 
-
 export const rxdb = true;
 export const prototypes = {
-    RxDatabase: (proto) => {
+    RxDatabase: proto => {
         proto.server = spawnServer;
     }
 };

--- a/typings/rx-database.d.ts
+++ b/typings/rx-database.d.ts
@@ -31,11 +31,18 @@ export interface RxDatabaseCreator {
     pouchSettings?: PouchSettings;
 }
 
+export interface PouchServerOptions {
+    inMemoryConfig?: boolean;
+    logPath?: string;
+}
+
 // options for the server-plugin
 export interface ServerOptions {
     path?: string;
     port?: number;
     cors?: boolean;
+    express?: any;
+    pouchServerOptions?: PouchServerOptions;
 }
 
 export type RxDatabase<Collections = { [key: string]: RxCollection }> = RxDatabaseBase<Collections> & Collections;


### PR DESCRIPTION
## This PR contains:
 - #1141: Allow the `db.server` plugin to reuse an existing express app instead of creating a new one every call

## Describe the problem you have without this PR
 - cannot use the `db.server` on different databases using the same server.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Typings
- [ ] Changelog
