### PR TITLE
#2471 multiple invocations of subscription after upsertLocal()

### DIFF
--- a/test/unit/local-documents.test.ts
+++ b/test/unit/local-documents.test.ts
@@ -114,6 +114,21 @@ config.parallel('local-documents.test.js', () => {
                 assert.strictEqual(doc.get('foo'), 'bar2');
                 c.database.destroy();
             });
+            it('should invoke subscription onces', async () => {
+                let invocations = 0;
+                const c = await humansCollection.create();
+                const doc = await c.upsertLocal('foobar', {
+                    foo: 'bar',
+                });
+                const doc$ = doc.$.subscribe((doc) => {
+                    invocations++;
+                });
+                await c.upsertLocal('foobar', {
+                    foo: 'bar2',
+                });
+                doc$.unsubscribe();
+                assert.strictEqual(invocations, 1);
+            });
         });
         describe('negative', () => { });
     });

--- a/test/unit/local-documents.test.ts
+++ b/test/unit/local-documents.test.ts
@@ -120,7 +120,7 @@ config.parallel('local-documents.test.js', () => {
                 const doc = await c.upsertLocal('foobar', {
                     foo: 'bar',
                 });
-                const doc$ = doc.$.subscribe((doc) => {
+                const doc$ = doc.$.subscribe(() => {
                     invocations++;
                 });
                 await c.upsertLocal('foobar', {


### PR DESCRIPTION
## This PR contains:
IMPROVED TESTS revealing a potential bug

## Describe the problem you have without this PR
Issue #2471: 
- when upsert a localDocument subscriptions invoked twice
- the implemented test additionally revealed that subscribing with
   .$.subscribe on a document it is directly invoked already, 
    not sure whether this is intended

## Todos
- [x] Tests
- [ ] Changelog
- [ ] Bugfix
