### PR TITLE
add preCreateRxCollection

### DIFF
--- a/src/types/rx-plugin.ts
+++ b/src/types/rx-plugin.ts
@@ -18,6 +18,7 @@ export interface RxPlugin {
     hooks?: {
         createRxDatabase?: Function,
         createRxCollection?: Function,
+        preCreateRxCollection?: Function,
         preCreateRxSchema?: Function,
         createRxSchema?: Function,
         createRxQuery?: Function,


### PR DESCRIPTION
fix #1533 

## This PR contains:
- IMPROVED typings

## Describe the problem you have without this PR
When creating a plugin using typescript, the `hooks` property doesn't contain the type for `preCreateRxCollection` function.
