### PR TITLE
In GraphQL replication docs use the correct names of the input params

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -158,7 +158,7 @@ With the queryBuilder, you can then setup the pull-replication.
 const replicationState = myCollection.syncGraphQL({
     url: 'http://example.com/graphql', // url to the GraphQL endpoint
     pull: {
-        pullQueryBuilder, // the queryBuilder from above
+        queryBuilder: pullQueryBuilder, // the queryBuilder from above
         modifier: doc => doc // (optional) modifies all pulled documents before they are handeled by RxDB
     },
     deletedFlag: 'deleted', // the flag which indicates if a pulled document is deleted
@@ -196,7 +196,7 @@ With the queryBuilder, you can then setup the push-replication.
 const replicationState = myCollection.syncGraphQL({
     url: 'http://example.com/graphql', // url to the GraphQL endpoint
     push: {
-        pushQueryBuilder, // the queryBuilder from above
+        queryBuilder: pushQueryBuilder, // the queryBuilder from above
         batchSize: 5, // (optional) amount of documents that will be send in one batch
         modifier: d => d // (optional) modifies all pushed documents before they are send to the GraphQL endpoint
     },


### PR DESCRIPTION
## This PR contains:
Improved docs.

## Describe the problem you have without this PR
The current GraphQL replication docs use wrong names of the params.

https://github.com/pubkey/rxdb/blob/996b5bbb13b41dba14d00f3b3bad6ad78bc26450/src/types/plugins/replication-graphql.d.ts#L13-L21

