### PR TITLE
Update example readmes to include preinstall

### DIFF
--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -9,7 +9,7 @@ Also it uses **angular-universal** to enable server side rendering.
 2. go into project `cd rxdb`
 3. run `npm install`
 4. go to this folder `cd examples/angular`
-5. run `npm install`
+5. run `npm run preinstall && npm install`
 6. run `npm start`
 7. Open [http://127.0.0.1:4200/](http://127.0.0.1:4200/) **IMPORTANT: do not use localhost**
 

--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -7,7 +7,7 @@ For an example with Electron [`remote`](https://electronjs.org/docs/api/remote) 
 # Try it out
 1. clone the whole [RxDB-repo](https://github.com/pubkey/rxdb)
 2. go into project `cd rxdb`
-3. run `npm install`
+3. run `npm run preinstall && npm install`
 4. go to this folder `cd examples/electron`
 5. run `npm install --verbose` (downloading electron can take a while, so use verbose to ensure its running)
 6. run `npm start`

--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -8,6 +8,6 @@ It represents a simple hero-list which is two-way-replicated with the server.
 2. go into project `cd rxdb`
 3. run `npm install`  (you may need to run `npm install --legacy-peer-deps`)
 4. go to this folder `cd examples/graphql`
-5. run `npm install`
+5. run `npm run preinstall && npm install`
 6. run `npm start`
 7. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -6,7 +6,7 @@ This is an example usage of RxDB with [Create React App](https://github.com/face
 2. go into project `cd rxdb`
 3. run `npm install`
 4. go to this folder `cd examples/react`
-5. run `npm install`
+5. run `npm run preinstall && npm install`
 6. run `npm start`
 7. Open [http://127.0.0.1:8888/](http://127.0.0.1:8888/) **IMPORTANT: do not use localhost**
 

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -5,5 +5,5 @@
 This is a quick note-taking app that demonstrates how to use RxDB within a Svelte app.
 
 ```sh
-npm i && npm run dev
+npm run preinstall && npm i && npm run dev
 ```


### PR DESCRIPTION
npm apparently removed this getting done automatically, so it needs to
be executed manually for the examples to work.

## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR
The examples do not run with the existing documentation instructions in the README.mds

## Todos
- [x ] Documentation
