### PR TITLE
Update middleware to be more flexible about input data

### DIFF
--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -120,7 +120,8 @@ export class RxCollectionBase<
     InstanceCreationOptions,
     RxDocumentType = { [prop: string]: any },
     OrmMethods = {},
-    StaticMethods = { [key: string]: any }
+    StaticMethods = { [key: string]: any },
+    MiddlewareInputType = RxDocumentType
     > {
 
     constructor(
@@ -348,7 +349,7 @@ export class RxCollectionBase<
      * to not have duplicated code.
      */
     async insert(
-        json: RxDocumentType | RxDocument | any
+        json: MiddlewareInputType | RxDocument
     ): Promise<RxDocument<RxDocumentType, OrmMethods>> {
         // inserting a temporary-document
         let tempDoc: RxDocument | null = null;
@@ -386,7 +387,7 @@ export class RxCollectionBase<
     }
 
     async bulkInsert(
-        docsData: RxDocumentType[]
+        docsData: MiddlewareInputType[]
     ): Promise<{
         success: RxDocument<RxDocumentType, OrmMethods>[],
         error: RxStorageBulkWriteError<RxDocumentType>[]
@@ -508,7 +509,7 @@ export class RxCollectionBase<
     /**
      * same as insert but overwrites existing document with same primary
      */
-    upsert(json: Partial<RxDocumentType>): Promise<RxDocument<RxDocumentType, OrmMethods>> {
+    upsert(json: Partial<MiddlewareInputType>): Promise<RxDocument<RxDocumentType, OrmMethods>> {
         const useJson = fillObjectDataBeforeInsert(this as any, json);
         const primary = useJson[this.schema.primaryPath];
         if (!primary) {
@@ -535,7 +536,7 @@ export class RxCollectionBase<
     /**
      * upserts to a RxDocument, uses atomicUpdate if document already exists
      */
-    atomicUpsert(json: Partial<RxDocumentType>): Promise<RxDocument<RxDocumentType, OrmMethods>> {
+    atomicUpsert(json: Partial<MiddlewareInputType>): Promise<RxDocument<RxDocumentType, OrmMethods>> {
         const useJson = fillObjectDataBeforeInsert(this as any, json);
         const primary = (useJson as any)[this.schema.primaryPath];
         if (!primary) {

--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -348,7 +348,7 @@ export class RxCollectionBase<
      * to not have duplicated code.
      */
     async insert(
-        json: RxDocumentType | RxDocument
+        json: RxDocumentType | RxDocument | any
     ): Promise<RxDocument<RxDocumentType, OrmMethods>> {
         // inserting a temporary-document
         let tempDoc: RxDocument | null = null;

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -76,9 +76,10 @@ export type RxCollection<
     StaticMethods = {},
     InstanceCreationOptions = {},
     MiddlewareInputType = RxDocumentType
-    > = StaticMethods &
+    > =
     RxCollectionBase<InstanceCreationOptions, RxDocumentType, OrmMethods, MiddlewareInputType> &
-    RxCollectionGenerated<RxDocumentType, OrmMethods, MiddlewareInputType>;
+    RxCollectionGenerated<RxDocumentType, OrmMethods, MiddlewareInputType> & 
+    StaticMethods;
 
 export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}, MiddlewareInputType = any> extends RxLocalDocumentMutation<RxCollection<RxDocumentType, OrmMethods>> {
 

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -63,8 +63,8 @@ export type RxCollectionHookNoInstanceCallback<
     RxDocumentType,
     OrmMethods
     > = (
+        this: RxCollection<RxDocumentType, OrmMethods>,
         data: any,
-        instance: RxCollection<RxDocumentType, OrmMethods>
     ) => Promise<void> | void | any;
 
 export type RxCollection<

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -63,7 +63,7 @@ export type RxCollectionHookNoInstanceCallback<
     RxDocumentType,
     OrmMethods
     > = (
-        data: RxDocumentType,
+        data: {},
         instance: RxCollection<RxDocumentType, OrmMethods>
     ) => Promise<void> | void | any;
 

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -63,7 +63,7 @@ export type RxCollectionHookNoInstanceCallback<
     RxDocumentType,
     OrmMethods
     > = (
-        data: {},
+        data: any,
         instance: RxCollection<RxDocumentType, OrmMethods>
     ) => Promise<void> | void | any;
 

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -49,10 +49,11 @@ export type RxCacheReplacementPolicy = (collection: RxCollection, queryCache: Qu
 
 export type RxCollectionHookCallback<
     RxDocumentType,
-    OrmMethods
+    OrmMethods,
+    MiddlewareInputType
     > = (
         this: RxCollection<RxDocumentType, OrmMethods>,
-        data: any,
+        data: MiddlewareInputType,
         instance: RxDocument<RxDocumentType, OrmMethods>
     ) => void | Promise<void> | any;
 export type RxCollectionHookNoInstance<RxDocumentType, OrmMethods> = (data: RxDocumentType) => void | Promise<void> | any;
@@ -62,30 +63,32 @@ export type RxCollectionHookCallbackNonAsync<RxDocumentType, OrmMethods> = (
 ) => void | any;
 export type RxCollectionHookNoInstanceCallback<
     RxDocumentType,
-    OrmMethods
+    OrmMethods,
+    MiddlewareInputType
     > = (
         this: RxCollection<RxDocumentType, OrmMethods>,
-        data: any,
+        data: MiddlewareInputType,
     ) => Promise<void> | void | any;
 
 export type RxCollection<
     RxDocumentType = any,
     OrmMethods = {},
     StaticMethods = {},
-    InstanceCreationOptions = {}
+    InstanceCreationOptions = {},
+    MiddlewareInputType = RxDocumentType
     > = StaticMethods &
-    RxCollectionBase<InstanceCreationOptions, RxDocumentType, OrmMethods> &
-    RxCollectionGenerated<RxDocumentType, OrmMethods>;
+    RxCollectionBase<InstanceCreationOptions, RxDocumentType, OrmMethods, MiddlewareInputType> &
+    RxCollectionGenerated<RxDocumentType, OrmMethods, MiddlewareInputType>;
 
-export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}> extends RxLocalDocumentMutation<RxCollection<RxDocumentType, OrmMethods>> {
+export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}, MiddlewareInputType = any> extends RxLocalDocumentMutation<RxCollection<RxDocumentType, OrmMethods>> {
 
     // HOOKS
-    preInsert(fun: RxCollectionHookNoInstanceCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
-    preSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
-    preRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
-    postInsert(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
-    postSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
-    postRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods>, parallel: boolean): void;
+    preInsert(fun: RxCollectionHookNoInstanceCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    preSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    preRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    postInsert(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    postSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    postRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
     postCreate(fun: RxCollectionHookCallbackNonAsync<RxDocumentType, OrmMethods>): void;
 
     // only inMemory-collections

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -86,10 +86,10 @@ export interface RxCollectionGenerated<RxDocumentType = any, OrmMethods = {}, Mi
     // HOOKS
     preInsert(fun: RxCollectionHookNoInstanceCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
     preSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
-    preRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
-    postInsert(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
-    postSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
-    postRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, MiddlewareInputType>, parallel: boolean): void;
+    preRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, RxDocumentType>, parallel: boolean): void;
+    postInsert(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, RxDocumentType>, parallel: boolean): void;
+    postSave(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, RxDocumentType>, parallel: boolean): void;
+    postRemove(fun: RxCollectionHookCallback<RxDocumentType, OrmMethods, RxDocumentType>, parallel: boolean): void;
     postCreate(fun: RxCollectionHookCallbackNonAsync<RxDocumentType, OrmMethods>): void;
 
     // only inMemory-collections

--- a/src/types/rx-collection.d.ts
+++ b/src/types/rx-collection.d.ts
@@ -51,7 +51,8 @@ export type RxCollectionHookCallback<
     RxDocumentType,
     OrmMethods
     > = (
-        data: RxDocumentType,
+        this: RxCollection<RxDocumentType, OrmMethods>,
+        data: any,
         instance: RxDocument<RxDocumentType, OrmMethods>
     ) => void | Promise<void> | any;
 export type RxCollectionHookNoInstance<RxDocumentType, OrmMethods> = (data: RxDocumentType) => void | Promise<void> | any;


### PR DESCRIPTION

## This PR contains:
 - IMPROVED typings
 - Suggested Features
 
## Describe the problem you have without this PR

I want to pass in an object that has luxon dates for my date fields and then convert them into strings within the `preInsert` hook. This is currently difficult because this hook expects the input to be the RxDocumentType.
