### PR TITLE
update links in plugins docs

### DIFF
--- a/docs-src/plugins.md
+++ b/docs-src/plugins.md
@@ -59,15 +59,15 @@ The `rxdb`-property signals that this plugin is and rxdb-plugin and not a pouchd
 
 ## prototypes
 
-The `prototypes`-property contains a function for each of RxDB's internal prototype that you want to manipulate. Each function gets the prototype-object of the corresponding class as parameter and than can modify it. You can see a list of all available prototypes [here](https://github.com/pubkey/rxdb/blob/master/src/plugin.js)
+The `prototypes`-property contains a function for each of RxDB's internal prototype that you want to manipulate. Each function gets the prototype-object of the corresponding class as parameter and than can modify it. You can see a list of all available prototypes [here](https://github.com/pubkey/rxdb/blob/master/src/plugin.ts)
 
 ## overwritable
 
-Some of RxDB's functions are not inside of a class-prototype but are static. You can set and overwrite them with the `overwritable`-object. You can see a list of all overwriteables [here](https://github.com/pubkey/rxdb/blob/master/src/overwritable.js).
+Some of RxDB's functions are not inside of a class-prototype but are static. You can set and overwrite them with the `overwritable`-object. You can see a list of all overwriteables [here](https://github.com/pubkey/rxdb/blob/master/src/overwritable.ts).
 
 # hooks
 
-Sometimes you don't want to overwrite an existing RxDB-method, but extend it. You can do this by adding hooks which will be called each time the code jumps into the hooks corresponding call. You can find a list of all hooks here [here](https://github.com/pubkey/rxdb/blob/master/src/hooks.js).
+Sometimes you don't want to overwrite an existing RxDB-method, but extend it. You can do this by adding hooks which will be called each time the code jumps into the hooks corresponding call. You can find a list of all hooks here [here](https://github.com/pubkey/rxdb/blob/master/src/hooks.ts).
 
 # options
 


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:
 - Fixed outdated links in docs

## Describe the problem you have without this PR
There are some links on the "plugins" page of the docs that link to `.js` files which have been changed to `.ts` files. I have changed the destination of those links in the `docs-src/plugins.md` file.

The outdated links can be seen on the live [plugins][plugins] page under the "prototypes", "hooks", and "overwriteable" headers.

[plugins]: https://rxdb.info/plugins.html