### PR TITLE
FIX add RxDBNoValidatePlugin to react-example

### DIFF
--- a/examples/react/src/Database.jsx
+++ b/examples/react/src/Database.jsx
@@ -7,11 +7,13 @@ import {
 } from './Schema';
 import { RxDBLeaderElectionPlugin } from 'rxdb/plugins/leader-election';
 import { RxDBReplicationPlugin } from 'rxdb/plugins/replication';
+import { RxDBNoValidatePlugin } from 'rxdb/plugins/no-validate';
 
 addRxPlugin(require('pouchdb-adapter-idb'));
 addRxPlugin(require('pouchdb-adapter-http')); // enable syncing over http
 addRxPlugin(RxDBLeaderElectionPlugin);
 addRxPlugin(RxDBReplicationPlugin);
+addRxPlugin(RxDBNoValidatePlugin);
 
 const collections = [
     {


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
Sorry I forgot another import in the react example. Travis should pass after the change.
