### PR TITLE
switched params of schema validation call

### DIFF
--- a/src/rx-document.js
+++ b/src/rx-document.js
@@ -338,7 +338,7 @@ export const basePrototype = {
         }
 
         // ensure modifications are ok
-        this.collection.schema.validateChange(newData, oldData);
+        this.collection.schema.validateChange(oldData, newData);
 
         return this.collection._runHooks('pre', 'save', newData, this)
             .then(() => {


### PR DESCRIPTION
## This PR contains:
 - SOMETHING ELSE

## Describe the problem you have without this PR
I consider this not really as bug, its more a kind of exception improvement.
In the below exception the information of old and new values are interchanged 
`RxError: RxError:
final fields cannot be modified
Given parameters: {
dataBefore:{
  "_rev": "1-5bf10021913fa326879ebf447d18cca5",
  "key": "new value"
}
dataAfter:{
  "_rev": "1-5bf10021913fa326879ebf447d18cca5",
  "key": "old value"
}
fieldName:"key"}`

this is because validateChange of rx-schema expects the old data as first argument and the new one as second but is called as follows:
`rx-document: this.collection.schema.validateChange(newData, oldData)`
`rx-schema: function validateChange(dataBefore, dataAfter)`

