### PR TITLE
handle missing rev strings

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -389,6 +389,9 @@ export function flattenObject(ob) {
  * @return {number}
  */
 export function getHeightOfRevision(revString) {
+    if(!revString) {
+        return 0;
+    }
     const first = revString.split('-')[0];
     return parseInt(first);
 }


### PR DESCRIPTION
Sometimes the `revString` parameter can be undefined when processing document changes.

## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR

I am debugging strange behavior on React Native. I am using pouchdb-adapter-asyncstorage and pouchdb-adapter-http to sync from CouchDB. During some of the initial document change reading, some change objects arrive with no revision field. I am not CouchDB expert so I can't tell why this is,
but for now I've patched over the problem by assuming a revision number of `0` for these incoming changes.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Discuss: is this correct? Why has it never been seen before?
- [ ] Test

## Discussion

I do not know whether I am doing something weird that causes this or it's a bug. I will attach a backup of the (very small) CouchDB data that I'm working with in case it helps. Please feel free to ask lots of questions or ask for more information; I am all ears on this one.
 
[CouchDB2_backup.zip](https://github.com/pubkey/rxdb/files/3462605/CouchDB2_backup.zip)
