### PR TITLE
add missing `deleted` field

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -177,7 +177,8 @@ const pushQueryBuilder = doc => {
         mutation CreateHuman($human: HumanInput) {
             setHuman(human: $human) {
                 id,
-                updatedAt
+                updatedAt,
+                deleted
             }
         }
     `;


### PR DESCRIPTION
on GraphQL push replication docs.

closes #3144

## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR
graphQL replication example is missing `deleted` field that is specified as `deletedFlag`

## Todos
- [ ] Tests
- [X] Documentation
- [ ] Typings
- [ ] Changelog