### PR TITLE
Fix serving migrated collections with server plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### X.X.X (comming soon)
 
+Bugfixes:
+  - Fix replication of migrated schemas in the server plugin
+
 ### 8.7.2 (24 October 2019)
 
 Bugfixes:

--- a/src/plugins/server.ts
+++ b/src/plugins/server.ts
@@ -66,7 +66,7 @@ function tunnelCollectionPath(
     const collectionPath = pathWithSlash + colName;
     app.use(collectionPath, function (req: any, res: any, next: any) {
         if (req.baseUrl.endsWith(collectionPath)) {
-            const to = normalizeDbName(db) + '-rxdb-0-' + colName;
+            const to = normalizeDbName(db) + '-rxdb-' + db[colName].schema.version + '-' + colName;
             const toFull = req.originalUrl.replace(collectionPath, pathWithSlash + to);
             req.originalUrl = toFull;
         }

--- a/test/helper/schema-objects.ts
+++ b/test/helper/schema-objects.ts
@@ -40,6 +40,17 @@ export function simpleHuman(): SimpleHumanDocumentType {
     };
 }
 
+export interface SimpleHumanV3DocumentType {
+    passportId: string;
+    age: string;
+}
+export function simpleHumanV3(): SimpleHumanV3DocumentType {
+    return {
+        passportId: randomToken(12),
+        age: randomInt(10, 50)
+    };
+}
+
 export interface SimpleHumanAgeDocumentType {
     passportId: string;
     age: string;


### PR DESCRIPTION
## This PR contains:

A fix for serving migrated schemas with the server plugin.

## Describe the problem you have without this PR

When using rxdb, I have a version 1 schema, and it doesn't sync new data from the server since it only finds the v0 database for the collection.

## Todos
- [ ] Changelog
