### PR TITLE
feat: expose pouchApp from spawnServer

### DIFF
--- a/src/plugins/server.ts
+++ b/src/plugins/server.ts
@@ -118,7 +118,8 @@ export function spawnServer(
         }));
     }
 
-    app.use(collectionsPath, ExpressPouchDB(pseudo));
+    const pouchApp = ExpressPouchDB(pseudo);
+    app.use(collectionsPath, pouchApp);
 
     let server = null;
     if (startServer) {
@@ -128,6 +129,7 @@ export function spawnServer(
 
     return {
         app,
+        pouchApp,
         server
     };
 }


### PR DESCRIPTION

## This PR contains:
 - A NEW FEATURE

## Describe the problem you have without this PR

I am wanting to use rxdb with pouchdb-auth, to provide user authentication, but I am unable to define an admin user at first startup.
This is because pouchdb-auth requires them to be defined as part of its config, which is only exposed on the pouchApp object this exposes. If an admin user is not defined, then every client will be an admin, so not having this control makes securing the master database on first startup very hard.

An example of how the result of this can be used for this is:
```
pouchApp.couchConfig.set('admins', 'admin1', 'password', cb);
```

There was some other fiddling I need to do with raw PouchDB databases to get the client side rxdb setup with pouchdb-auth, but that is fine. (I think just configuring pouchdb-auth with the special _users database)

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog
