### PR TITLE
add missing migration types to export

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -149,6 +149,8 @@ export type {
     ServerOptions,
     SyncOptions,
     SyncOptionsGraphQL,
+    MigrationStrategy,
     MigrationStrategies,
+    OldRxCollection,
     WithAttachmentsData
 } from './types';


### PR DESCRIPTION

## This PR contains:

 - IMPROVED typings

## Describe the problem you have without this PR
Types for `MigrationStrategy` are not available
