### PR TITLE
GraphQL Replication: Refactor retry logic

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -175,7 +175,6 @@ export class RxGraphQLReplicationState {
             const ok = await this.runPush();
             if (!ok) {
                 willRetry = true;
-                setTimeout(() => this.run(), this.retryTime);
             }
         }
 
@@ -183,8 +182,12 @@ export class RxGraphQLReplicationState {
             const ok = await this.runPull();
             if (!ok) {
                 willRetry = true;
-                setTimeout(() => this.run(), this.retryTime);
             }
+        }
+
+        // retry on error
+        if (willRetry) {
+            setTimeout(() => this.run(), this.retryTime);
         }
 
         return willRetry;


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
If both push and pull fail `setTimeout(() => this.run(), this.retryTime);` is executed twice. Therefore run() is executed twice again and restarts itself 4x ... This can happen e.g. if there is no internet connection and results in an enormous stack of executing run(). In my opinion it should be sufficient to execute `setTimeout(() => this.run(), this.retryTime);` only once if there is an error in push OR pull.
```js
    async _run() {
        /* ... */

        // retry on error
        if (willRetry) {
            setTimeout(() => this.run(), this.retryTime);
        }
        return willRetry;
    }
```


