### PR TITLE
Failing test case for importing dump with attachments

### DIFF
--- a/test/unit/bug-report.test.js
+++ b/test/unit/bug-report.test.js
@@ -13,7 +13,7 @@ import assert from 'assert';
 import * as humansCollection from './../helper/humans-collection';
 
 describe('bug-report.test.js', () => {
-    it('should fail because it reproduces the bug', async () => {
+    it('should import dump of db with attachments', async () => {
         const sourceCol = await humansCollection.createAttachments(1);
         const doc = await sourceCol.findOne().exec();
         await doc.putAttachment({

--- a/test/unit/bug-report.test.js
+++ b/test/unit/bug-report.test.js
@@ -12,7 +12,7 @@ import assert from 'assert';
 
 import * as humansCollection from './../helper/humans-collection';
 
-describe.only('bug-report.test.js', () => {
+describe('bug-report.test.js', () => {
     it('should fail because it reproduces the bug', async () => {
         const sourceCol = await humansCollection.createAttachments(1);
         const doc = await sourceCol.findOne().exec();


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS

## Describe the problem you have without this PR
Actually, I'm not completely sure what I'm trying to do is supposed to be supported. That's why I'm opening a PR with a test case instead of an issue, so you can judge by yourself.

My problem is that importing a dump of a DB that contains attachments fails with an error.

Furthermore, the attachment's data are not present in the json data produced by the dump.

Is dumping of attachments meant to supported by RxDB?