### PR TITLE
Create compound index with primary key and sort by its items 

### DIFF
--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -825,10 +825,12 @@ function _prepareCreateIndexes(
             .map(indexAr => {
                 const compressedIdx = indexAr
                     .map(key => {
+                        const primPath = rxCollection.schema.primaryPath;
+                        const useKey = key === primPath ? '_id' : key;
                         if (!rxCollection.schema.doKeyCompression()) {
-                            return key;
+                            return useKey;
                         } else {
-                            const indexKey = rxCollection._keyCompressor.transformKey(key);
+                            const indexKey = rxCollection._keyCompressor.transformKey(useKey);
                             return indexKey;
                         }
                     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -202,11 +202,12 @@ export function sortObject(obj: any, noArraySort = false): any {
                 if (typeof a === 'object') return 1;
                 else return -1;
             })
-            .map(i => sortObject(i));
+            .map(i => sortObject(i, noArraySort));
     }
 
     // object
-    if (typeof obj === 'object') {
+    // array is also of type object
+    if (typeof obj === 'object' && !Array.isArray(obj)) {
         if (obj instanceof RegExp)
             return obj;
 
@@ -214,7 +215,7 @@ export function sortObject(obj: any, noArraySort = false): any {
         Object.keys(obj)
             .sort((a, b) => a.localeCompare(b))
             .forEach(key => {
-                out[key] = sortObject(obj[key]);
+                out[key] = sortObject(obj[key], noArraySort);
             });
         return out;
     }

--- a/test/helper/humans-collection.ts
+++ b/test/helper/humans-collection.ts
@@ -535,3 +535,31 @@ export async function createRelatedNested(
 
     return collection;
 }
+
+export async function createIdAndAgeIndex(
+    amount = 20
+): Promise<RxCollection<schemaObjects.HumanWithIdAndAgeIndexDocumentType>> {
+    PouchDB.plugin(require('pouchdb-adapter-memory'));
+
+    const db = await createRxDatabase<{ humana: RxCollection<schemaObjects.HumanWithIdAndAgeIndexDocumentType> }>({
+        name: randomCouchString(10),
+        adapter: 'memory',
+        eventReduce: true,
+        ignoreDuplicate: true
+    });
+    // setTimeout(() => db.destroy(), dbLifetime);
+    const collection = await db.collection<schemaObjects.HumanWithIdAndAgeIndexDocumentType>({
+        name: 'humana',
+        schema: schemas.humanIdAndAgeIndex
+    });
+
+    // insert data
+    if (amount > 0) {
+        const docsData = new Array(amount)
+            .fill(0)
+            .map(() => schemaObjects.humanWithIdAndAgeIndexDocumentType());
+        await collection.bulkInsert(docsData);
+    }
+
+    return collection;
+}

--- a/test/helper/schema-objects.ts
+++ b/test/helper/schema-objects.ts
@@ -384,3 +384,16 @@ export function _idPrimary(): IdPrimaryDocumentType {
         firstName: faker.name.firstName()
     };
 }
+
+export interface HumanWithIdAndAgeIndexDocumentType {
+    id: string;
+    name: string;
+    age: number;
+}
+export function humanWithIdAndAgeIndexDocumentType(): HumanWithIdAndAgeIndexDocumentType {
+    return {
+        id: randomToken(12),
+        name: faker.name.firstName(),
+        age: randomNumber(1, 100)
+    };
+}

--- a/test/helper/schemas.ts
+++ b/test/helper/schemas.ts
@@ -984,3 +984,28 @@ export const humanWithDeepNestedIndexes: RxJsonSchema = {
     },
     indexes: ['name', 'job.name', 'job.manager.fullName', 'job.manager.previousJobs.[].name']
 };
+
+export const humanIdAndAgeIndex: RxJsonSchema = {
+    version: 0,
+    description: 'uses a compound index with id as lowest level',
+    type: 'object',
+    properties: {
+        id: {
+            type: 'string',
+            primary: true
+        },
+        name: {
+            type: 'string'
+        },
+        age: {
+            description: 'Age in years',
+            type: 'integer',
+            minimum: 0,
+            maximum: 150
+        }
+    },
+    required: ['id', 'name', 'age'],
+    indexes: [
+        ['age', 'id']
+    ]
+};

--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -810,6 +810,32 @@ config.parallel('rx-collection.test.js', () => {
                         assert.strictEqual(doc1._data.passportId, doc2._data.passportId);
                         c.database.destroy();
                     });
+                    it('sort by compound index with id', async () => {
+                        const c = await humansCollection.createIdAndAgeIndex();
+                        const query = c.find({
+                            selector: {
+                                age: {
+                                    $gt: 0
+                                }
+                            }
+                        }).sort({
+                            age: 'desc',
+                            id: 'desc'
+                        });
+
+                        assert.ok(isRxQuery(query));
+                        const docs = await query.exec();
+
+                        assert.strictEqual(docs.length, 20);
+                        assert.ok(
+                            docs[0]._data.age > docs[1]._data.age ||
+                            (
+                                docs[0]._data.age === docs[1]._data.age &&
+                                docs[0]._data.id > docs[1]._data.id
+                            )
+                        );
+                        c.database.destroy();
+                    });
                 });
                 describe('negative', () => {
                     it('throw when sort is not index', async () => {

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -65,6 +65,19 @@ config.parallel('rx-query.test.js', () => {
 
             col.database.destroy();
         });
+        it('should get a valid string-representation with two sort params', async () => {
+            const col = await humansCollection.createAgeIndex();
+            const q = col.find().sort({
+                passportId: 'desc', age: 'desc'
+            });
+            const str = q.toString();
+            const mustString = '{"op":"find","other":{},"query":{"selector":{"_id":{}},"sort":[{"passportId":"desc"},{"age":"desc"}]}}';
+            assert.strictEqual(str, mustString);
+            const str2 = q.toString();
+            assert.strictEqual(str2, mustString);
+
+            col.database.destroy();
+        });
         it('ISSUE #190: should contain the regex', async () => {
             const col = await humansCollection.create(0);
             const queryWithoutRegex = col.find();


### PR DESCRIPTION
## This PR contains:
A bugfix concerning compound indexes

## Describe the problem you have without this PR
I tried to create a _compound index_ (age + id) that contains the primary key (id) of the schema and sort docs by the attributes of the compound index (see test). This fails with the error message "_cannot sort on field(s) 'age' when using the default index_". Why is the default index ('_id)' used here, although an appropriate custom index has been defined?

The first problem was that in _RxStoragePouchDbClass_ - **prepareQuery()** the primary key is changed to '_id' and therefore the new custom index does not match the attribute anymore: 
https://github.com/pubkey/rxdb/blob/8b954b44ce67177003d2ceef2d79c54bc1d27c23/src/rx-storage-pouchdb.ts#L221
Therefore in my opinion the method **createIndex()** of _RxCollection_ has to be adapted and the change of the primary key has to be done as well.

Second, the order of the attributes in **sort()** is changed. This has proven to be a problem with the util **sortObject()**. When the method is called recursively, the param _noArraySort_ is currently not passed to further calls, which results in nested arrays being sorted. The problem occurred in the method **toString()** of _RxQuery_, so the custom index was not found. Additionally, the test `typeof obj === 'object' ` in the method is not sufficient to exclude an array. Therefore I have added `!Array.isArray(obj)` here.

Hopefully I explained the problem sufficiently :)

## Todos
- [ ] Changelog
