### PR TITLE
Create a new example with Electron remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
   firefox: latest
 
 before_install:
-  - export CHROME_BIN=chromium-browser	
-  - export DISPLAY=:99.0	
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - docker run -d -p 5984:5984 --rm --name rxdb-couchdb couchdb:2.1.1
 
@@ -88,6 +88,9 @@ jobs:
     - stage: examples
       script: npm run build && (cd ./examples/electron && npm install > "/dev/null" 2>&1 && travis_retry npm run test)
       env: LABEL=electron
+    - stage: examples
+      script: npm run build && (cd ./examples/electron-remote && npm install > "/dev/null" 2>&1 && travis_retry npm run test)
+      env: LABEL=electron-remote
     - stage: examples
       script: npm run build && (cd ./examples/react-native && npx yarn@1.13.0 install > "/dev/null" 2>&1 && travis_retry npm run test && echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p && npm run test:bundle)
       env: LABEL=react-native

--- a/examples/electron-remote/.gitignore
+++ b/examples/electron-remote/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+log.txt
+config.json

--- a/examples/electron-remote/.npmrc
+++ b/examples/electron-remote/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/electron-remote/README.md
+++ b/examples/electron-remote/README.md
@@ -1,0 +1,11 @@
+# RxDB Electron Remote example
+
+This is an example usage of RxDB with Electron and `remote` instead of the `RxDB server plugin`. It implements a simple heroes-list which can be filled by the user.
+
+# Try it out
+1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)
+2. go into project `cd rxdb`
+3. run `npm install`
+4. go to this folder `cd examples/electron-remote`
+5. run `npm install --verbose` (downloading electron can take a while, so use verbose to ensure its running)
+6. run `npm start`

--- a/examples/electron-remote/README.md
+++ b/examples/electron-remote/README.md
@@ -1,6 +1,8 @@
 # RxDB Electron Remote example
 
-This is an example usage of RxDB with Electron and `remote` instead of the `RxDB server plugin`. It implements a simple heroes-list which can be filled by the user.
+This is an example usage of RxDB with Electron trough the [`remote`](https://electronjs.org/docs/api/remote) API. It implements a simple heroes-list which can be filled by the user.
+
+For an example with the `RxDB server plugin` check [examples/electron](../electron)
 
 # Try it out
 1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)

--- a/examples/electron-remote/database.js
+++ b/examples/electron-remote/database.js
@@ -1,0 +1,44 @@
+const RxDB = require('rxdb');
+RxDB.plugin(require('pouchdb-adapter-memory'));
+
+const heroSchema = {
+    title: 'hero schema',
+    description: 'describes a simple hero',
+    version: 0,
+    type: 'object',
+    properties: {
+        name: {
+            type: 'string',
+            primary: true
+        },
+        color: {
+            type: 'string'
+        }
+    },
+    required: ['color']
+};
+
+let _getDatabase; // cached
+function getDatabase(name, adapter) {
+    if (!_getDatabase) _getDatabase = createDatabase(name, adapter);
+    return _getDatabase;
+}
+
+async function createDatabase(name, adapter) {
+    const db = await RxDB.create({
+        name,
+        adapter,
+        password: 'myLongAndStupidPassword'
+    });
+
+    console.log('creating hero-collection..');
+    await db.collection({
+        name: 'heroes',
+        schema: heroSchema
+    });
+
+    return db;
+}
+module.exports = {
+    getDatabase
+};

--- a/examples/electron-remote/index.html
+++ b/examples/electron-remote/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>RxDB Heroes Electron Remote</title>
+    <link href="style.css" rel="stylesheet"/>
+  </head>
+  <body>
+    <h1> RxDB Heroes Electron Remote</h1>
+    <div id="list-box" class="box">
+        <h3>Heroes</h3>
+        <ul id="heroes-list"></ul>
+    </div>
+    <div id="insert-box" class="box">
+        <h3>Add Hero</h3>
+        <input type="text" placeholder="Name" name="name" id="input-name" />
+        <input type="text" placeholder="Color" name="color" id="input-color" />
+        <button onclick="addHero();" id="input-submit">Insert</button>
+    </div>
+  </body>
+
+  <script>
+    // You can also require other files to run in this process
+    require('./page.js')
+  </script>
+</html>

--- a/examples/electron-remote/main.js
+++ b/examples/electron-remote/main.js
@@ -1,0 +1,64 @@
+const electron = require('electron');
+require('electron-window-manager');
+const path = require('path');
+const url = require('url');
+const database = require('./database');
+
+const app = electron.app;
+const BrowserWindow = electron.BrowserWindow;
+
+const windows = [];
+
+global.db; // define the global db object
+
+function createWindow(dbSuffix) {
+    const width = 300;
+    const height = 600;
+    const w = new BrowserWindow({
+        width,
+        height,
+        webPreferences: {
+            nodeIntegration: true
+        }
+    });
+
+    w.loadURL(url.format({
+        pathname: path.join(__dirname, 'index.html'),
+        protocol: 'file:',
+        slashes: true
+    }));
+
+    const x = windows.length * width;
+    const y = 0;
+    w.setPosition(x, y);
+    w.custom = {
+        dbSuffix
+    };
+    windows.push(w);
+}
+
+
+app.on('ready', async function() {
+    const dbSuffix = new Date().getTime(); // we add a random timestamp in dev-mode to reset the database on each start
+
+    global.db = await database.getDatabase(
+        'heroesdb' + dbSuffix,
+        'memory'
+    );
+
+    // show heroes table in console
+    global.db.heroes.find().sort('name').$.subscribe(heroDocs => {
+        console.log('### got heroes(' + heroDocs.length + '):');
+        heroDocs.forEach(doc => console.log(
+            doc.name + '  |  ' + doc.color
+        ));
+    });
+
+    createWindow(dbSuffix);
+    createWindow(dbSuffix);
+});
+
+app.on('window-all-closed', function() {
+    if (process.platform !== 'darwin')
+        app.quit();
+});

--- a/examples/electron-remote/package.json
+++ b/examples/electron-remote/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "rxdb-example-electron-remote",
+  "main": "main.js",
+  "scripts": {
+    "start": "npm run electron",
+    "electron": "electron .",
+    "test": "mocha"
+  },
+  "dependencies": {
+    "babel-polyfill": "6.26.0",
+    "babel-runtime": "6.26.0",
+    "concurrently": "5.0.0",
+    "electron": "6.1.5",
+    "electron-tabs": "0.11.0",
+    "electron-window-manager": "1.0.6",
+    "melanke-watchjs": "1.5.0",
+    "pouchdb-adapter-http": "7.0.0",
+    "pouchdb-adapter-websql": "7.0.0",
+    "pouchdb-replication": "7.0.0",
+    "rxdb": "../../",
+    "rxjs": "6.5.3"
+  },
+  "devDependencies": {
+    "mocha": "6.2.2",
+    "node": "12.9.1",
+    "spectron": "8.0.0"
+  }
+}

--- a/examples/electron-remote/page.js
+++ b/examples/electron-remote/page.js
@@ -1,0 +1,54 @@
+const electron = require('electron');
+const renderTest = require('./test/render.test.js');
+
+require('babel-polyfill');
+
+const heroesList = document.querySelector('#heroes-list');
+
+async function run() {
+    /**
+     * to check if rxdb works correctly, we run some integration-tests here
+     * if you want to use this electron-example as boilerplate, remove this line
+     */
+    await renderTest();
+
+    const db = electron.remote.getGlobal('db'); // we get the db object from the main render
+
+    /**
+     * map the result of the find-query to the heroes-list in the dom
+     */
+    db.heroes.find()
+        .sort({
+            name: 1
+        })
+        .$.subscribe(function (heroes) {
+            if (!heroes) {
+                heroesList.innerHTML = 'Loading..';
+                return;
+            }
+            console.log('observable fired');
+            console.dir(heroes);
+
+            heroesList.innerHTML = heroes
+                .map(hero => {
+                    return '<li>' +
+                        '<div class="color-box" style="background:' + hero.color + '"></div>' +
+                        '<div class="name" name="' + hero.name + '">' + hero.name + '</div>' +
+                        '</li>';
+                })
+                .reduce((pre, cur) => pre += cur, '');
+        });
+
+    window.addHero = async function () {
+        const name = document.querySelector('input[name="name"]').value;
+        const color = document.querySelector('input[name="color"]').value;
+        const obj = {
+            name: name,
+            color: color
+        };
+        console.log('inserting hero:');
+        console.dir(obj);
+        db.heroes.insert(obj);
+    };
+}
+run();

--- a/examples/electron-remote/style.css
+++ b/examples/electron-remote/style.css
@@ -1,0 +1,87 @@
+body, html{
+    margin: 0;
+    padding: 0;
+    font-family: Roboto;
+    background: #ebeff1;
+}
+
+#insert-box, #list-box, h1{
+    width: 86%;
+    padding: 3%;
+    margin-left: auto;
+    margin-right: auto;
+}
+.box{
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+    margin-bottom: 20px;
+    background: white;
+}
+#insert-box h3,
+#insert-box input,
+#insert-box button{
+    width: 100%;
+}
+.box h3{
+    margin-top: 0;
+}
+input{
+    font-size: 16px;
+    font-weight: lighter;
+    border: 0;
+    border-bottom: 1px solid #999;
+    margin-bottom: 20px;
+    padding-bottom: 7px;
+}
+input:focus{
+    outline: none;
+}
+button{
+    background-color: #009688;
+    outline: none;
+    border: none;
+    color: white;
+    font-size: 16px;
+    border-radius: 4px;
+    padding: 1.5%;
+    cursor: pointer;
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+}
+h1{
+    display: block;
+    font-size: 1.17em;
+    -webkit-margin-before: 1em;
+    -webkit-margin-after: 1em;
+    -webkit-margin-start: 0px;
+    -webkit-margin-end: 0px;
+    font-weight: bold;
+    margin: 0 auto;
+    padding: 3%;
+    width: 92%;
+}
+h3{
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.54);
+}
+ul{
+    list-style: none;
+    padding: 0 2%;
+    display: inline-block;
+    position: relative;
+    width: 96%;
+}
+ul#heroes-list li{
+    width: 100%;
+    float: left;
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+.color-box{
+    width: 20px;
+    height: 20px;
+    float: left;
+    margin-right: 11px;
+    border-radius: 2px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: grey;
+}

--- a/examples/electron-remote/test/render.test.js
+++ b/examples/electron-remote/test/render.test.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const RxDB = require('../../../');
+RxDB.plugin(require('pouchdb-adapter-idb'));
+
+
+/**
+ * this tests run inside of the browser-windows so we can ensure
+ * rxdb works correctly
+ */
+module.exports = (function () {
+    const runTests = async function () {
+        // issue #587 Icorrect working attachments in electron-render
+        await (async function () {
+            const db = await RxDB.create({
+                name: 'foobar587' + new Date().getTime(),
+                adapter: 'idb',
+                password: 'myLongAndStupidPassword',
+                multiInstance: true
+            });
+
+            await db.waitForLeadership();
+            if (db.broadcastChannel.method.type !== 'native') {
+                throw new Error('wrong BroadcastChannel-method chosen: ' + db.broadcastChannel.method.type);
+            }
+
+            const col = await db.collection({
+                name: 'heroes',
+                schema: {
+                    version: 0,
+                    type: 'object',
+                    properties: {
+                        id: {
+                            type: 'string',
+                            primary: true
+                        }
+                    },
+                    attachments: {
+                        encrypted: true
+                    }
+                }
+            });
+            const doc = await col.insert({
+                id: 'foo'
+            });
+            assert.ok(doc);
+
+            const attachmentData = 'foo bar asldfkjalkdsfj';
+            const attachment = await doc.putAttachment({
+                id: 'cat.jpg',
+                data: attachmentData,
+                type: 'text/plain'
+            });
+            assert.ok(attachment);
+
+
+            // issue #1371 Attachments not working in electron renderer with idb
+            const readData = await attachment.getStringData();
+            assert.equal(readData, attachmentData);
+
+            await db.destroy();
+        }());
+    };
+    return runTests;
+}());

--- a/examples/electron-remote/test/spec.js
+++ b/examples/electron-remote/test/spec.js
@@ -1,0 +1,78 @@
+const Application = require('spectron').Application;
+const assert = require('assert');
+const electronPath = require('electron'); // Require Electron from the binaries included in node_modules.
+const path = require('path');
+const AsyncTestUtil = require('async-test-util');
+
+describe('Application launch', function() {
+    this.timeout(20000);
+    let app;
+    before(function() {
+        this.app = new Application({
+            // Your electron path can be any binary
+            // i.e for OSX an example path could be '/Applications/MyApp.app/Contents/MacOS/MyApp'
+            // But for the sake of the example we fetch it from our node_modules.
+            path: electronPath,
+
+            // Assuming you have the following directory structure
+
+            //  |__ my project
+            //     |__ ...
+            //     |__ main.js
+            //     |__ package.json
+            //     |__ index.html
+            //     |__ ...
+            //     |__ test
+            //        |__ spec.js  <- You are here! ~ Well you should be.
+
+            // The following line tells spectron to look and use the main.js file
+            // and the package.json located 1 level above.
+            args: [path.join(__dirname, '..')]
+        });
+        app = this.app;
+        return this.app.start();
+    });
+
+    after(function() {
+        if (this.app && this.app.isRunning())
+            return this.app.stop();
+    });
+
+    it('shows an initial window', async () => {
+        await app.client.waitUntilWindowLoaded();
+        const count = await app.client.getWindowCount();
+        assert.equal(count, 2);
+        // Please note that getWindowCount() will return 2 if `dev tools` are opened.
+        // assert.equal(count, 2)
+        await AsyncTestUtil.wait(500);
+    });
+
+    it('insert one hero', async () => {
+        console.log('test: insert one hero');
+        console.dir(await app.client.getRenderProcessLogs());
+        await app.client.waitUntilWindowLoaded();
+        await app.client.element('#input-name').setValue('Bob Kelso');
+        await app.client.element('#input-color').setValue('blue');
+        await app.client.element('#input-submit').click();
+
+        await AsyncTestUtil.waitUntil(async () => {
+            const foundElement = await app.client.element('.name[name="Bob Kelso"]');
+            return foundElement.value;
+        });
+        await AsyncTestUtil.wait(100);
+    });
+    it('check if replicated to both windows', async () => {
+        const window1 = app.client.windowByIndex(0);
+        await AsyncTestUtil.waitUntil(async () => {
+            const foundElement = await window1.element('.name[name="Bob Kelso"]');
+            return foundElement.value;
+        });
+
+        const window2 = app.client.windowByIndex(1);
+        await AsyncTestUtil.waitUntil(async () => {
+            const foundElement = await window2.element('.name[name="Bob Kelso"]');
+            return foundElement.value;
+        });
+        await AsyncTestUtil.wait(100);
+    });
+});

--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -1,6 +1,8 @@
 # RxDB Electron example
 
-This is an example usage of RxDB with Electron. It implements a simple heroes-list which can be filled by the user.
+This is an example usage of RxDB with Electron trough the `RxDB server plugin`. It implements a simple heroes-list which can be filled by the user.
+
+For an example with Electron [`remote`](https://electronjs.org/docs/api/remote) API check [examples/electron-remote](../electron-remote)
 
 # Try it out
 1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)


### PR DESCRIPTION
## This PR contains:
- NEW EXAMPLE

## Describe the problem you have without this PR
None.
This is another example of implementing RxDB with Electron but using `remote` instead of `RxDB server plugin`.