### PR TITLE
Replace `es5` with `CommonJS` in comments

### DIFF
--- a/docs-src/install.md
+++ b/docs-src/install.md
@@ -44,7 +44,7 @@ To import `rxdb`, add this to your javascript file:
 // es6
 import RxDB from 'rxdb';
 
-// es5
+// CommonJS
 var RxDB = require('rxdb');
 ```
 
@@ -54,7 +54,7 @@ If you have not included es8-polyfills, you also have to import `babel-polyfill`
 // es6
 import 'babel-polyfill';
 
-// es5
+// CommonJS
 require('babel-polyfill');
 ```
 


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:

 - IMPROVED DOCS
<!-- - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
`require` statement is a `CommonJS` statement and not a `ES5` statement.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ x ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
