### PR TITLE
fixed typescript compile error in rx-query.ts

### DIFF
--- a/src/event-reduce.ts
+++ b/src/event-reduce.ts
@@ -12,8 +12,8 @@ export type EventReduceResultNeg = {
 };
 export type EventReduceResultPos<RxDocumentType> = {
     runFullQueryAgain: false,
-    changed: boolean,
-    newResults: RxDocumentType[];
+    changed?: boolean,
+    newResults?: RxDocumentType[];
 };
 export type EventReduceResult<RxDocumentType> = EventReduceResultNeg | EventReduceResultPos<RxDocumentType>;
 


### PR DESCRIPTION
### Description
The production build for an Angular 9 project fails due to a non-existing property on type EventReduceResultNeg.

### Console Output
```
ERROR in node_modules/rxdb/src/rx-query.ts:507:42 - error TS2339: Property 'changed' does not exist on type 'EventReduceResult<any>'.
  Property 'changed' does not exist on type 'EventReduceResultNeg'.

507             } else if (eventReduceResult.changed) {
                                             ~~~~~~~
node_modules/rxdb/src/rx-query.ts:510:58 - error TS2339: Property 'newResults' does not exist on type 'EventReduceResult<any>'.
  Property 'newResults' does not exist on type 'EventReduceResultNeg'.

510                 rxQuery._setResultData(eventReduceResult.newResults);
```

### Dependencies
```
    "@angular/common": "^9.1.9",
    "@angular/compiler": "^9.1.9",
    "@angular/core": "^9.1.9",

    "@angular-devkit/architect": "~0.901.7",
    "@angular-devkit/build-angular": "~0.901.7",
    "@angular-devkit/build-optimizer": "~0.901.7",
    "@angular-devkit/core": "~9.1.7",
    "@angular-devkit/schematics": "~9.1.7",
    "@angular/cli": "^9.1.7",
    "@angular/compiler-cli": "^9.1.9",

    "@types/pouchdb-adapter-http": "6.1.3",
    "@types/pouchdb-adapter-idb": "6.1.3",

    "typescript": "~3.8.3"

    "rxdb": "~9.1.0",
```

### Compiler Options
```
    "sourceMap": true,
    "downlevelIteration": true,
    "declaration": false,
    "module": "esnext",
    "moduleResolution": "node",
    "resolveJsonModule": true,
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "importHelpers": true,
    "target": "es2015",
    "typeRoots": [
      "node_modules/@types"
    ],
    "lib": [
      "es2018",
      "dom"
    ],
```

### Alternative Solution
Another solution could be to perform a type check where the error occurs, instead of making the two additional properties of EventReduceResultPos<T> optional.

Here an example:

```
            const eventReduceResult = calculateNewResults(
                rxQuery as any,
                runChangeEvents
            );
            if (eventReduceResult.runFullQueryAgain) {
                // could not calculate the new results, execute must be done
                mustReExec = true;
            } else if ((eventReduceResult as EventReduceResultPos<any>)?.changed) {
                // we got the new results, we do not have to re-execute, mustReExec stays false
                ret = true; // true because results changed
                rxQuery._setResultData((eventReduceResult as EventReduceResultPos<any>)?.newResults);
            }
```

I'm fine with both solutions tbh, so the decision is up to you.