### PR TITLE
Add notice findByIds doesn't respect input order

### DIFF
--- a/docs-src/rx-collection.md
+++ b/docs-src/rx-collection.md
@@ -224,6 +224,8 @@ const docsMap = await myCollection.findByIds(ids);
 console.dir(docsMap); // Map(2)
 ```
 
+NOTICE: The `Map` returned by `findByIds` is not guaranteed to return elements in the same order as the list of ids passed to it.
+
 ### findByIds$()
 
 Same as `findByIds()` but returns and `Observable` that emits the `Map` each time a value of it has changed because of a database write.


### PR DESCRIPTION
## This PR contains:
Notice on `findByIds` behaviour in the documentation

## Describe the problem you have without this PR
It is unclear from the docs whether `findByIds` will populate the `Map` in the same order as that of the ids passed for filling it. It does not in all cases, though might be expected to by some users, so a warning is warranted.