### PR TITLE
add missing possible `null` for `getLocal` on database

### DIFF
--- a/src/types/rx-database.d.ts
+++ b/src/types/rx-database.d.ts
@@ -75,7 +75,7 @@ export interface RxLocalDocumentMutation<StorageType> {
         RxLocalDocument<StorageType, LocalDocType>
     >;
     getLocal<LocalDocType = any>(id: string): Promise<
-        RxLocalDocument<StorageType, LocalDocType>
+        RxLocalDocument<StorageType, LocalDocType> | null
     >;
     getLocal$<LocalDocType = any>(id: string): Observable<
         RxLocalDocument<StorageType, LocalDocType> | null

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -666,7 +666,12 @@ describe('typings.test.js', function () {
                 const myDb: RxDatabase = {} as any;
                 const typedLocalDoc = await myDb.getLocal<{foo: string;}>('foobar');
                 const typedLocalDocInsert = await myDb.insertLocal<{foo: string;}>('foobar', { bar: 'foo' });
-                const x: null = typedLocalDoc.foo;
+
+                if (!typedLocalDoc) {
+                    throw new Error('local doc missing');
+                }
+
+                const x: string = typedLocalDoc.foo;
                 const x2: string = typedLocalDocInsert.foo;
             });
             `;
@@ -681,6 +686,11 @@ describe('typings.test.js', function () {
                 const myDb: RxDatabase = {} as any;
                 const typedLocalDoc = await myDb.getLocal<{foo: string;}>('foobar');
                 const typedLocalDocUpsert = await myDb.upsertLocal<{foo: string;}>('foobar', { foo: 'bar' });
+
+                if (!typedLocalDoc) {
+                    throw new Error('local doc missing');
+                }
+
                 const x: string = typedLocalDoc.foo;
                 const x2: string = typedLocalDocUpsert.foo;
             });

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -666,7 +666,7 @@ describe('typings.test.js', function () {
                 const myDb: RxDatabase = {} as any;
                 const typedLocalDoc = await myDb.getLocal<{foo: string;}>('foobar');
                 const typedLocalDocInsert = await myDb.insertLocal<{foo: string;}>('foobar', { bar: 'foo' });
-                const x: string = typedLocalDoc.foo;
+                const x: undefined = typedLocalDoc.foo;
                 const x2: string = typedLocalDocInsert.foo;
             });
             `;

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -666,7 +666,7 @@ describe('typings.test.js', function () {
                 const myDb: RxDatabase = {} as any;
                 const typedLocalDoc = await myDb.getLocal<{foo: string;}>('foobar');
                 const typedLocalDocInsert = await myDb.insertLocal<{foo: string;}>('foobar', { bar: 'foo' });
-                const x: undefined = typedLocalDoc.foo;
+                const x: null = typedLocalDoc.foo;
                 const x2: string = typedLocalDocInsert.foo;
             });
             `;

--- a/test/unit/local-documents.test.ts
+++ b/test/unit/local-documents.test.ts
@@ -392,7 +392,7 @@ config.parallel('local-documents.test.js', () => {
 
             await doc1.atomicSet('foo', 'bar2');
 
-            await waitUntil(() => doc2.toJSON().foo === 'bar2');
+            await waitUntil(() => doc2 && doc2.toJSON().foo === 'bar2');
 
             db.destroy();
             db2.destroy();
@@ -427,7 +427,7 @@ config.parallel('local-documents.test.js', () => {
                 emitted.push(x);
             });
 
-            await waitUntil(() => doc2.toJSON().foo === 'bar2');
+            await waitUntil(() => doc2 && doc2.toJSON().foo === 'bar2');
             await waitUntil(() => emitted.length >= 2);
 
             sub.unsubscribe();
@@ -459,7 +459,7 @@ config.parallel('local-documents.test.js', () => {
             assert.ok(emitted.pop());
 
             const doc = await db2.getLocal<TestDocType>('foobar');
-            assert.strictEqual(doc.toJSON().foo, 'bar');
+            assert.strictEqual(doc && doc.toJSON().foo, 'bar');
 
             sub.unsubscribe();
             db.destroy();


### PR DESCRIPTION


## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR

getLocal looks like it always returns a doc, but can return `null` if they key does not exist.