### PR TITLE
Update rx-database.md

### DIFF
--- a/docs-src/rx-database.md
+++ b/docs-src/rx-database.md
@@ -7,7 +7,7 @@ A RxDatabase-Object contains your collections and handles the synchronisation of
 The database is created by the asynchronous .create()-function of the main RxDB-module. It has the following parameters:
 
 ```javascript
-import { createRxDatabase } from 'rxdb';
+import { createRxDatabase, getRxStoragePouch } from 'rxdb';
 const db = await createRxDatabase({
   name: 'heroesdb',           // <- name
   storage: getRxStoragePouch('idb'),          // <- storage-adapter


### PR DESCRIPTION
Add missing import to db creation docs

## This PR contains:

 - IMPROVED DOCS


## Describe the problem you have without this PR

getRxStoragePouch is referenced in example code, but it is not imported. This change makes it a little clearer where it comes from in the example.
