### PR TITLE
WIP transpile to promises instead of generators

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -70,6 +70,7 @@ if (process.env['NODE_ENV'] === 'es5') {
         [
             '@babel/typescript',
             {
+                loose: true,
                 targets: {
                     edge: '17',
                     firefox: '60',

--- a/babel.config.js
+++ b/babel.config.js
@@ -30,8 +30,19 @@ const plugins = [
     '@babel/transform-block-scoping',
     '@babel/plugin-transform-member-expression-literals',
     '@babel/transform-property-literals',
-    '@babel/transform-async-to-generator',
-    '@babel/transform-regenerator', ['@babel/transform-runtime', {
+
+
+    // '@babel/transform-async-to-generator',
+    // '@babel/transform-regenerator', 
+    /**
+     * TODO transpile to promises instead of async, when this bug is fixed:
+     * @link https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/62
+     */
+    ['babel-plugin-transform-async-to-promises', {
+        externalHelpers: false
+    }],
+
+    ['@babel/transform-runtime', {
         'regenerator': true
     }],
     '@babel/proposal-class-properties',

--- a/babel.config.js
+++ b/babel.config.js
@@ -31,15 +31,19 @@ const plugins = [
     '@babel/plugin-transform-member-expression-literals',
     '@babel/transform-property-literals',
 
-
-    // '@babel/transform-async-to-generator',
-    // '@babel/transform-regenerator', 
     /**
-     * TODO transpile to promises instead of async, when this bug is fixed:
-     * @link https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/62
+     * Transpile async/await to promises instead of generators.
+     * This has shown to be 10% smaller build size and also be a bit faster.
+     * 
      */
     ['babel-plugin-transform-async-to-promises', {
-        externalHelpers: false
+        /**
+         * TODO use externalHelpers instead of inline helpers,
+         * but we have to wait for this bug to be fixed:
+         * @link https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/62
+         */
+        externalHelpers: false,
+        inlineHelpers: true
     }],
 
     ['@babel/transform-runtime', {

--- a/babel.config.js
+++ b/babel.config.js
@@ -38,7 +38,7 @@ const plugins = [
      */
     ['babel-plugin-transform-async-to-promises', {
         /**
-         * TODO use externalHelpers instead of inline helpers,
+         * TODO use externalHelpers instead of inlineHelpers,
          * but we have to wait for this bug to be fixed:
          * @link https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/62
          */

--- a/orga/performance-trackings.md
+++ b/orga/performance-trackings.md
@@ -819,7 +819,12 @@ https://www.npmjs.com/package/babel-plugin-transform-async-to-promises
 
 BEFORE:
 
+core:
 Build-Size (minified+gzip):
 75489
 
 AFTER:
+
+core: 
+Build-Size (minified+gzip):
+70723

--- a/orga/performance-trackings.md
+++ b/orga/performance-trackings.md
@@ -809,3 +809,17 @@ WITH async/await transpiled to generator:
   }
 }
 
+
+
+
+## transpile async/await to promises instead of generators
+https://www.npmjs.com/package/babel-plugin-transform-async-to-promises
+
+> npm run build:size
+
+BEFORE:
+
+Build-Size (minified+gzip):
+75489
+
+AFTER:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:core": "npm run pretest && mocha ./test_tmp/unit/core.node.js",
     "test:typings": "npm run pretest && cross-env DEFAULT_STORAGE=pouchdb NODE_ENV=fast mocha --config ./config/.mocharc.js ./test_tmp/typings.test.js",
     "test:typings:ci": "npm run pretest && mocha --config ./config/.mocharc.js ./test_tmp/typings.test.js",
-    "test:deps": "npm run build && dependency-check ./package.json ./dist/lib/plugins/replication-graphql/index.js ./dist/lib/plugins/server.js ./dist/lib/plugins/validate-z-schema.js ./dist/lib/plugins/lokijs/index.js ./dist/lib/plugins/worker/index.js --no-dev --ignore-module util --ignore-module url --ignore-module \"@types/*\"",
+    "test:deps": "npm run build && dependency-check ./package.json ./dist/lib/plugins/replication-graphql/index.js ./dist/lib/plugins/server.js ./dist/lib/plugins/validate-z-schema.js ./dist/lib/plugins/lokijs/index.js ./dist/lib/plugins/worker/index.js --no-dev --ignore-module util --ignore-module babel-plugin-transform-async-to-promises --ignore-module url --ignore-module \"@types/*\"",
     "test:circular": "npm run build && madge --circular ./dist/es/index.js",
     "test:performance:pouchdb": "npm run pretest && cross-env STORAGE=pouchdb mocha --config ./config/.mocharc.js ./test_tmp/performance.test.js --unhandled-rejections=strict --expose-gc",
     "test:performance:lokijs": "npm run pretest && cross-env STORAGE=lokijs mocha --config ./config/.mocharc.js ./test_tmp/performance.test.js --unhandled-rejections=strict --expose-gc",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@types/object-path": "0.11.1",
     "@types/pouchdb-core": "7.0.9",
     "@types/spark-md5": "3.0.2",
+    "babel-plugin-transform-async-to-promises": "0.8.17",
     "broadcast-channel": "4.8.0",
     "clone": "^2.1.2",
     "cors": "2.8.5",
@@ -141,6 +142,7 @@
   "devDependencies": {
     "@babel/cli": "7.16.0",
     "@babel/core": "7.16.5",
+    "@babel/plugin-external-helpers": "7.16.5",
     "@babel/plugin-proposal-class-properties": "7.16.5",
     "@babel/plugin-proposal-object-rest-spread": "7.16.5",
     "@babel/plugin-transform-member-expression-literals": "7.16.5",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@typescript-eslint/parser": "4.33.0",
     "assert": "2.0.0",
     "async-test-util": "1.7.3",
+    "babel-loader": "8.2.3",
     "babel-plugin-transform-class-properties": "6.24.1",
     "brfs": "2.0.2",
     "browserify": "17.0.0",

--- a/src/plugins/lokijs/loki-save-queue.ts
+++ b/src/plugins/lokijs/loki-save-queue.ts
@@ -1,4 +1,4 @@
-import { LokiDatabaseSettings } from '../../types';
+import type { LokiDatabaseSettings } from '../../types';
 import {
     promiseWait,
     PROMISE_RESOLVE_VOID,
@@ -35,7 +35,7 @@ export class LokiSaveQueue {
         this.run();
     }
 
-    public async run() {
+    public run() {
         if (
             // no persistence adapter given, so we do not need to save
             !this.databaseSettings.adapter ||
@@ -76,8 +76,7 @@ export class LokiSaveQueue {
                 await Promise.all([
                     requestIdlePromise(),
                     promiseWait(100)
-                ]);
-                await requestIdlePromise();
+                ]).then(() => requestIdlePromise());
 
                 if (this.writesSinceLastRun === 0) {
                     return;
@@ -98,7 +97,6 @@ export class LokiSaveQueue {
                         }
                     });
                 });
-
             })
             .catch(() => { })
             .then(() => {

--- a/src/plugins/lokijs/rx-storage-lokijs.ts
+++ b/src/plugins/lokijs/rx-storage-lokijs.ts
@@ -149,13 +149,13 @@ export class RxStorageLoki implements RxStorage<LokiStorageInternals, LokiSettin
         public databaseSettings: LokiDatabaseSettings
     ) { }
 
-    async createStorageInstance<RxDocType>(
+    public createStorageInstance<RxDocType>(
         params: RxStorageInstanceCreationParams<RxDocType, LokiSettings>
     ): Promise<RxStorageInstanceLoki<RxDocType>> {
         return createLokiStorageInstance(this, params, this.databaseSettings);
     }
 
-    public async createKeyObjectStorageInstance(
+    public createKeyObjectStorageInstance(
         params: RxKeyObjectStorageInstanceCreationParams<LokiSettings>
     ): Promise<RxStorageKeyObjectInstanceLoki> {
 

--- a/src/plugins/worker/workers/tsconfig.json
+++ b/src/plugins/worker/workers/tsconfig.json
@@ -9,6 +9,12 @@
         "moduleResolution": "node",
         "target": "es2017",
         "noEmit": false,
+
+        /**
+         * @link https://spblog.net/post/2018/10/26/TypeScript-Tips-How-to-reduce-the-size-of-a-bundle
+         */
+         "importHelpers": true,
+
         "lib": [
             "es2017",
             "webworker"

--- a/src/plugins/worker/workers/webpack.config.js
+++ b/src/plugins/worker/workers/webpack.config.js
@@ -6,6 +6,7 @@ const projectRootPath = path.resolve(
     '../../../../'
 );
 
+const babelConfig = require('../../../../babel.config');
 module.exports = {
     entry: {
         'lokijs-incremental-indexeddb': './src/plugins/worker/workers/lokijs-incremental-indexeddb.worker.ts',
@@ -17,6 +18,7 @@ module.exports = {
     },
     output: {
         filename: '[name].worker.js',
+        clean: true,
         path: path.resolve(
             projectRootPath,
             'dist/workers'
@@ -34,15 +36,19 @@ module.exports = {
     devtool: 'source-map',
     module: {
         rules: [
+            /**
+             * We transpile the typscript via babel instead of ts-loader.
+             * This ensures we have the exact same babel config
+             * as the root RxDB project.
+             */
             {
                 test: /\.tsx?$/,
+                exclude: /(node_modules)/,
                 use: {
-                    loader: 'ts-loader',
-                    options: {
-                        transpileOnly: true
-                    }
+                    loader: 'babel-loader',
+                    options: babelConfig
                 }
-            },
+            }
         ],
     },
     resolve: {

--- a/test/unit/rx-storage-implementations.test.ts
+++ b/test/unit/rx-storage-implementations.test.ts
@@ -815,6 +815,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                     options: {},
                     multiInstance: false
                 });
+                assert.ok(storageInstance);
                 async function getSequenceAfter(since: number): Promise<number> {
                     const changesResult = await storageInstance.getChangedDocuments({
                         direction: 'after',

--- a/test/unit/rx-storage-lokijs.test.ts
+++ b/test/unit/rx-storage-lokijs.test.ts
@@ -123,6 +123,7 @@ config.parallel('rx-storage-lokijs.test.js', () => {
                 });
             }
 
+
             // wait until one is leader
             await waitUntil(() => {
                 const leaderAmount = getLeaders().length;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,11 @@
         "noEmit": true,
         "declaration": true,
 
+        /**
+         * @link https://spblog.net/post/2018/10/26/TypeScript-Tips-How-to-reduce-the-size-of-a-bundle
+         */
+        "importHelpers": true,
+
         "typeRoots": [
             "./src/types/modules"
         ]


### PR DESCRIPTION
Work in progress.
I found out that transpiling async/await to promises instead of generators, we can save about 10% of bundle size. Also the performance improved. https://www.npmjs.com/package/babel-plugin-transform-async-to-promises
Currently waiting for a fix of this bug: https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/62