### PR TITLE
Update the readme and docs to mention minimum version of Typescript required

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 | 📤📥  | **Import/Export** of the database-state (json), awesome for coding with [TDD](https://en.wikipedia.org/wiki/Test-driven_development)                                                                                                    |
 | 📡  | **Multi-Window** to synchronise data between different browser-windows or nodejs-processes                                                                                                                                              |
 | 💅 | **ORM-capabilities** to easily handle data-code-relations and customize functions of documents and collections                                                                                                                                                                               |
-| 🔷  | Full **TypeScript** support for fast and secure coding                                                                                                                                              |
+| 🔷  | Full **TypeScript** support for fast and secure coding (Requires Typescript v3.8 or higher)                                                                                                                                             |
 
 ## Platform-support
 

--- a/docs-src/tutorials/typescript.md
+++ b/docs-src/tutorials/typescript.md
@@ -5,7 +5,7 @@
 In this tutorial you learn how to use RxDB with TypeScript.
 We will create a basic database with one collection and several ORM-methods, fully typed!
 
-RxDB directly comes with it's typings and you do not have to install anything else, however the latst version of RxDB (v9+) requires that you are using Typescript v3.8+.
+RxDB directly comes with it's typings and you do not have to install anything else, however the latest version of RxDB (v9+) requires that you are using Typescript v3.8 or higher.
 Our way to go is
 
 - First define how the documents look like

--- a/docs-src/tutorials/typescript.md
+++ b/docs-src/tutorials/typescript.md
@@ -5,7 +5,7 @@
 In this tutorial you learn how to use RxDB with TypeScript.
 We will create a basic database with one collection and several ORM-methods, fully typed!
 
-RxDB directly comes with it's typings and you do not have to install anything else.
+RxDB directly comes with it's typings and you do not have to install anything else, however the latst version of RxDB (v9+) requires that you are using Typescript v3.8+.
 Our way to go is
 
 - First define how the documents look like


### PR DESCRIPTION
## This PR contains: 
 - IMPROVED DOCS

## Describe the problem you have without this PR
This PR updates the readme and docs to mention that RxDB v9 requires Typescript v3.8 or higher. Issue was raised in #2487 
