### PR TITLE
use deleted flag for pushing in graphql replication

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -345,7 +345,7 @@ export class RxGraphQLReplicationState<RxDocType> {
 
                 // TODO _deleted should be required on type RxDocumentData
                 // so we do not need this check here
-                if (!changeWithDoc.doc.hasOwnProperty(this.deletedFlag)) {
+                if (!changeWithDoc.doc.hasOwnProperty('_deleted')) {
                     changeWithDoc.doc[this.deletedFlag] = false;
                 }
 

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -345,8 +345,8 @@ export class RxGraphQLReplicationState<RxDocType> {
 
                 // TODO _deleted should be required on type RxDocumentData
                 // so we do not need this check here
-                if (!changeWithDoc.doc.hasOwnProperty('_deleted')) {
-                    changeWithDoc.doc._deleted = false;
+                if (!changeWithDoc.doc.hasOwnProperty(this.deletedFlag)) {
+                    changeWithDoc.doc[this.deletedFlag] = false;
                 }
 
                 const pushObj = await this.push.queryBuilder(changeWithDoc.doc);


### PR DESCRIPTION


## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
Fixes #3436

I don't feel like this is a full fix yet as I'm not sure how if a doc is deleted in pouch that gets set via the deleted flag. I think this has something to do with checking for if this is a delete operation, but I'm not sure why that was changed via https://github.com/pubkey/rxdb/commit/480c56bfa4d18d304525e1cd2b2e20b34a5364ce#diff-9d7498b685187264496834aaae5e2d04b1273c86b921c6b1bc1a2bf5c797f6d8 and I don't want to rebreak things without understanding the fix. 

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [X] Tests
- [ ] Documentation
- [ ] Typings
- [X] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
