### PR TITLE
Add collection methods to document type

### DIFF
--- a/docs-src/tutorials/typescript.md
+++ b/docs-src/tutorials/typescript.md
@@ -45,13 +45,7 @@ type HeroDocMethods = {
 };
 ```
 
-We can merge these into our HeroDocument.
-
-```typescript
-type HeroDocument = RxDocument<HeroDocType, HeroDocMethods>;
-```
-
-Now we can define type for the collection which contains the documents.
+We can also define type for the collection which contains the documents.
 
 ```typescript
 
@@ -59,8 +53,17 @@ Now we can define type for the collection which contains the documents.
 type HeroCollectionMethods = {
     countAllDocuments: () => Promise<number>;
 }
+```
 
-// and then merge all our types
+Now we can merge these into our HeroDocument.
+
+```typescript
+type HeroDocument = RxDocument<HeroDocType, HeroDocMethods, HeroCollectionMethods>;
+```
+
+And then we merge all our types:
+
+```typescript
 type HeroCollection = RxCollection<HeroDocType, HeroDocMethods, HeroCollectionMethods>;
 ```
 

--- a/src/types/rx-document.ts
+++ b/src/types/rx-document.ts
@@ -15,15 +15,16 @@ import {
     RxAttachmentCreator
 } from './rx-attachment';
 
-export type RxDocument<RxDocumentType = {}, OrmMethods = {}> = RxDocumentBase<RxDocumentType, OrmMethods> & RxDocumentType & OrmMethods;
+export type RxDocument<RxDocumentType = {}, OrmMethods = {}, StaticMethods = {}> =
+    RxDocumentBase<RxDocumentType, OrmMethods, StaticMethods> & RxDocumentType & OrmMethods;
 
 export type RxDocumentTypeWithRev<RxDocumentType> = RxDocumentType & { _rev: string };
 
 declare type AtomicUpdateFunction<RxDocumentType> = (doc: RxDocumentType) => RxDocumentType | Promise<RxDocumentType>;
 
-export declare interface RxDocumentBase<RxDocumentType, OrmMethods = {}> {
+export declare interface RxDocumentBase<RxDocumentType, OrmMethods = {}, StaticMethods = {}> {
     isInstanceOfRxDocument: true;
-    collection: RxCollection<RxDocumentType, OrmMethods>;
+    collection: RxCollection<RxDocumentType, OrmMethods, StaticMethods>;
     readonly deleted: boolean;
 
     readonly $: Observable<any>;


### PR DESCRIPTION

## This PR contains:
 - IMPROVED typings
 - Updated docs

## Describe the problem you have without this PR
I noticed that the `document.collection` property isn't typed with the collection's static methods. This updates the types so the collection static methods can be added when setting up the document's type.

I've also updated and rearranged the docs for types so it makes more sense- you can't send the collection methods in to the document type if you haven't declared them yet.

I set a default for the collection method types, so this is not a breaking change.