### PR TITLE
Allow query builders to be asynchronous

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -125,7 +125,7 @@ addRxPlugin(RxDBReplicationGraphQL);
 
 #### Pull replication
 
-For the pull-replication, you first need a `pullQueryBuilder`. This is a function that gets the last replicated document as input and returns an object with a GraphQL-query and its variables. RxDB will use the query builder to construct what is later send to the GraphQL endpoint.
+For the pull-replication, you first need a `pullQueryBuilder`. This is a function that gets the last replicated document as input and returns an object with a GraphQL-query and its variables (or a promise that resolves to the same object). RxDB will use the query builder to construct what is later send to the GraphQL endpoint.
 
 ```js
 const pullQueryBuilder = doc => {

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -207,7 +207,7 @@ export class RxGraphQLReplicationState {
 
         const latestDocument = await getLastPullDocument(this.collection, this.endpointHash);
         const latestDocumentData = latestDocument ? latestDocument : null;
-        const pullGraphQL = this.pull.queryBuilder(latestDocumentData);
+        const pullGraphQL = await this.pull.queryBuilder(latestDocumentData);
 
         let result;
         try {
@@ -321,7 +321,7 @@ export class RxGraphQLReplicationState {
              */
             for (let i = 0; i < changesWithDocs.length; i++) {
                 const changeWithDoc = changesWithDocs[i];
-                const pushObj = this.push.queryBuilder(changeWithDoc.doc);
+                const pushObj = await this.push.queryBuilder(changeWithDoc.doc);
                 const result = await this.client.query(pushObj.query, pushObj.variables);
                 if (result.errors) {
                     throw new Error(JSON.stringify(result.errors));

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -1,7 +1,14 @@
-export type RxGraphQLReplicationQueryBuilder = (doc: any) => {
+export interface RxGraphQLReplicationQueryBuilderResponseObject {
     query: string;
     variables: any;
-};
+}
+
+export type RxGraphQLReplicationQueryBuilderResponse =
+    RxGraphQLReplicationQueryBuilderResponseObject |
+    Promise<RxGraphQLReplicationQueryBuilderResponseObject>;
+
+export type RxGraphQLReplicationQueryBuilder = (doc: any) =>
+    RxGraphQLReplicationQueryBuilderResponse;
 
 export interface GraphQLSyncPullOptions {
     queryBuilder: RxGraphQLReplicationQueryBuilder;


### PR DESCRIPTION
## This PR contains
A New Feature

## Describe the problem you have without this PR
I am using graphql replication. In my use case, in my query builder I need to run asynchronous operations before returning the query and variables. 

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests
- [x] Documentation
- [x] Typings
- [ ] Changelog

I have included a new unit test that simply wraps the existing test queryBuilder in an async function. Additionally all the existing tests still pass.
