### PR TITLE
Emit collection change after adding it to the db object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### comming soon
 
+Bugfixes:
+  - Collection change event was emitted before the actual change happened
+
 Typings:
   - ADD typings to access the `PouchSyncHandler` of `RxReplicationState`
 

--- a/src/rx-database.js
+++ b/src/rx-database.js
@@ -262,10 +262,11 @@ export class RxDatabase {
                 );
                 cEvent.data.v = col.name;
                 cEvent.data.col = '_collections';
-                this.$emit(cEvent);
 
                 this.collections[args.name] = col;
                 this.__defineGetter__(args.name, () => this.collections[args.name]);
+
+                this.$emit(cEvent);
 
                 return col;
             });

--- a/test/unit/reactive-database.test.js
+++ b/test/unit/reactive-database.test.js
@@ -28,7 +28,7 @@ describe('reactive-database.test.js', () => {
                         first()
                     ).toPromise().then(event => {
                         assert.notEqual(db[event.data.v], undefined);
-                        return event
+                        return event;
                     });
                 assert.equal(changeEvent.constructor.name, 'RxChangeEvent');
                 assert.equal(changeEvent.data.v, 'myname');

--- a/test/unit/reactive-database.test.js
+++ b/test/unit/reactive-database.test.js
@@ -26,7 +26,10 @@ describe('reactive-database.test.js', () => {
                     .pipe(
                         filter(cEvent => cEvent.data.op === 'RxDatabase.collection'),
                         first()
-                    ).toPromise();
+                    ).toPromise().then(event => {
+                        assert.notEqual(db[event.data.v], undefined);
+                        return event
+                    });
                 assert.equal(changeEvent.constructor.name, 'RxChangeEvent');
                 assert.equal(changeEvent.data.v, 'myname');
                 db.destroy();


### PR DESCRIPTION
## This PR contains:
- A Bugfix

## Describe the problem you have without this PR
While creating a collection, a subscriber to the db is notified of that, but cannot access the collection via the db object, since it is added after the emitting process.
