### PR TITLE
clarify the ref keyword reffer to the properties, not the scheme obje…

### DIFF
--- a/docs-src/population.md
+++ b/docs-src/population.md
@@ -7,7 +7,7 @@ This works exactly like population with [mongoose](http://mongoosejs.com/docs/po
 
 ## Schema with ref
 
-The `ref`-keyword describes to which collection the field-value belongs to.
+The `ref`-keyword in properties describes to which collection the field-value belongs to (has a relationship). 
 
 ```javascript
 export const refHuman = {


### PR DESCRIPTION
…ct name 'refHuman'

## This PR contains:
 - IMPROVED DOCS


## Describe the problem you have without this PR
`ref`- keyword misguides the reader to name the scheme object with ref, which is not the case

## Todos 
- [ ] Documentation