### PR TITLE
Replace randomInt with randomNumber from async-test-util in test files

### DIFF
--- a/test/helper/schema-objects.ts
+++ b/test/helper/schema-objects.ts
@@ -4,9 +4,8 @@
 
 import faker from 'faker';
 
-// TODO replace these 2 with methods of async-test-util
+// TODO replace this method with corresponding method from async-test-util
 import randomToken from 'random-token';
-import randomInt from 'random-int';
 
 import {
     randomNumber
@@ -29,7 +28,7 @@ export function human(
         passportId: passportId,
         firstName: faker.name.firstName(),
         lastName: faker.name.lastName(),
-        age: randomInt(10, 50)
+        age: randomNumber(10, 50)
     };
 }
 
@@ -48,7 +47,7 @@ export interface SimpleHumanV3DocumentType {
 export function simpleHumanV3(): SimpleHumanV3DocumentType {
     return {
         passportId: randomToken(12),
-        age: randomInt(10, 50)
+        age: randomNumber(10, 50)
     };
 }
 
@@ -59,7 +58,7 @@ export interface SimpleHumanAgeDocumentType {
 export function simpleHumanAge(): SimpleHumanAgeDocumentType {
     return {
         passportId: randomToken(12),
-        age: randomInt(10, 50) + ''
+        age: randomNumber(10, 50) + ''
     };
 }
 
@@ -73,7 +72,7 @@ export function humanWithSubOther(): HumanWithSubOtherDocumentType {
     return {
         passportId: randomToken(12),
         other: {
-            age: randomInt(10, 50)
+            age: randomNumber(10, 50)
         }
     };
 }
@@ -144,7 +143,7 @@ export function bigHumanDocumentType(): BigHumanDocumentType {
         dnaHash: randomToken(12),
         firstName: faker.name.firstName(),
         lastName: faker.name.lastName(),
-        age: randomInt(10, 50)
+        age: randomNumber(10, 50)
     };
 }
 
@@ -161,7 +160,7 @@ export function heroArray(): HeroArrayDocumentType {
         skills: new Array(3).fill(0).map(() => {
             return {
                 name: randomToken(6),
-                damage: randomInt(10, 50)
+                damage: randomNumber(10, 50)
             };
         })
     };
@@ -258,7 +257,7 @@ export function compoundIndex(): CompoundIndexDocumentType {
     return {
         passportId: randomToken(12),
         passportCountry: randomToken(12),
-        age: randomInt(10, 50)
+        age: randomNumber(10, 50)
     };
 }
 
@@ -271,7 +270,7 @@ export function compoundIndexNoString(): CompoundIndexNoStringDocumentType {
     return {
         passportId: randomToken(12),
         passportCountry: { [randomToken(12)]: randomToken(12) },
-        age: randomInt(10, 50)
+        age: randomNumber(10, 50)
     };
 }
 
@@ -351,7 +350,7 @@ export function averageSchema(): AverageSchemaDocumentType {
     return {
         id: randomToken(12),
         var1: randomToken(12),
-        var2: randomInt(100, 50000),
+        var2: randomNumber(100, 50000),
         deep: {
             deep1: randomToken(5),
             deep2: randomToken(8)

--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -1,9 +1,8 @@
 import assert from 'assert';
-import randomInt from 'random-int';
 import randomToken from 'random-token';
 import clone from 'clone';
 import config from './config';
-import AsyncTestUtil from 'async-test-util';
+import AsyncTestUtil, { randomNumber } from 'async-test-util';
 
 import * as schemas from '../helper/schemas';
 import * as schemaObjects from '../helper/schema-objects';
@@ -670,13 +669,13 @@ config.parallel('rx-collection.test.js', () => {
                         passportId: randomToken(12),
                         firstName: 'foobarAlice',
                         lastName: 'aliceLastName',
-                        age: randomInt(10, 50)
+                        age: randomNumber(10, 50)
                     });
                     await c.insert({
                         passportId: randomToken(12),
                         firstName: 'foobarBob',
                         lastName: 'bobLastName',
-                        age: randomInt(10, 50)
+                        age: randomNumber(10, 50)
                     });
                     const query = c.find().or([{
                         firstName: 'foobarAlice'
@@ -762,7 +761,7 @@ config.parallel('rx-collection.test.js', () => {
                             return {
                                 passportId: randomCouchString(10),
                                 other: {
-                                    age: randomInt(10, 50)
+                                    age: randomNumber(10, 50)
                                 }
                             };
                         });
@@ -809,7 +808,7 @@ config.parallel('rx-collection.test.js', () => {
                             return {
                                 passportId: randomCouchString(10),
                                 other: {
-                                    age: randomInt(10, 50)
+                                    age: randomNumber(10, 50)
                                 }
                             };
                         });


### PR DESCRIPTION
## This PR contains:

This PR replaces use of `randomInt` with`randomNumber` (from pubkey's `async-test-util` library) in test files that can make use of `async-test-util`. Motivation comes from a TODO comment in `test/helper/schema-objects.ts`.

Original TODO comment:
```
// TODO replace these 2 with methods of async-test-util
import randomToken from 'random-token';
import randomInt from 'random-int';
```

There is one other file that uses `random-int`, but for now I'll hold off on replacing it as it can't make use of `async-test-util` (thank you @dome4).
