### PR TITLE
feat: strict mango dsl

### DIFF
--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -79,7 +79,7 @@ export class RxQueryBase<
 
     constructor(
         public op: RxQueryOP,
-        public mangoQuery: Readonly<MangoQuery>,
+        public mangoQuery: Readonly<MangoQuery<RxDocumentType>>,
         public collection: RxCollection<RxDocumentType>
     ) {
         if (!mangoQuery) {
@@ -390,7 +390,7 @@ export class RxQueryBase<
     }
 }
 
-export function _getDefaultQuery(): MangoQuery {
+export function _getDefaultQuery<RxDocType>(): MangoQuery<RxDocType> {
     return {
         selector: {}
     };
@@ -405,9 +405,9 @@ export function tunnelQueryCache<RxDocumentType, RxQueryResult>(
     return rxQuery.collection._queryCache.getByQuery(rxQuery as any);
 }
 
-export function createRxQuery(
+export function createRxQuery<RxDocType>(
     op: RxQueryOP,
-    queryObj: MangoQuery,
+    queryObj: MangoQuery<RxDocType>,
     collection: RxCollection
 ) {
     // checks
@@ -553,3 +553,5 @@ function __ensureEqual(rxQuery: RxQueryBase): Promise<boolean> | boolean {
 export function isInstanceOf(obj: any): boolean {
     return obj instanceof RxQueryBase;
 }
+
+declare const test: RxQuery<{foo: string}>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -21,3 +21,6 @@ export * from './plugins/server';
 export * from './plugins/migration';
 export * from './plugins/backup';
 export * from './plugins/lokijs';
+
+// mango
+export * from './mango-dsl'

--- a/src/types/mango-dsl.d.ts
+++ b/src/types/mango-dsl.d.ts
@@ -1,0 +1,136 @@
+// @see https://github.com/cloudant/mango
+
+export type MangoQuerySelector<T> =
+    | MangoPropertyOperator<T>
+    | MangoCombinationOperator<T>
+
+export type MangoOperator<T> =
+    | MangoPropertyOperator<T>
+    | MangoCombinationOperator<T>
+    | MangoConditionOperator<T>
+
+export type MangoPropertyOperator<T> = {
+    readonly [Property in keyof T]?:
+        | MangoCombinationOperator<T[Property]>
+        | MangoConditionOperator<T[Property]>
+        | (T[Property] extends object ? MangoOperator<T[Property]> : T[Property])
+};
+
+export interface $AndCombinationOperator<T> {
+    readonly $and: readonly MangoQuerySelector<T>[]
+}
+
+export interface $OrCombinationOperator<T> {
+    readonly $or: readonly MangoQuerySelector<T>[]
+}
+
+export interface $NotCombinationOperator<T> {
+    readonly $not: MangoQuerySelector<T>;
+}
+
+export interface $NorCombinationOperator<T> {
+    readonly $nor: readonly MangoQuerySelector<T>[]
+}
+
+export interface $AllCombinationOperator<T> {
+    readonly $all: readonly MangoQuerySelector<T>[]
+}
+
+export type $ElemMatchCombinationOperator<T extends readonly unknown[]> = {
+    readonly $elemMatch: readonly MangoOperator<T[number]>[]
+}
+
+export type MangoCombinationOperator<T> =
+    | $AndCombinationOperator<T>
+    | $OrCombinationOperator<T>
+    | $NotCombinationOperator<T>
+    | $NorCombinationOperator<T>
+    | $AllCombinationOperator<T>
+    | (T extends readonly unknown[] ? $ElemMatchCombinationOperator<T> : never)
+
+export interface $LTConditionOperator<T> {
+    readonly $lt: T
+}
+
+export interface $LTEConditionOperator<T> {
+    readonly $lte: T
+}
+
+export interface $EQConditionOperator<T> {
+    readonly $eq: T
+}
+
+export interface $NEConditionOperator<T> {
+    readonly $ne: T
+}
+
+export interface $GTEConditionOperator<T> {
+    readonly $gte: T
+}
+
+export interface $GTConditionOperator<T> {
+    readonly $gt: T
+}
+
+export interface $ExistsConditionOperator {
+    readonly $exists: boolean
+}
+
+export interface $TypeConditionOperator<T> {
+    readonly $type: T
+}
+
+export interface $InConditionOperator<T> {
+    readonly $in: readonly T[]
+}
+
+export interface $NInConditionOperator<T> {
+    readonly $nin: readonly T[]
+}
+
+export interface $SizeConditionOperator {
+    readonly $size: number
+}
+
+export interface $ModConditionOperator {
+    readonly $mod: readonly [divisor: number, remainder: number]
+}
+
+export interface $RegexConditionOperator {
+    readonly $regex: string
+}
+
+export type MangoConditionOperator<T> =
+    | $LTConditionOperator<T>
+    | $LTEConditionOperator<T>
+    | $EQConditionOperator<T>
+    | $NEConditionOperator<T>
+    | $GTEConditionOperator<T>
+    | $GTConditionOperator<T>
+    | $ExistsConditionOperator
+    | $TypeConditionOperator<T>
+    | $InConditionOperator<T>
+    | $NInConditionOperator<T>
+    | $SizeConditionOperator
+    | $ModConditionOperator
+    | $RegexConditionOperator
+
+/**
+ * Discussion was at:
+ * @link https://github.com/pubkey/rxdb/issues/1972
+ */
+export type MangoQuerySortDirection = 'asc' | 'desc';
+
+export type MangoQuerySortPart<RxDocType> = {
+    readonly [k in keyof RxDocType | string]: MangoQuerySortDirection;
+};
+
+export interface MangoQueryNoLimit<RxDocType> {
+    readonly selector: MangoQuerySelector<RxDocType>;
+    readonly skip?: number;
+    readonly sort?: MangoQuerySortPart<RxDocType>[]
+}
+
+export interface MangoQuery<RxDocType = unknown> extends MangoQueryNoLimit<RxDocType> {
+    readonly limit?: number;
+}

--- a/src/types/pouch.d.ts
+++ b/src/types/pouch.d.ts
@@ -1,4 +1,4 @@
-import { MangoQuery } from './rx-query';
+import { MangoQuery } from './mango-dsl';
 
 /**
  * this file contains types that are pouchdb-specific

--- a/src/types/rx-plugin.d.ts
+++ b/src/types/rx-plugin.d.ts
@@ -1,9 +1,10 @@
-import { RxQuery, RxQueryOP, MangoQuery } from './rx-query';
+import { RxQuery, RxQueryOP} from './rx-query';
 import { RxCollection } from './rx-collection';
 import { RxStorageInstanceCreationParams } from './rx-storage';
 import type {
     DeepReadonly
-} from '../types'
+} from './util'
+import { MangoQuery } from './mango-dsl';
 
 export type RxPluginPreCreateRxQueryArgs = {
     op: RxQueryOP;

--- a/src/types/rx-query.d.ts
+++ b/src/types/rx-query.d.ts
@@ -1,6 +1,4 @@
-import {
-    RxQueryBase
-} from '../rx-query';
+import { RxQueryBase } from '../rx-query';
 
 export interface RxQueryOptions<T> {
     $eq?: T;
@@ -27,30 +25,6 @@ export type RxQueryObject<T = any> = keyof T & { [P in keyof T]?: T[P] | RxQuery
     $and: RxQueryObject<T>[];
 };
 
-
-// TODO this should be typed
-export type MangoQuerySelector<RxDocType = any> = {
-    [k: string]: MangoQuerySelector<RxDocType> | any;
-};
-
-/**
- * Discussion was at:
- * @link https://github.com/pubkey/rxdb/issues/1972
- */
-export type MangoQuerySortDirection = 'asc' | 'desc';
-export type MangoQuerySortPart<RxDocType = any> = {
-    [k in keyof RxDocType | string]: MangoQuerySortDirection;
-};
-
-export type MangoQueryNoLimit<RxDocType = any> = {
-    selector: MangoQuerySelector<RxDocType>;
-    skip?: number;
-    sort?: MangoQuerySortPart<RxDocType>[]
-};
-
-export type MangoQuery<RxDocType = any> = MangoQueryNoLimit<RxDocType> & {
-    limit?: number;
-};
 
 export type RxQueryOP = 'find' | 'findOne';
 

--- a/src/types/rx-storage.d.ts
+++ b/src/types/rx-storage.d.ts
@@ -1,7 +1,7 @@
 import type { ChangeEvent } from 'event-reduce-js';
 import { BlobBuffer } from './pouch';
-import { MangoQuery } from './rx-query';
 import { RxJsonSchema } from './rx-schema';
+import { MangoQuery } from './mango-dsl';
 
 /**
  * The document data how it comes out of the storage instance.
@@ -279,7 +279,7 @@ export type ChangeStreamOptions = {
      * Sequence number of the first event to start with.
      * If you want to get all ongoing events,
      * first get the latest sequence number and input it here.
-     * 
+     *
      * Optional on changeStream,
      * will start from the newest sequence.
      */


### PR DESCRIPTION
Hey @pubkey, I noticed a `TODO` comment regarding implementing the types for `MangoQuerySelector` and decided to implement them. Here's the PR, looking forward to some feedback.

## This PR contains:
IMPROVED typings;
A BREAKING CHANGE - the types are now stricter which may result in a breaking change for codebases that were previously using the types incorrectly.

## Describe the problem you have without this PR
Currently, `MangoQuerySelector` is completely untyped.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Typings
- [x] Changelog

## Changelog
`MangoQuerySelector` is now converted into a recursive union type consisting of 3 main subtypes - `MangoPropertyOperator`, `MangoCombinationOperator` and `MangoConditionOperator`. 

`MangoPropertyOperator` is suited for defining property based shortcuts: `id: 'foo'`, `id: { $eq: 'foo' }` etc.
`MangoCombinationOperator` is suited for defining combinations such as `$and`, `$or` etc.
`MangoConditionOperator` is suited for defining conditions such as `$eq`, `$in` etc.

Only `MangoPropertyOperator` and `MangoCombinationOperator` are allowed on the query's top level because `MangoConditionOperator` requires a target property.
