### PR TITLE
ADD z-schema validator plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### comming soon
+### coming soon
+
+Features:
+  - Add a [z-schema](https://github.com/zaggino/z-schema) validator plugin
 
 Typings:
   - ADD typings to access the `PouchSyncHandler` of `RxReplicationState`

--- a/docs-src/custom-build.md
+++ b/docs-src/custom-build.md
@@ -45,6 +45,18 @@ RxDB.plugin(RxDBAjvValidateModule);
 RxDB.plugin(require('rxdb/plugins/ajv-validate'));
 ```
 
+### validate-z-schema
+
+Both `is-my-json-valid` and `ajv-validate` use `eval()` to perform validation which might not be wanted when `'unsafe-eval'` is not allowed in Content Security Policies. This one is using [z-schema](https://github.com/zaggino/z-schema) as validator which doesn't use `eval`.
+
+```javascript
+// es6-import
+import RxDBZSchemaValidateModule from 'rxdb/plugins/validate-z-schema';
+RxDB.plugin(RxDBZSchemaValidateModule);
+
+// es5-require
+RxDB.plugin(require('rxdb/plugins/validate-z-schema'));
+```
 
 ### no-validate
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "spark-md5": "^3.0.0",
     "unload": "2.1.0",
     "url": "^0.11.0",
-    "util": "^0.12.0"
+    "util": "^0.12.0",
+    "z-schema": "^4.0.2"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/plugins/validate-z-schema/index.d.ts
+++ b/plugins/validate-z-schema/index.d.ts
@@ -1,0 +1,2 @@
+declare let _default: {};
+export default _default;

--- a/plugins/validate-z-schema/package.json
+++ b/plugins/validate-z-schema/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "rxdb-plugin-validate-z-schema",
+  "main": "../../dist/lib/plugins/validate-z-schema.js",
+  "jsnext:main": "../../dist/es/plugins/validate-z-schema.js",
+  "module": "../../dist/es/plugins/validate-z-schema.js"
+}

--- a/src/plugins/validate-z-schema.js
+++ b/src/plugins/validate-z-schema.js
@@ -30,7 +30,7 @@ function _getValidator(rxSchema, schemaPath = '') {
     const validatorsOfHash = validatorsCache[hash];
   
     if (!validatorsOfHash[schemaPath]) {
-        const schemaPart = schemaPath === '' ? this.jsonID : this.getSchemaByObjectPath(schemaPath);
+        const schemaPart = schemaPath === '' ? rxSchema.jsonID : rxSchema.getSchemaByObjectPath(schemaPath);
     
         if (!schemaPart) {
             throw newRxError('VD1', {
@@ -56,7 +56,7 @@ function _getValidator(rxSchema, schemaPath = '') {
  * @return {any} obj if validation successful
  */
 const validate = function (obj, schemaPath = '') {
-    const validator = this._getValidator(schemaPath);
+    const validator = _getValidator(this, schemaPath);
     const useValidator = validator(obj);
     /** @type {ZSchema.SchemaErrorDetail[]} */
     const errors = useValidator.getLastErrors();
@@ -78,7 +78,7 @@ const validate = function (obj, schemaPath = '') {
 
 const runAfterSchemaCreated = rxSchema => {
     // pre-generate the validator-z-schema from the schema
-    requestIdleCallbackIfAvailable(() => _getValidator(rxSchema));
+    requestIdleCallbackIfAvailable(() => _getValidator.bind(rxSchema, rxSchema));
 };
 
 export const rxdb = true;

--- a/src/plugins/validate-z-schema.js
+++ b/src/plugins/validate-z-schema.js
@@ -11,8 +11,6 @@ import {
     requestIdleCallbackIfAvailable
 } from '../util';
 
-const validator = new ZSchema();
-
 /**
  * cache the validators by the schema-hash
  * so we can reuse them when multiple collections have the same schema
@@ -26,20 +24,25 @@ const validatorsCache = {};
  * @param {string} [schemaPath=''] if given, the schema for the sub-path is used
  * @
  */
-function _getValidator(schemaPath = '') {
+function _getValidator() {
+    const schemaPath = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
     const hash = this.hash;
-    if (!validatorsCache[hash])
-        validatorsCache[hash] = {};
+    if (!validatorsCache[hash]) validatorsCache[hash] = {};
     const validatorsOfHash = validatorsCache[hash];
+  
     if (!validatorsOfHash[schemaPath]) {
         const schemaPart = schemaPath === '' ? this.jsonID : this.getSchemaByObjectPath(schemaPath);
+    
         if (!schemaPart) {
             throw newRxError('VD1', {
-                schemaPath
+                schemaPath: schemaPath
             });
         }
-        validatorsOfHash[schemaPath] = validator(schemaPart);
+  
+        const validator = new ZSchema();
+        validatorsOfHash[schemaPath] = (obj) => validator.validate(obj, schemaPart);
     }
+  
     return validatorsOfHash[schemaPath];
 }
 

--- a/src/plugins/validate-z-schema.js
+++ b/src/plugins/validate-z-schema.js
@@ -24,9 +24,8 @@ const validatorsCache = {};
  * @param {string} [schemaPath=''] if given, the schema for the sub-path is used
  * @
  */
-function _getValidator() {
-    const schemaPath = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-    const hash = this.hash;
+function _getValidator(rxSchema, schemaPath = '') {
+    const hash = rxSchema.hash;
     if (!validatorsCache[hash]) validatorsCache[hash] = {};
     const validatorsOfHash = validatorsCache[hash];
   

--- a/src/plugins/validate-z-schema.js
+++ b/src/plugins/validate-z-schema.js
@@ -1,0 +1,93 @@
+/**
+ * this plugin validates documents before they can be inserted into the RxCollection.
+ * It's using z-schema as jsonschema-validator
+ * @link https://github.com/zaggino/z-schema
+ */
+import ZSchema from 'z-schema';
+import {
+    newRxError
+} from '../rx-error';
+import {
+    requestIdleCallbackIfAvailable
+} from '../util';
+
+const validator = new ZSchema();
+
+/**
+ * cache the validators by the schema-hash
+ * so we can reuse them when multiple collections have the same schema
+ * @type {Object<string, any>}
+ */
+const validatorsCache = {};
+
+
+/**
+ * returns the parsed validator from z-schema
+ * @param {string} [schemaPath=''] if given, the schema for the sub-path is used
+ * @
+ */
+function _getValidator(schemaPath = '') {
+    const hash = this.hash;
+    if (!validatorsCache[hash])
+        validatorsCache[hash] = {};
+    const validatorsOfHash = validatorsCache[hash];
+    if (!validatorsOfHash[schemaPath]) {
+        const schemaPart = schemaPath === '' ? this.jsonID : this.getSchemaByObjectPath(schemaPath);
+        if (!schemaPart) {
+            throw newRxError('VD1', {
+                schemaPath
+            });
+        }
+        validatorsOfHash[schemaPath] = validator(schemaPart);
+    }
+    return validatorsOfHash[schemaPath];
+}
+
+/**
+ * validates the given object against the schema
+ * @param  {any} obj
+ * @param  {String} [schemaPath=''] if given, the sub-schema will be validated
+ * @throws {RxError} if not valid
+ * @return {any} obj if validation successful
+ */
+const validate = function (obj, schemaPath = '') {
+    const useValidator = this._getValidator(schemaPath);
+    const isValid = useValidator(obj);
+    if (isValid) return obj;
+    else {
+        throw newRxError('VD2', {
+            errors: useValidator.errors,
+            schemaPath,
+            obj,
+            schema: this.jsonID
+        });
+    }
+};
+
+const runAfterSchemaCreated = rxSchema => {
+    // pre-generate the isMyJsonValid-validator from the schema
+    requestIdleCallbackIfAvailable(() => {
+        rxSchema._getValidator();
+    });
+};
+
+export const rxdb = true;
+export const prototypes = {
+    /**
+     * set validate-function for the RxSchema.prototype
+     * @param {[type]} prototype of RxSchema
+     */
+    RxSchema: (proto) => {
+        proto._getValidator = _getValidator;
+        proto.validate = validate;
+    }
+};
+export const hooks = {
+    createRxSchema: runAfterSchemaCreated
+};
+
+export default {
+    rxdb,
+    prototypes,
+    hooks
+};

--- a/test/unit/plugin.test.js
+++ b/test/unit/plugin.test.js
@@ -140,6 +140,35 @@ config.parallel('plugin.test.js', () => {
             }
         });
     });
+    describe('validate-z-schema.node.js', () => {
+        it('should allow everything', async () => {
+            if (!config.platform.isNode())
+                return;
+
+            const spawn = REQUIRE_FUN('child-process-promise').spawn;
+            const stdout = [];
+            const stderr = [];
+            const promise = spawn('mocha', [config.rootPath + 'test_tmp/unit/validate-z-schema.node.js']);
+            const childProcess = promise.childProcess;
+            childProcess.stdout.on('data', data => {
+                // comment in to debug
+                // console.log(':: ' + data.toString());
+                stdout.push(data.toString());
+            });
+            childProcess.stderr.on('data', data => stderr.push(data.toString()));
+            try {
+                await promise;
+            } catch (err) {
+                console.log('errrrr');
+                console.dir(stdout);
+                throw new Error(`could not run validate-z-schema.node.js.
+                            # Error: ${err}
+                            # Output: ${stdout}
+                            # ErrOut: ${stderr}
+                            `);
+            }
+        });
+    });
     describe('no-validate.node.js', () => {
         it('should allow everything', async () => {
             if (!config.platform.isNode())

--- a/test/unit/validate-z-schema.node.js
+++ b/test/unit/validate-z-schema.node.js
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import AsyncTestUtil from 'async-test-util';
+import config from './config';
+
+import * as schemaObjects from '../helper/schema-objects';
+import * as schemas from '../helper/schemas';
+
+import * as util from '../../dist/lib/util';
+import Core from '../../dist/lib/core';
+Core.plugin(require('../../plugins/validate-z-schema'));
+Core.plugin(require('../../plugins/key-compression'));
+Core.plugin(require('../../plugins/error-messages'));
+Core.plugin(require('pouchdb-adapter-memory'));
+
+config.parallel('validate-z-schema.node.js', () => {
+    describe('validation', () => {
+        describe('positive', () => {
+            it('should not throw', async () => {
+                const db = await Core.create({
+                    name: util.randomCouchString(10),
+                    adapter: 'memory'
+                });
+                const col = await db.collection({
+                    name: 'humans',
+                    schema: schemas.human
+                });
+
+                const doc = await col.insert(schemaObjects.human());
+                assert.ok(doc);
+
+                db.destroy();
+            });
+        });
+        describe('negative', () => {
+            it('should not validate wrong data', async () => {
+                const db = await Core.create({
+                    name: util.randomCouchString(10),
+                    adapter: 'memory'
+                });
+                const col = await db.collection({
+                    name: 'humans',
+                    schema: schemas.human
+                });
+
+                await AsyncTestUtil.assertThrows(
+                    () => col.insert({
+                        foo: 'bar'
+                    }),
+                    'RxError'
+                );
+
+                db.destroy();
+            });
+            it('should have the correct params in error', async () => {
+                const db = await Core.create({
+                    name: util.randomCouchString(10),
+                    adapter: 'memory'
+                });
+                const col = await db.collection({
+                    name: 'humans',
+                    schema: schemas.human
+                });
+
+                let error = null;
+                try {
+                    await col.insert({
+                        foo: 'bar'
+                    });
+                } catch (e) {
+                    error = e;
+                }
+
+                console.log(error);
+
+                assert.ok(error);
+                assert.ok(error.parameters.errors.length > 0);
+                db.destroy();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## This PR contains:
 - A NEW FEATURE

## Describe the problem you have without this PR

Both `is-my-json-valid` and `ajv-validate` use `eval()` to perform validation which might not be wanted when `'unsafe-eval'` is not allowed in Content Security Policies. This one is using [z-schema](https://github.com/zaggino/z-schema) as validator which doesn't use `eval`.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests
- [x] Documentation
- [x] Typings
- [x] Changelog

Related to #243, actually closes #235 
