### PR TITLE
Enhance local document types

### DIFF
--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -9,6 +9,7 @@ import type {
 } from '../rx-collection';
 import type { QueryCache } from '../query-cache';
 import { Observable } from 'rxjs';
+import { RxLocalDocumentMutation } from './rx-database';
 
 export interface KeyFunctionMap {
     [key: string]: Function;
@@ -77,7 +78,7 @@ export type RxCollection<
     RxCollectionGenerated<RxDocumentType, OrmMethods> &
     StaticMethods;
 
-export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}> {
+export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}> extends RxLocalDocumentMutation<RxCollection<RxDocumentType, OrmMethods>> {
 
     // HOOKS
     preInsert(fun: RxCollectionHookNoInstanceCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
@@ -87,11 +88,6 @@ export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}> {
     postSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
     postRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
     postCreate(fun: RxCollectionHookCallbackNonAsync<RxDocumentType, OrmMethods>): void;
-
-    insertLocal<LocalDocType = any>(id: string, data: any): Promise<RxLocalDocument<RxCollection<RxDocumentType, OrmMethods>, LocalDocType>>;
-    upsertLocal<LocalDocType = any>(id: string, data: LocalDocType): Promise<RxLocalDocument<RxCollection<RxDocumentType, OrmMethods>, LocalDocType>>;
-    getLocal<LocalDocType = any>(id: string): Promise<RxLocalDocument<RxCollection<RxDocumentType, OrmMethods>, LocalDocType>>;
-    getLocal$<LocalDocType = any>(id: string): Observable<RxLocalDocument<RxCollection<RxDocumentType, OrmMethods>, LocalDocType> | null>;
 
     // only inMemory-collections
     awaitPersistence(): Promise<void>;

--- a/src/types/rx-database.d.ts
+++ b/src/types/rx-database.d.ts
@@ -61,21 +61,22 @@ export type CollectionsOfDatabase = { [key: string]: RxCollection };
 export type RxDatabase<Collections = CollectionsOfDatabase> = RxDatabaseBase<Collections> &
     Collections & RxDatabaseGenerated<Collections>;
 
-
-export interface RxDatabaseGenerated<Collections> {
-    insertLocal<LocalDocType = any>(id: string, data: any): Promise<
-        RxLocalDocument<RxDatabase<Collections>, LocalDocType>
+export interface RxLocalDocumentMutation<StorageType> {
+    insertLocal<LocalDocType = any>(id: string, data: LocalDocType): Promise<
+        RxLocalDocument<StorageType, LocalDocType>
     >;
     upsertLocal<LocalDocType = any>(id: string, data: LocalDocType): Promise<
-        RxLocalDocument<RxDatabase<Collections>, LocalDocType>
+        RxLocalDocument<StorageType, LocalDocType>
     >;
     getLocal<LocalDocType = any>(id: string): Promise<
-        RxLocalDocument<RxDatabase<Collections>, LocalDocType>
+        RxLocalDocument<StorageType, LocalDocType>
     >;
     getLocal$<LocalDocType = any>(id: string): Observable<
-        RxLocalDocument<RxDatabase<Collections>, LocalDocType> | null
+        RxLocalDocument<StorageType, LocalDocType> | null
     >;
 }
+
+export interface RxDatabaseGenerated<Collections> extends RxLocalDocumentMutation<RxDatabase<Collections>> { }
 
 /**
  * Extract the **DocumentType** of a collection.

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -660,6 +660,21 @@ describe('typings.test.js', function () {
         });
     });
     config.parallel('local documents', () => {
+        it('should allow to type input data', async () => {
+            const code = codeBase + `
+            (async() => {
+                const myDb: RxDatabase = {} as any;
+                const typedLocalDoc = await myDb.getLocal<{foo: string;}>('foobar');
+                const typedLocalDocInsert = await myDb.insertLocal<{foo: string;}>('foobar', { bar: 'foo' });
+                const x: string = typedLocalDoc.foo;
+                const x2: string = typedLocalDocInsert.foo;
+            });
+            `;
+            await AsyncTestUtil.assertThrows(
+                () => transpileCode(code),
+                Error
+            );
+        });
         it('should allow to type the return data', async () => {
             const code = codeBase + `
             (async() => {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR
The typing of `insertLocal` in `rx-database.d.ts` and `rx-collection.d.ts` was the following:
```
    insertLocal<LocalDocType = any>(id: string, data: any): Promise<...>;
```
I haven't discovered any reason, why data should not be typed with the `LocalDocType` as `upsertLocal()` does it too.

There was also some code redundancy between `rx-database.d.ts` and `rx-collection.d.ts`, which was resolved as well.

A typing test was added accordingly.
