### PR TITLE
bugfix in prepareQuery for pouchdb

### DIFF
--- a/src/rx-storage-pouchdb.ts
+++ b/src/rx-storage-pouchdb.ts
@@ -160,14 +160,16 @@ export class RxStoragePouchDbClass implements RxStorage<PouchDBInstance> {
         const query = mutateableQuery;
 
         /**
-         * because sort wont work on unused keys we have to workarround
+         * because sort wont work on unused keys we have to workaround
          * so we add the key to the selector if necessary
          * @link https://github.com/nolanlawson/pouchdb-find/issues/204
          */
         if (query.sort) {
             query.sort.forEach(sortPart => {
                 const key = Object.keys(sortPart)[0];
-                if (!query.selector[key] || !query.selector[key].$gt) {
+                const comparisonOperators = ['$gt', '$gte', '$lt', '$lte'];
+                const keyUsed = query.selector[key] && Object.keys(query.selector[key]).some(op => comparisonOperators.includes(op)) || false;
+                if (!keyUsed) {
                     const schemaObj = rxQuery.collection.schema.getSchemaByObjectPath(key);
                     if (!schemaObj) {
                         throw newRxError('QU5', {

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -37,7 +37,8 @@ describe('bug-report.test.js', () => {
                     minimum: 0,
                     maximum: 150
                 }
-            }
+            },
+            indexes: ['age'],
         };
 
         // generate a random database-name
@@ -64,6 +65,13 @@ describe('bug-report.test.js', () => {
             age: 56
         });
 
+        await collection.insert({
+            passportId: 'foobar2',
+            firstName: 'Bob2',
+            lastName: 'Kelso2',
+            age: 58
+        });
+
         /**
          * to simulate the event-propagation over multiple browser-tabs,
          * we create the same database again
@@ -82,16 +90,23 @@ describe('bug-report.test.js', () => {
 
         // find the document in the other tab
         const myDocument = await collectionInOtherTab
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
+            .findOne({
+                selector: {
+                    age: {
+                        $gte: 57,
+                    },
+                },
+                sort: [{ age: 'asc' }]
+            })
             .exec();
+
+        console.log(myDocument);
 
         /*
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.strictEqual(myDocument.age, 56);
+        assert.strictEqual(myDocument.age, 58);
 
         // you can also wait for events
         const emitted = [];


### PR DESCRIPTION

## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
In `rx-storage-pouchdb.prepareQuery`, a `gt` operator in selector is added if not already present.
This creates a problem if the selector originally has `gte` operator as `pouch-find` internally merges startKey for both these operators, mostly overriding gte with gt.

This PR checks for any comparison operators in selector for that key, and adds that hack only if required, and thereby avoiding reproduced issue.

## Todos 
- [ ] Tests
