### PR TITLE
Setter for Headers of GraphQlReplicationState 

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -286,6 +286,16 @@ Returns true if the replication is stopped. This can be if a non-live replicatio
 replicationState.isStopped(); // true/false
 ```
 
+#### .setHeaders()
+
+Changes the headers for the replication after it has been set up.
+
+```js
+replicationState.setHeaders({
+    Authorization: `...`
+});
+```
+
 #### .awaitInitialReplication()
 
 Returns a `Promise` that is resolved as soon as the initial replication is done.

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -70,7 +70,7 @@ export class RxGraphQLReplicationState {
 
     constructor(
         public collection: RxCollection,
-        url: string,
+        private url: string,
         headers: { [k: string]: string },
         public pull: GraphQLSyncPullOptions,
         public push: GraphQLSyncPushOptions,
@@ -430,11 +430,19 @@ export class RxGraphQLReplicationState {
         );
         this.collection.$emit(cE);
     }
+
     cancel(): Promise<any> {
         if (this.isStopped()) return Promise.resolve(false);
         this._subs.forEach(sub => sub.unsubscribe());
         this._subjects.canceled.next(true);
         return Promise.resolve(true);
+    }
+
+    setHeaders(headers: { [k: string]: string }): void {
+        this.client = GraphQLClient({
+            url: this.url,
+            headers
+        });
     }
 }
 

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -2036,6 +2036,70 @@ describe('replication-graphql.test.js', () => {
 
                 db.destroy();
             });
+            it('should work with headers', async () => {
+                const [c, server] = await Promise.all([
+                    humansCollection.createHumanWithTimestamp(0),
+                    SpawnServer.spawn(getTestData(1))
+                ]);
+
+                server.requireHeader('Authorization', 'password');
+                const replicationState = c.syncGraphQL({
+                    url: server.url,
+                    pull: {
+                        queryBuilder
+                    },
+                    headers: {
+                        Authorization: 'password'
+                    },
+                    live: true,
+                    deletedFlag: 'deleted'
+                });
+                await replicationState.awaitInitialReplication();
+
+                const docs = await c.find().exec();
+                assert.strictEqual(docs.length, 1);
+
+                server.close();
+                await c.database.destroy();
+            });
+            it('should work after headers change', async () => {
+                const [c, server] = await Promise.all([
+                    humansCollection.createHumanWithTimestamp(0),
+                    SpawnServer.spawn(getTestData(1))
+                ]);
+
+                server.requireHeader('Authorization', 'password');
+                const replicationState = c.syncGraphQL({
+                    url: server.url,
+                    pull: {
+                        queryBuilder
+                    },
+                    headers: {
+                        Authorization: 'password'
+                    },
+                    live: true,
+                    deletedFlag: 'deleted'
+                });
+                await replicationState.awaitInitialReplication();
+
+                server.requireHeader('Authorization', '1234');
+                const doc = getTestData(1).pop();
+                await server.setDocument(doc);
+
+                replicationState.setHeaders({
+                    'Authorization': '1234'
+                });
+                await replicationState.run();
+
+                const docs = await c.find().exec();
+                assert.strictEqual(docs.length, 2);
+
+                server.close();
+                await c.database.destroy();
+
+                // replication should be canceled when collection is destroyed
+                assert.ok(replicationState.isStopped());
+            });
         });
 
         config.parallel('issues', () => {


### PR DESCRIPTION
## This PR contains:
<!--
 - IMPROVED DOCS
 - A NEW FEATURE
-->

## Describe the problem you have without this PR
Headers of the GqlReplState cannot be changed currently, e.g. when Authentication Tokens change.
#2389 

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Changelog