### PR TITLE
Support composite indices in schema literal types

### DIFF
--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -16,7 +16,7 @@ import type {
     TopLevelProperty
 } from '../../types';
 import {
-    flattenObject,
+    flattenObject, isMaybeReadonlyArray,
     trimDots
 } from '../../util';
 import { rxDocumentProperties } from './entity-properties';
@@ -320,7 +320,7 @@ export function checkSchema(jsonSchema: RxJsonSchema<any>) {
     // check format of jsonSchema.indexes
     if (jsonSchema.indexes) {
         // should be an array
-        if (!Array.isArray(jsonSchema.indexes)) {
+        if (!isMaybeReadonlyArray(jsonSchema.indexes)) {
             throw newRxError('SC18', {
                 indexes: jsonSchema.indexes,
                 schema: jsonSchema
@@ -378,7 +378,7 @@ export function checkSchema(jsonSchema: RxJsonSchema<any>) {
     /* check types of the indexes */
     (jsonSchema.indexes || [])
         .reduce((indexPaths: string[], currentIndex) => {
-            if (Array.isArray(currentIndex)) {
+            if (isMaybeReadonlyArray(currentIndex)) {
                 indexPaths.concat(currentIndex);
             } else {
                 indexPaths.push(currentIndex);

--- a/src/plugins/key-compression.ts
+++ b/src/plugins/key-compression.ts
@@ -22,7 +22,7 @@ import type {
     RxCollection,
     CompositePrimaryKey
 } from '../types';
-import { flatClone } from '../util';
+import {flatClone, isMaybeReadonlyArray} from '../util';
 
 declare type CompressionState = {
     table: CompressionTable;
@@ -87,7 +87,7 @@ export function createCompressionState(
      */
     if (schema.indexes) {
         const newIndexes = schema.indexes.map(idx => {
-            if (Array.isArray(idx)) {
+            if (isMaybeReadonlyArray(idx)) {
                 return idx.map(subIdx => compressedPath(table, subIdx));
             } else {
                 return compressedPath(table, idx);

--- a/src/plugins/lokijs/rx-storage-instance-loki.ts
+++ b/src/plugins/lokijs/rx-storage-instance-loki.ts
@@ -14,7 +14,7 @@ import {
     flatClone,
     now,
     ensureNotFalsy,
-    randomCouchString
+    randomCouchString, isMaybeReadonlyArray
 } from '../../util';
 import { newRxError } from '../../rx-error';
 import { getPrimaryFieldOfPrimaryKey } from '../../rx-schema';
@@ -547,7 +547,7 @@ export async function createLokiLocalState<RxDocType>(
     const indices: string[] = [];
     if (params.schema.indexes) {
         params.schema.indexes.forEach(idx => {
-            if (!Array.isArray(idx)) {
+            if (!isMaybeReadonlyArray(idx)) {
                 indices.push(idx);
             }
         });

--- a/src/plugins/pouchdb/rx-storage-pouchdb.ts
+++ b/src/plugins/pouchdb/rx-storage-pouchdb.ts
@@ -5,12 +5,12 @@ import type {
     RxJsonSchema,
     RxStorageInstanceCreationParams,
     RxStorage,
-    RxKeyObjectStorageInstanceCreationParams
+    RxKeyObjectStorageInstanceCreationParams, MaybeReadonly
 } from '../../types';
 
 import {
     flatClone,
-    adapterObject
+    adapterObject, isMaybeReadonlyArray
 } from '../../util';
 import {
     isLevelDown,
@@ -167,7 +167,7 @@ export async function createIndexesOnPouch(
 
     await Promise.all(
         schema.indexes.map(async (indexMaybeArray) => {
-            let indexArray: string[] = Array.isArray(indexMaybeArray) ? indexMaybeArray : [indexMaybeArray];
+            let indexArray: MaybeReadonly<string[]> = isMaybeReadonlyArray(indexMaybeArray) ? indexMaybeArray : [indexMaybeArray];
 
             /**
              * replace primary key with _id

--- a/src/rx-schema.ts
+++ b/src/rx-schema.ts
@@ -6,7 +6,7 @@ import {
     hash,
     sortObject,
     overwriteGetterForCaching,
-    flatClone
+    flatClone, isMaybeReadonlyArray
 } from './util';
 import {
     newRxError,
@@ -21,13 +21,13 @@ import {
 import type {
     CompositePrimaryKey,
     DeepMutable,
-    DeepReadonly,
+    DeepReadonly, MaybeReadonly,
     PrimaryKey,
     RxJsonSchema
 } from './types';
 
 export class RxSchema<T = any> {
-    public indexes: string[][];
+    public indexes: MaybeReadonly<string[]>[];
     public primaryPath: keyof T;
     public finalFields: string[];
 
@@ -213,8 +213,8 @@ export class RxSchema<T = any> {
 
 export function getIndexes<T = any>(
     jsonSchema: RxJsonSchema<T>
-): string[][] {
-    return (jsonSchema.indexes || []).map(index => Array.isArray(index) ? index : [index]);
+): MaybeReadonly<string[]>[] {
+    return (jsonSchema.indexes || []).map(index => isMaybeReadonlyArray(index) ? index : [index]);
 }
 
 export function getPrimaryFieldOfPrimaryKey<RxDocType>(

--- a/src/types/rx-error.d.ts
+++ b/src/types/rx-error.d.ts
@@ -90,7 +90,7 @@ export interface RxErrorParameters {
     readonly collection?: any;
     readonly database?: any;
     readonly indexes?: Array<string | string[]> | Readonly<Array<string | string[]>>;
-    readonly index?: string | string[];
+    readonly index?: string | string[] | readonly string[];
     readonly plugin?: RxPlugin | any;
     readonly plugins?: Set<RxPlugin | any>;
 }

--- a/src/types/rx-schema.d.ts
+++ b/src/types/rx-schema.d.ts
@@ -115,7 +115,7 @@ export declare class RxJsonSchema<
     required?: StringKeys<RxDocType>[] | readonly StringKeys<RxDocType>[];
 
 
-    indexes?: (string | string[])[] | readonly (string | string[])[];
+    indexes?: (string | string[])[] | (string | readonly string[])[] | readonly (string | string[])[] | readonly (string | readonly string[])[];
     encrypted?: string[];
     keyCompression?: boolean;
     /**

--- a/src/types/util.d.ts
+++ b/src/types/util.d.ts
@@ -17,6 +17,8 @@ type DeepReadonlyObject<T> = {
     readonly [P in keyof T]: DeepReadonly<T[P]>;
 };
 
+export type MaybeReadonly<T> = T | Readonly<T>;
+
 
 /**
  * Opposite of DeepReadonly,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { BlobBuffer, DeepReadonlyObject } from './types';
+import type {BlobBuffer, DeepReadonlyObject, MaybeReadonly} from './types';
 import {
     default as deepClone
 } from 'clone';
@@ -463,6 +463,20 @@ export function getFromObjectOrThrow<V>(
         throw new Error('missing value from object ' + key);
     }
     return val;
+}
+
+/**
+ * returns true if the supplied argument is either an Array<T> or a Readonly<Array<T>>
+ */
+export function isMaybeReadonlyArray(x: any): x is MaybeReadonly<any[]> {
+    // While this looks strange, it's a workaround for an issue in TypeScript:
+    // https://github.com/microsoft/TypeScript/issues/17002
+    //
+    // The problem is that `Array.isArray` as a type guard returns `false` for a readonly array,
+    // but at runtime the object is an array and the runtime call to `Array.isArray` would return `true`.
+    // The type predicate here allows for both `Array<T>` and `Readonly<Array<T>>` to pass a type check while
+    // still performing runtime type inspection.
+    return Array.isArray(x);
 }
 
 export const blobBufferUtil = {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings
 - A BUGFIX

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

Following "Option A" for typing for providing a schema and generating the doc type in TypeScript from the [Use RxDB with Typescript guide](https://rxdb.info/tutorials/typescript.html), I tried to add a composite index to the hero example with something like:

```ts
indexes: ['firstName', ['lastName', 'passportId']]
```
As far as I can tell, that syntax should be okay. I consulted the [RxSchema docs](https://rxdb.info/rx-schema.html#indexes) to be sure. However, making that change causes a TypeScript compilation failure when using the `RxJsonSchema` type. Using the "hero" example from the aforementioned TypeScript guide:

```ts
const heroSchema: RxJsonSchema<HeroDocType> = heroSchemaLiteral;
```

I end up with the following compilation error:

```
Types of property 'indexes' are incompatible.
  Type 'readonly ["firstName", readonly ["lastName", "passportId"]]' is not assignable to type '(string | string[])[] | readonly (string | string[])[] | undefined'.
```


## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

Since it's a compilation error rather than a logical error, please advise on how you would like to see this tested.