### PR TITLE
Add schema object type detection for nullable property & Add support for nested array in getSchemaByObjectPath

### DIFF
--- a/dist/lib/plugins/schema-check.js
+++ b/dist/lib/plugins/schema-check.js
@@ -22,6 +22,8 @@ var _rxSchema = require("../rx-schema");
 
 var _rxCollection = require("../rx-collection");
 
+var _util = require("../util");
+
 /**
  * does additional checks over the schema-json
  * to ensure nothing is broken or not supported
@@ -43,7 +45,7 @@ function checkFieldNameRegex(fieldName) {
     });
   }
 
-  var regexStr = '^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$';
+  var regexStr = '^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$|^[0-9]$';
   var regex = new RegExp(regexStr);
 
   if (!fieldName.match(regex)) {
@@ -255,9 +257,12 @@ function checkSchema(jsonID) {
     return arr.indexOf(elem) === pos;
   }) // unique
   .map(function (key) {
-    var path = 'properties.' + key.replace(/\./g, '.properties.');
+    var usePath = key.replace(/\.([a-z])/g, '.properties.$1');
+    usePath = usePath.replace(/\.([0-9]+)/g, '.items.$1');
+    usePath = 'properties.' + usePath;
+    usePath = (0, _util.trimDots)(usePath);
 
-    var schemaObj = _objectPath["default"].get(jsonID, path);
+    var schemaObj = _objectPath["default"].get(jsonID, usePath);
 
     if (!schemaObj || typeof schemaObj !== 'object') {
       throw (0, _rxError.newRxError)('SC21', {

--- a/dist/lib/rx-query.js
+++ b/dist/lib/rx-query.js
@@ -37,9 +37,7 @@ var newQueryID = function newQueryID() {
   return ++_queryCount;
 };
 
-var RxQueryBase =
-/*#__PURE__*/
-function () {
+var RxQueryBase = /*#__PURE__*/function () {
   function RxQueryBase(op, queryObj, collection) {
     this.id = newQueryID();
     this._latestChangeEvent = -1;
@@ -475,8 +473,11 @@ function _throwNotInSchema(key) {
 function _sortAddToIndex(checkParam, clonedThis) {
   var schemaObj = clonedThis.collection.schema.getSchemaByObjectPath(checkParam);
   if (!schemaObj) _throwNotInSchema(checkParam);
+  var schemaType = Array.isArray(schemaObj.type) ? schemaObj.type.find(function (type) {
+    return type !== 'null';
+  }) : schemaObj.type;
 
-  switch (schemaObj.type) {
+  switch (schemaType) {
     case 'integer':
       // TODO change back to -Infinity when issue resolved
       // @link https://github.com/pouchdb/pouchdb/issues/6454

--- a/dist/lib/rx-schema.js
+++ b/dist/lib/rx-schema.js
@@ -30,9 +30,7 @@ var _hooks = require("./hooks");
 
 var _rxDocument = require("./rx-document");
 
-var RxSchema =
-/*#__PURE__*/
-function () {
+var RxSchema = /*#__PURE__*/function () {
   function RxSchema(jsonID) {
     this.jsonID = jsonID;
     this.compoundIndexes = this.jsonID.compoundIndexes;
@@ -62,8 +60,8 @@ function () {
   var _proto = RxSchema.prototype;
 
   _proto.getSchemaByObjectPath = function getSchemaByObjectPath(path) {
-    var usePath = path;
-    usePath = usePath.replace(/\./g, '.properties.');
+    var usePath = path.replace(/\.([a-z])/g, '.properties.$1');
+    usePath = usePath.replace(/\.([0-9]+)/g, '.items.$1');
     usePath = 'properties.' + usePath;
     usePath = (0, _util.trimDots)(usePath);
 

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -526,8 +526,9 @@ function _sortAddToIndex(checkParam: any, clonedThis: any) {
     const schemaObj = clonedThis.collection.schema.getSchemaByObjectPath(checkParam);
     if (!schemaObj) _throwNotInSchema(checkParam);
 
+    const schemaType = Array.isArray(schemaObj.type) ? schemaObj.type.find((type: any) => type !== 'null') : schemaObj.type;
 
-    switch (schemaObj.type) {
+    switch (schemaType) {
         case 'integer':
             // TODO change back to -Infinity when issue resolved
             // @link https://github.com/pouchdb/pouchdb/issues/6454

--- a/src/rx-schema.ts
+++ b/src/rx-schema.ts
@@ -121,7 +121,8 @@ export class RxSchema<T = any> {
 
     public getSchemaByObjectPath(path: string): JsonSchema {
         let usePath: string = path as string;
-        usePath = usePath.replace(/\./g, '.properties.');
+        usePath = usePath.replace(/\.([a-z])/g, '.properties.$1');
+        usePath = usePath.replace(/\.([0-9]+)/g, '.items.$1');
         usePath = 'properties.' + usePath;
         usePath = trimDots(usePath);
 

--- a/src/rx-schema.ts
+++ b/src/rx-schema.ts
@@ -120,8 +120,7 @@ export class RxSchema<T = any> {
     private _getDocumentPrototype?: any;
 
     public getSchemaByObjectPath(path: string): JsonSchema {
-        let usePath: string = path as string;
-        usePath = usePath.replace(/\.([a-z])/g, '.properties.$1');
+        let usePath = path.replace(/\.([a-z])/g, '.properties.$1');
         usePath = usePath.replace(/\.([0-9]+)/g, '.items.$1');
         usePath = 'properties.' + usePath;
         usePath = trimDots(usePath);


### PR DESCRIPTION
Add schema object type detection for nullable property
Add support for nested array in getSchemaByObjectPath

## This PR contains:
 - A BUGFIX
 - A NEW FEATURE

## Describe the problem you have without this PR
Nested array were not supported because path was badly computed
`dbQuery.sort({'localizations.0.title': 'asc'})` didn't work, so i changed regex replace with
```
usePath = usePath.replace(/\.([a-z])/g, '.properties.$1');
usePath = usePath.replace(/\.([0-9]+)/g, '.items.$1');
```
And now it works.
_Don't forget to add `compoundIndexes: [['localizations.0.title']]`_

Nullable property could have wrong type because it's an array, for exemple
```
authorId: {
 type: ['string', 'null'],
}
```
trigger default case of switch, so i added 
```
const schemaType = Array.isArray(schemaObj.type) ? schemaObj.type.find((type: any) => type !== 'null') : schemaObj.type;
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog
