### PR TITLE
`getAttachment` type should be nullable

### DIFF
--- a/typings/rx-document.d.ts
+++ b/typings/rx-document.d.ts
@@ -42,7 +42,7 @@ export declare class RxDocumentBase<RxDocumentType, OrmMethods = {}> {
 
     // attachments
     putAttachment(creator: RxAttachmentCreator): Promise<RxAttachment<RxDocumentType, OrmMethods>>;
-    getAttachment(id: string): RxAttachment<RxDocumentType, OrmMethods>;
+    getAttachment(id: string): RxAttachment<RxDocumentType, OrmMethods> | null;
     allAttachments(): RxAttachment<RxDocumentType, OrmMethods>[];
     readonly allAttachments$: Observable<RxAttachment<RxDocumentType, OrmMethods>[]>;
 


### PR DESCRIPTION
`getAttachment` returns `null` when the requested attachment does not exist. 
Reflect this in the typings so that clients know to handle the `null` case.

## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR

I was using `getAttachment` with the assumption that it would return something. This is not always the case, however, so it could throw a runtime error.
