### PR TITLE
Fix an error on server spawn when full leveldown-module is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Bugfixes:
   - LokiJS: Do not call `saveDatabase()` when no persistence adapter is given.
   - Query returns outdated result in second subscription [#3498](https://github.com/pubkey/rxdb/issues/3498) Thanks [@swnf](https://github.com/swnf)
+  - Spawning a server when full leveldown-module is used must not throw an error.
+
 ### 10.5.3 (19 November 2021)
 
 Bugfixes:

--- a/src/plugins/server.ts
+++ b/src/plugins/server.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types';
 
 import {
+    adapterObject,
     addRxPlugin,
     flatClone,
     PROMISE_RESOLVE_VOID
@@ -117,12 +118,13 @@ export async function spawnServer(
         throw new Error('The RxDB server plugin only works with pouchdb storage.');
     }
 
+    const adapterObj = adapterObject(storage.adapter);
+    const pouchDBOptions = Object.assign(
+        { prefix: getPrefix(db), log: false },
+        adapterObj,
+    );
 
-    const pseudo = PouchDB.defaults({
-        adapter: storage.adapter,
-        prefix: getPrefix(db),
-        log: false
-    });
+    const pseudo = PouchDB.defaults(pouchDBOptions);
 
     const app = express();
     APP_OF_DB.set(db, app);

--- a/src/util.ts
+++ b/src/util.ts
@@ -315,7 +315,8 @@ export function adapterObject(adapter: any): any {
     };
     if (typeof adapter === 'string') {
         adapterObj = {
-            adapter
+            adapter,
+            db: undefined,
         };
     }
     return adapterObj;


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
When full leveldown-module is passed to `getRxStoragePouch`, [spawning a server](https://rxdb.info/rx-database.html#server) throws the following error:
```
Error: Invalid Adapter: function LevelDOWN (location) {
  if (!(this instanceof LevelDOWN)) {
    return new LevelDOWN(location)
  }

  if (typeof location !== 'string') {
    throw new Error('constructor requires a location string argument')
  }

  AbstractLevelDOWN.call(this, {
    bufferKeys: true,
    snapshots: true,
    permanence: true,
    seek: true,
    clear: true,
    createIfMissing: true,
    errorIfExists: true,
    additionalMethods: {
      approximateSize: true,
      compactRange: true
    }
  })

  this.location = location
  this.context = binding.db_init()
}
    at PouchAlt.PouchDB (/home/runner/work/rxdb/rxdb/node_modules/pouchdb-core/lib/index.js:1292:11)
    at new PouchAlt (/home/runner/work/rxdb/rxdb/node_modules/pouchdb-core/lib/index.js:1412:13)
    at /home/runner/work/rxdb/rxdb/node_modules/express-pouchdb/lib/create-or-delete-dbs.js:30:10
```

## Todos
- [ ] Documentation?
