### PR TITLE
Fix usage of Buffer for browsers

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -17,7 +17,11 @@ const configuration = {
         'detectBrowsers'
     ],
     browserify: {
-        debug: true
+        debug: true,
+        insertGlobalVars: {
+            Buffer: (file) => file.includes('node_modules') ? 'require("buffer").Buffer' : undefined,
+            'Buffer.isBuffer': undefined
+        }
     },
     files: [
         '../test_tmp/unit.test.js'

--- a/src/util.ts
+++ b/src/util.ts
@@ -450,14 +450,14 @@ export const blobBufferUtil = {
         return blobBuffer;
     },
     isBlobBuffer(data: any): boolean {
-        if (Buffer.isBuffer(data) || data instanceof Blob) {
+        if ((typeof Buffer !== 'undefined' && Buffer.isBuffer(data)) || data instanceof Blob) {
             return true;
         } else {
             return false;
         }
     },
     toString(blobBuffer: BlobBuffer): Promise<string> {
-        if (blobBuffer instanceof Buffer) {
+        if (typeof Buffer !== 'undefined' && blobBuffer instanceof Buffer) {
             // node
             return nextTick()
                 .then(() => blobBuffer.toString());


### PR DESCRIPTION
## This PR contains:
Improved tests + bugfix

## Describe the problem you have without this PR
`Buffer` is not available in Browsers but `util.ts` tries to access it. The browser tests cannot detect this because they use browserify which polyfills `Buffer`. I've adapted the karma config to detect this issue and patched `util.ts`.

## Todos
- [X] Tests
