### PR TITLE
FIX skipping docs in push replication

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -293,7 +293,7 @@ export class RxGraphQLReplicationState {
             this.syncRevisions
         );
 
-        const changesWithDocs: any = await Promise.all(changes.results.map(async (change: any) => {
+        const changesWithDocs: any = (await Promise.all(changes.results.map(async (change: any) => {
             let doc = change['doc'];
 
             doc[this.deletedFlag] = !!change['deleted'];
@@ -315,7 +315,7 @@ export class RxGraphQLReplicationState {
                 doc,
                 seq
             };
-        }).filter(doc => doc));
+        }))).filter(doc => doc);
 
         let lastSuccessfullChange = null;
         try {

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -88,6 +88,9 @@ describe('replication-graphql.test.js', () => {
         };
     };
     const pushQueryBuilder = (doc: any) => {
+        if (!doc) {
+            throw new Error();
+        }
         const query = `
         mutation CreateHuman($human: HumanInput) {
             setHuman(human: $human) {
@@ -1782,6 +1785,9 @@ describe('replication-graphql.test.js', () => {
                     live: false,
                     deletedFlag: 'deleted'
                 });
+                const errSub = replicationState.error$.subscribe(() => {
+                    throw new Error('The replication threw an error');
+                });
 
                 await replicationState.awaitInitialReplication();
 
@@ -1791,6 +1797,7 @@ describe('replication-graphql.test.js', () => {
                 assert.strictEqual(docsOnServer.length, 2 * amount + 1);
                 assert.strictEqual(docsOnDb.length, 2 * amount + 1);
 
+                errSub.unsubscribe();
                 server.close();
                 db.destroy();
             });


### PR DESCRIPTION
## This PR contains:
<!--
 - A BUGFIX
-->

## Describe the problem you have without this PR
When updating the rxdb package after the latest release and trying out the feature in our code base, we've noticed that a small bug has remained that . We are yet unsure why this bug wasn't caught by the tests that had been defined for the previous PR.

## Todos
- [ ] Tests
