### PR TITLE
add null to getLocal return type

### DIFF
--- a/src/types/rx-database.d.ts
+++ b/src/types/rx-database.d.ts
@@ -75,7 +75,7 @@ export interface RxLocalDocumentMutation<StorageType> {
         RxLocalDocument<StorageType, LocalDocType>
     >;
     getLocal<LocalDocType = any>(id: string): Promise<
-        RxLocalDocument<StorageType, LocalDocType>
+        RxLocalDocument<StorageType, LocalDocType> | null
     >;
     getLocal$<LocalDocType = any>(id: string): Observable<
         RxLocalDocument<StorageType, LocalDocType> | null


### PR DESCRIPTION
## This PR contains:

 - IMPROVED typings

## Describe the problem you have without this PR

getLocal is currently set to only return a document, but should also be able to return null 
