### PR TITLE
Nullable relation in RxSchema

### DIFF
--- a/docs-src/population.md
+++ b/docs-src/population.md
@@ -20,13 +20,13 @@ export const refHuman = {
         },
         bestFriend: {
             ref: 'human',     // refers to collection human
-            type: 'string'    // ref-values must always be string (primary of foreign RxDocument)
+            type: 'string'    // ref-values must always be string or ['string','null'] (primary of foreign RxDocument) 
         }
     }
 };
 ```
 
-You can also have a one-to-may reference by using a string-array.
+You can also have a one-to-many reference by using a string-array.
 
 ```js
 export const schemaWithOneToManyReference = {

--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -75,22 +75,30 @@ export function validateFieldsDeep(jsonSchema: any): true {
         }
 
 
-        // if ref given, must be type=='string' or type=='array' with string-items
+        // if ref given, must be type=='string', type=='array' with string-items or type==['string','null']
         if (schemaObj.hasOwnProperty('ref')) {
-            switch (schemaObj.type) {
-                case 'string':
-                    break;
-                case 'array':
-                    if (!schemaObj.items || !schemaObj.items.type || schemaObj.items.type !== 'string') {
-                        throw newRxError('SC3', {
-                            fieldName
-                        });
-                    }
-                    break;
-                default:
+            if (Array.isArray(schemaObj.type)) {
+                if (schemaObj.type.length > 2 || !schemaObj.type.includes('string') || !schemaObj.type.includes('null')) {
                     throw newRxError('SC4', {
                         fieldName
                     });
+                }
+            } else {
+                switch (schemaObj.type) {
+                    case 'string':
+                        break;
+                    case 'array':
+                        if (!schemaObj.items || !schemaObj.items.type || schemaObj.items.type !== 'string') {
+                            throw newRxError('SC3', {
+                                fieldName
+                            });
+                        }
+                        break;
+                    default:
+                        throw newRxError('SC4', {
+                            fieldName
+                        });
+                }
             }
         }
 

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -128,7 +128,7 @@ export const ERROR_MESSAGES: { [k: string]: string } = {
     SC1: 'fieldnames do not match the regex',
     SC2: 'SchemaCheck: name \'item\' reserved for array-fields',
     SC3: 'SchemaCheck: fieldname has a ref-array but items-type is not string',
-    SC4: 'SchemaCheck: fieldname has a ref but is not type string or array<string>',
+    SC4: 'SchemaCheck: fieldname has a ref but is not type string, [string,null] or array<string>',
     SC5: 'SchemaCheck: fieldname cannot be primary and ref at same time',
     SC6: 'SchemaCheck: primary can only be defined at top-level',
     SC7: 'SchemaCheck: default-values can only be defined at top-level',

--- a/test/unit/population.test.ts
+++ b/test/unit/population.test.ts
@@ -61,6 +61,22 @@ config.parallel('population.test.js', () => {
                 });
                 assert.strictEqual(schema.constructor.name, 'RxSchema');
             });
+            it('should allow to create relation with nullable string', () => {
+                const schema = createRxSchema({
+                    version: 0,
+                    type: 'object',
+                    properties: {
+                        friends: {
+                            type: 'array',
+                            items: {
+                                ref: 'human',
+                                type: ['string', 'null']
+                            }
+                        }
+                    }
+                });
+                assert.strictEqual(schema.constructor.name, 'RxSchema');
+            });
         });
         describe('negative', () => {
             it('throw if primary is ref', () => {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED DOCS
 - A NEW FEATURE

## Describe the problem you have without this PR
Cannot define a relation property in an RxSchema with a nullable string, as a type of ['string', 'null'] is not accepted. But without a null-type, any validation of objects with a null-reference will fail because they don't fit the schema.

Discussed in issue #2285 .

## Todos
- [ ] Changelog

