### PR TITLE
Fix GraphQL example install docs and bad cp/paste

### DIFF
--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -5,7 +5,9 @@ It represents a simple hero-list which is two-way-replicated with the server.
 
 # Try it out
 1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)
-2. go to this folder (examples/graphql)
-3. run "npm install"
-4. run "npm start"
-5. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**
+2. go into project `cd rxdb`
+3. run `npm install`  (you may need to run `npm install --legacy-peer-deps`)
+4. go to this folder `cd examples/graphql`
+5. run `npm install`
+6. run `npm start`
+7. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**

--- a/examples/graphql/client/index.html
+++ b/examples/graphql/client/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body id="app">
-    <h1> RxDB Heroes vanilla</h1>
+    <h1> RxDB Heroes Graphql</h1>
     <div id="list-box" class="box">
         <div id="leader-icon">&#9819;</div>
         <h3>Heroes</h3>


### PR DESCRIPTION
## This PR contains:
 - better GraphQL example instructions
 - Fix a copy/paste error in the GraphQL example

## Describe the problem you have without this PR
The GraphQL example will not install with the current instructions, which not follow the pattern of the other examples (which work). The example page shows "Vanilla" when it is for the `graphql` example