### PR TITLE
added test for bug with deleted docs showing up in find().sort() with…

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "modifyjs": "0.3.1",
     "object-path": "0.11.5",
     "pouchdb-adapter-http": "7.2.2",
+    "pouchdb-adapter-indexeddb": "^7.2.2",
     "pouchdb-all-dbs": "1.0.2",
     "pouchdb-core": "7.2.2",
     "pouchdb-find": "7.2.2",


### PR DESCRIPTION
… indexeddb

## This PR contains:
- Added a test to reproduce a bug described below
- Package dependency for `pouchdb-adapter-indexeddb` in package.json

## Describe the problem you have without this PR
When applying `sort()` to `find()` queries, documents that were previously deleted are returned.
Checking the browser's IndexedDB reveals that the documents in question are indeed saved with attribute `deleted: 1`, however the incorrectly returned documents have their `deleted` attribute set to `false`.

---
PS: I'm sure I've made some formal errors in this PR, please let me know what to fix.