### PR TITLE
Replication doc key

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -279,9 +279,13 @@ When the clients sends a document to the server which causes a conflict, this ha
 
 When you call `myCollection.syncGraphQL()` it returns a `RxGraphQLReplicationState` which can be used to subscribe to events, for debugging or other functions.
 
-#### .replicationDocId
+#### .pullDocId
 
-This is the id of the document used to track the replication state. This is a local document added to the collection. You can use this id to filter out this doc when subscribing to `update$` on the collection if needed.
+This is the id of the document used to track the pull replication state. This is the id of a local document added to the collection. You can use this id to filter out this doc when subscribing to `update$` on the collection if needed.
+
+#### .pushDocId
+
+This is the id of the document used to track the push replication state. This is the id of a local document added to the collection. You can use this id to filter out this doc when subscribing to `update$` on the collection if needed.
 
 #### .isStopped()
 
@@ -326,6 +330,10 @@ Cancels the replication. This is done automatically if the `RxCollection` or it'
 ```js
 await replicationState.cancel();
 ```
+
+#### .reset()
+
+Resets the replication state. This will make your replication start from scratch pulling and pushing all docs again.
 
 #### .recieved$
 

--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -37,7 +37,7 @@ For example if your documents look like this,
 }
 ```
 
-Then your data is always sortable by `updatedAt`. This ensures that when RxDB fetches 'new' changes, it can send the latest `updatedAt` to the GraphQL-endpoint and then recieve all newer documents.
+Then your data is always sortable by `updatedAt`. This ensures that when RxDB fetches 'new' changes, it can send the latest `updatedAt` to the GraphQL-endpoint and then receive all newer documents.
 
 Deleted documents still exist but have `deleted: true` set. This ensures that when RxDB fetches new documents, even the deleted documents are send back and can be known at the client-side.
 
@@ -170,7 +170,7 @@ const replicationState = myCollection.syncGraphQL({
 
 #### Push replication
 
-For the push-replication, you also need a `queryBuilder`. Here, the builder recieves a changed document as input which has to be send to the server. It also returns a GraphQL-Query and its data.
+For the push-replication, you also need a `queryBuilder`. Here, the builder receives a changed document as input which has to be send to the server. It also returns a GraphQL-Query and its data.
 
 ```js
 const pushQueryBuilder = doc => {
@@ -279,7 +279,9 @@ When the clients sends a document to the server which causes a conflict, this ha
 
 When you call `myCollection.syncGraphQL()` it returns a `RxGraphQLReplicationState` which can be used to subscribe to events, for debugging or other functions.
 
+#### .replicationDocId
 
+This is the id of the document used to track the replication state. This is a local document added to the collection. You can use this id to filter out this doc when subscribing to `update$` on the collection if needed.
 
 #### .isStopped()
 
@@ -319,7 +321,7 @@ await replicationState.run();
 
 #### .cancel()
 
-Cancels the replication. This is done autmatically if the `RxCollection` or it's `RxDatabase` is destroyed.
+Cancels the replication. This is done automatically if the `RxCollection` or it's `RxDatabase` is destroyed.
 
 ```js
 await replicationState.cancel();
@@ -327,7 +329,7 @@ await replicationState.cancel();
 
 #### .recieved$
 
-An `Observable` that emits each document that is recieved from the endpoint.
+An `Observable` that emits each document that is received from the endpoint.
 
 #### .send$
 

--- a/src/plugins/replication-graphql/crawling-checkpoint.ts
+++ b/src/plugins/replication-graphql/crawling-checkpoint.ts
@@ -33,7 +33,7 @@ import { newRxError } from '../../rx-error';
 // things for the push-checkpoint
 //
 
-const pushSequenceId = (endpointHash: string) => GRAPHQL_REPLICATION_PLUGIN_IDENT + '-push-checkpoint-' + endpointHash;
+export const pushSequenceId = (endpointHash: string) => GRAPHQL_REPLICATION_PLUGIN_IDENT + '-push-checkpoint-' + endpointHash;
 
 /**
  * @return last sequence checkpoint

--- a/src/plugins/replication-graphql/crawling-checkpoint.ts
+++ b/src/plugins/replication-graphql/crawling-checkpoint.ts
@@ -198,7 +198,7 @@ export async function getChangesSinceLastPushSequence<RxDocType>(
 //
 
 
-const pullLastDocumentId = (endpointHash: string) => GRAPHQL_REPLICATION_PLUGIN_IDENT + '-pull-checkpoint-' + endpointHash;
+export const pullLastDocumentId = (endpointHash: string) => GRAPHQL_REPLICATION_PLUGIN_IDENT + '-pull-checkpoint-' + endpointHash;
 
 export async function getLastPullDocument(
     collection: RxCollection,

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -37,7 +37,8 @@ import {
     setLastPushSequence,
     getLastPullDocument,
     setLastPullDocument,
-    getChangesSinceLastPushSequence
+    getChangesSinceLastPushSequence,
+    pushSequenceId
 } from './crawling-checkpoint';
 
 import { RxDBLeaderElectionPlugin } from '../leader-election';
@@ -75,10 +76,12 @@ export class RxGraphQLReplicationState<RxDocType> {
             headers
         });
         this.endpointHash = hash(url);
+        this.replicationDocId = pushSequenceId(this.endpointHash)
         this._prepare();
     }
     public client: any;
     public endpointHash: string;
+    public replicationDocId: string;
     public _subjects = {
         recieved: new Subject(), // all documents that are recieved from the endpoint
         send: new Subject(), // all documents that are send to the endpoint


### PR DESCRIPTION
fixes #3394

## This PR contains:

 - A NEW FEATURE

## Describe the problem you have without this PR

As part of updating to 10.0 we noticed that we're getting events for the replication status when watching collection document updates. This is new and was breaking some things in our app. For now we're filtering this out by constructing the ID ourselves, but I thought others might have this same issue and it would be nice for `RxGraphQLReplicationState` to provide these id's to make it easer.

The other thing this PR does is provide a `reset` function on `RxGraphQLReplicationState`. We need this because we currently have a way for a user to delete data on our server (but not in their local app) Right now we have the following bug:

1. User chooses to delete server data 
2. User chooses to store data on server again
3. User's data does not go to server because RxDB thinks all data has already been replicated.

I figured it might be useful for others to be able to do this same thing.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [X] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
