### PR TITLE
[GraphQL Replication] Only create a new push sequence if necessary

### DIFF
--- a/src/plugins/replication-graphql/crawling-checkpoint.ts
+++ b/src/plugins/replication-graphql/crawling-checkpoint.ts
@@ -118,6 +118,7 @@ export async function getChangesSinceLastPushSequence<RxDocType>(
         sequence: number;
     }>;
     lastSequence: number;
+    hasChangesSinceLastSequence: boolean;
 }> {
     let lastPushSequence = await getLastPushSequence(
         collection,
@@ -212,7 +213,8 @@ export async function getChangesSinceLastPushSequence<RxDocType>(
 
     return {
         changedDocs,
-        lastSequence
+        lastSequence,
+        hasChangesSinceLastSequence: lastPushSequence !== lastSequence,
     };
 }
 

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -386,7 +386,7 @@ export class RxGraphQLReplicationState<RxDocType> {
             return false;
         }
 
-        if (lastSuccessfullChange) {
+        if (changesResult.hasChangesSinceLastSequence) {
             // all docs where successfull, so we use the seq of the changes-fetch
             await setLastPushSequence(
                 this.collection,

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -386,12 +386,14 @@ export class RxGraphQLReplicationState<RxDocType> {
             return false;
         }
 
-        // all docs where successfull, so we use the seq of the changes-fetch
-        await setLastPushSequence(
-            this.collection,
-            this.endpointHash,
-            changesResult.lastSequence
-        );
+        if (lastSuccessfullChange) {
+            // all docs where successfull, so we use the seq of the changes-fetch
+            await setLastPushSequence(
+                this.collection,
+                this.endpointHash,
+                changesResult.lastSequence
+            );
+        }
 
         if (changesResult.changedDocs.size === 0) {
             if (this.live) {

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -394,7 +394,7 @@ export class RxReplicationStateBase<RxDocType> {
 
         pushDocs.forEach(pushDoc => this.subjects.send.next(pushDoc));
 
-        if (pushDocs.length > 0) {
+        if (changesResult.hasChangesSinceLastSequence) {
             await setLastPushSequence(
                 this.collection,
                 this.replicationIdentifier,

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -394,11 +394,13 @@ export class RxReplicationStateBase<RxDocType> {
 
         pushDocs.forEach(pushDoc => this.subjects.send.next(pushDoc));
 
-        await setLastPushSequence(
-            this.collection,
-            this.replicationIdentifier,
-            changesResult.lastSequence
-        );
+        if (pushDocs.length > 0) {
+            await setLastPushSequence(
+                this.collection,
+                this.replicationIdentifier,
+                changesResult.lastSequence
+            );
+        }
 
         // batch had documents so there might be more changes to replicate
         if (changesResult.changedDocs.size !== 0) {

--- a/src/plugins/replication/replication-checkpoint.ts
+++ b/src/plugins/replication/replication-checkpoint.ts
@@ -92,6 +92,7 @@ export async function getChangesSinceLastPushSequence<RxDocType>(
         sequence: number;
     }>;
     lastSequence: number;
+    hasChangesSinceLastSequence: boolean;
 }> {
     let lastPushSequence = await getLastPushSequence(
         collection,
@@ -174,7 +175,8 @@ export async function getChangesSinceLastPushSequence<RxDocType>(
 
     return {
         changedDocs,
-        lastSequence
+        lastSequence,
+        hasChangesSinceLastSequence: lastPushSequence !== lastSequence,
     };
 }
 

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -2375,7 +2375,7 @@ describe('replication-graphql.test.js', () => {
                     replicationState.collection,
                     replicationState.endpointHash,
                 );
-                assert.ok(originalSequence === newSequence);
+                assert.strictEqual(originalSequence, newSequence);
                 server.close();
                 c.database.destroy();
             });

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -2362,15 +2362,18 @@ describe('replication-graphql.test.js', () => {
                 });
 
                 await replicationState.awaitInitialReplication();
-                
+                await replicationState.run();
+            
                 const originalSequence = await getLastPushSequence(
                     replicationState.collection,
                     replicationState.endpointHash,
                 );
+                
                 // call .run() often
-                await Promise.all(
-                    new Array(3).fill(0).map(() => replicationState.run())
-                );
+                for(let i = 0; i < 3; i++){
+                    await replicationState.run();
+                }
+
                 const newSequence = await getLastPushSequence(
                     replicationState.collection,
                     replicationState.endpointHash,

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -2339,6 +2339,46 @@ describe('replication-graphql.test.js', () => {
         });
 
         config.parallel('issues', () => {
+            it('should not create push checkpoints unnecessarily [PR: #3627]', async () => {
+                const amount = batchSize * 4;
+                const testData = getTestData(amount);
+                const [c, server] = await Promise.all([
+                    humansCollection.createHumanWithTimestamp(amount),
+                    SpawnServer.spawn(testData),
+                ]);
+
+                const replicationState = c.syncGraphQL({
+                    url: server.url,
+                    push: {
+                        batchSize,
+                        queryBuilder: pushQueryBuilder,
+                    },
+                    pull: {
+                        queryBuilder,
+                    },
+                    live: true,
+                    deletedFlag: 'deleted',
+                    liveInterval: 60 * 1000,
+                });
+
+                await replicationState.awaitInitialReplication();
+                
+                const originalSequence = await getLastPushSequence(
+                    replicationState.collection,
+                    replicationState.endpointHash,
+                );
+                // call .run() often
+                await Promise.all(
+                    new Array(3).fill(0).map(() => replicationState.run())
+                );
+                const newSequence = await getLastPushSequence(
+                    replicationState.collection,
+                    replicationState.endpointHash,
+                );
+                assert.ok(originalSequence === newSequence);
+                server.close();
+                c.database.destroy();
+            });
             it('push not working on slow db', async () => {
                 const db = await createRxDatabase({
                     name: randomCouchString(10),

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -549,7 +549,7 @@ describe('replication.test.js', () => {
                 localCollection,
                 REPLICATION_IDENTIFIER_TEST
             );
-            assert.ok(originalSequence === newSequence);
+            assert.strictEqual(originalSequence, newSequence);
             localCollection.database.destroy();
             remoteCollection.database.destroy();
         });

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -534,17 +534,17 @@ describe('replication.test.js', () => {
             });
 
             await replicationState.awaitInitialReplication();
-
+            await replicationState.run();
+            
             const originalSequence = await getLastPushSequence(
                 localCollection,
                 REPLICATION_IDENTIFIER_TEST
             );
             // call .run() often
-            await Promise.all(
-                new Array(3)
-                    .fill(0)
-                    .map(() => replicationState.run())
-            );
+            for (let i = 0; i < 3; i++) {
+                await replicationState.run()
+            }
+
             const newSequence = await getLastPushSequence(
                 localCollection,
                 REPLICATION_IDENTIFIER_TEST

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -513,6 +513,47 @@ describe('replication.test.js', () => {
         });
     });
     config.parallel('issues', () => {
+        it('should not create push checkpoints unnecessarily [PR: #3627]', async () => {
+            const { localCollection, remoteCollection } =
+                await getTestCollections({ local: 5, remote: 5 });
+
+            const replicationState = replicateRxCollection({
+                collection: localCollection,
+                replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                live: false,
+                pull: {
+                    handler: getPullHandler(remoteCollection),
+                },
+                push: {
+                    handler: getPushHandler(remoteCollection),
+                },
+            });
+            replicationState.error$.subscribe((err) => {
+                console.log('got error :');
+                console.dir(err);
+            });
+
+            await replicationState.awaitInitialReplication();
+
+            const originalSequence = await getLastPushSequence(
+                localCollection,
+                REPLICATION_IDENTIFIER_TEST
+            );
+            // call .run() often
+            await Promise.all(
+                new Array(3)
+                    .fill(0)
+                    .map(() => replicationState.run())
+            );
+            const newSequence = await getLastPushSequence(
+                localCollection,
+                REPLICATION_IDENTIFIER_TEST
+            );
+            assert.ok(originalSequence === newSequence);
+            localCollection.database.destroy();
+            remoteCollection.database.destroy();
+        });
+
         /**
          * When a local write happens while the pull is running,
          * we should drop the pulled documents and first run the push again


### PR DESCRIPTION
## This PR contains:
 - A bugfix

## Describe the problem you have without this PR

I was working on a project using GraphQL replication without subscriptions and I left a browser tab open for an ungodly amount of time. To my surprise, my local storage had gotten bloated to the point where I couldn't access it anymore. While investigating I noticed that thousands of `push-checkpoints` were being created.

![image](https://user-images.githubusercontent.com/16158417/149645696-8ab2ebc4-9fcf-4009-9827-87e3a47d057b.png)

Indeed, I was able to confirm that a new push-checkpoint was made on every sync operation. @pubkey confirmed in Gitter [that this is indeed a bug](https://gitter.im/pubkey/rxdb?at=61e37eaf526fb77b317feec2).

My solution is to surround the `setLastPushSequence` with the same check that is in the `catch` block above. This works well in my testing. I'll note that this **doesn't technically solve the memory leak** and is only kicking it down the road to when thousands of pushes have been required. I would think there should be a cleanup operation on successful pulls that remove old and irrelevant push checkpoints - but this is early in my tooling with `rxdb`  and I'm very unfamiliar with both this codebase as well the intricacies of pouchdb.

In my testing, this is still working great and the records are no longer being created unnecessarily.

@pubkey wouldn't mind your assistance on if this is the right solution and what the best practice for the test should be

## Todos
- [x] Testing
- [ ] Changelog