### PR TITLE
graphql - await initial replication resolves on failed replication

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -160,7 +160,7 @@ export class RxGraphQLReplicationState {
             this._subjects.active.next(true);
             const willRetry = await this._run(retryOnFail);
             this._subjects.active.next(false);
-            if (!willRetry && this._subjects.initialReplicationComplete['_value'] === false) {
+            if (retryOnFail && !willRetry && this._subjects.initialReplicationComplete['_value'] === false) {
                 this._subjects.initialReplicationComplete.next(true);
             }
             this._runQueueCount--;


### PR DESCRIPTION
## This PR contains:
-  IMPROVED TESTS
- A BUGFIX

## Describe the problem you have without this PR
I experienced that `awaitInitialReplication()` of the graphql replicator plugin resolves even if the replication never succeeds (see attached issue). Is this the expected behavior? 

### Path of issue

`syncGraphQL()` executes `replication.run()` ([see code](https://github.com/pubkey/rxdb/blob/88a99ed9eab7cdac4af6abf003aa307c20da9909/src/plugins/replication-graphql/index.ts#L518)) without param and thus the default `retryOnFail = true` is used. If this first pull cycle fails `run()` is executed with the default param again ([code](https://github.com/pubkey/rxdb/blob/88a99ed9eab7cdac4af6abf003aa307c20da9909/src/plugins/replication-graphql/index.ts#L193)). Works as expected.

The problem is that `syncGraphQL` executes `run(false)` on every following pull sync cycle every `liveInterval` ms ([code](https://github.com/pubkey/rxdb/blob/88a99ed9eab7cdac4af6abf003aa307c20da9909/src/plugins/replication-graphql/index.ts#L528)). If `run(false)`  is executed and fails `this._run(retryOnFail=false)` returns false, the following if check resolves and `initialReplicationComplete` emits true:

```javascript
 if (!willRetry && this._subjects.initialReplicationComplete['_value'] === false) {
     this._subjects.initialReplicationComplete.next(true);
 }
```

([code](https://github.com/pubkey/rxdb/blob/88a99ed9eab7cdac4af6abf003aa307c20da9909/src/plugins/replication-graphql/index.ts#L163))

### Fix
Simply adding `retryOnFail` to the if statement fixes the issue. Thus, only the initial replication cycle and every retry execution of run() are able to emit  `true` to `this.subjects.initialReplicationComplete`.

### Discuss
The current behavior of `awaitInitialReplication()` is that it neither resolves nor rejects if the replication stays erroneous. I'm thinking about if it would be useful to reject the promise and *cancel the whole replication* after an specific timeout that can be set by the user because this timeout hardly depends on the amount of data pulled initially. Could be implemented with `Promise.race()` and an timeout Promise in the `awaitInitialReplication()` method. Looking forward to discus :+1: 

## Todos
- [ ] Changelog
