### PR TITLE
fix(examples/graphql): update webpack start command

### DIFF
--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rxdb-example-graphql",
   "scripts": {
-    "dev": "webpack-dev-server",
+    "dev": "webpack serve",
     "start": "concurrently \"npm run server\" \"npm run dev\"",
     "server": "node -r esm ./server/index.js",
     "refresh": "rimraf -r node_modules/rxdb/ && npm i ",


### PR DESCRIPTION
## This PR contains:
A fix to the `start` script of the graphql example.

## Describe the problem you have without this PR

Without this PR the client part of the graphql example does not start (see log below).

Error and solution applied:
https://stackoverflow.com/a/64205610/1850609

Commit that updated webpack:
https://github.com/pubkey/rxdb/commit/d199b9c8f0b13695d4f466cfa2f9a6c275da822a#diff-192ef64589816349604beb98f7a1f5d3d8a5f4b61484f796a8e2a013dcf76da2

Error log (without the fix):
```
$ npm start

> rxdb-example-graphql@ start ~/rxdb/examples/graphql
> concurrently "npm run server" "npm run dev"

[0] 
[0] > rxdb-example-graphql@ server ~/rxdb/examples/graphql
[0] > node -r esm ./server/index.js
[0]
[1]
[1] > rxdb-example-graphql@ dev ~/rxdb/examples/graphql
[1] > webpack-dev-server
[1]
[1] internal/modules/cjs/loader.js:628
    throw err;
[1]     ^
[1]
[1] Error: Cannot find module 'webpack-cli/bin/config-yargs'
[1] Require stack:
[1] - ~/rxdb/examples/graphql/node_modules/webpack-dev-server/bin/webpack-dev-server.js
[1]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:625:15)
[1]     at Function.Module._load (internal/modules/cjs/loader.js:527:27)
[1]     at Module.require (internal/modules/cjs/loader.js:683:19)
[1]     at require (internal/modules/cjs/helpers.js:16:16)
[1]     at Object.<anonymous> (~/rxdb/examples/graphql/node_modules/webpack-dev-server/bin/webpack-dev-server.js:65:1)
[1]     at Module._compile (internal/modules/cjs/loader.js:776:30)
[1]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
[1]     at Module.load (internal/modules/cjs/loader.js:643:32)
[1]     at Function.Module._load (internal/modules/cjs/loader.js:556:12)
[1]     at Function.Module.runMain (internal/modules/cjs/loader.js:839:10) {
[1]   code: 'MODULE_NOT_FOUND',
[1]   requireStack: [
[1]     '~/rxdb/examples/graphql/node_modules/webpack-dev-server/bin/webpack-dev-server.js'
[1]   ]
[1] }
[1] npm ERR! code ELIFECYCLE
[1] npm ERR! errno 1
[1] npm ERR! rxdb-example-graphql@ dev: `webpack-dev-server`
[1] npm ERR! Exit status 1
[1] npm ERR!
[1] npm ERR! Failed at the rxdb-example-graphql@ dev script.
[1] npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
[1] 
[1] npm ERR! A complete log of this run can be found in:
[1] npm ERR!     ~/tools/NPM_CONFIG_CACHE/_logs/2021-04-24T04_17_49_691Z-debug.log
[1] npm run dev exited with code 1
[0] Server side GraphQL Schema:
...
```