### PR TITLE
Record details about replication action and associated document, if any, upon replication failure.

### DIFF
--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -44,6 +44,28 @@ import { _handleToStorageInstance } from '../../rx-collection-helper';
 import { newRxError } from '../../rx-error';
 import { getDocumentDataOfRxChangeEvent } from '../../rx-change-event';
 
+export type RxReplicationAction = 'pull' | 'push';
+
+interface RxReplicationErrorPullPayload {
+    type: 'pull'
+}
+
+interface RxReplicationErrorPushPayload<RxDocType> {
+    type: 'push'
+    documentData: RxDocumentData<RxDocType>
+}
+
+export class RxReplicationError<RxDocType> extends Error {
+    readonly payload: RxReplicationErrorPullPayload | RxReplicationErrorPushPayload<any>
+    readonly innerErrors?: any;
+
+    constructor(message: string, payload: RxReplicationErrorPullPayload | RxReplicationErrorPushPayload<RxDocType>, innerErrors?: any) {
+        super(message);
+
+        this.payload = payload;
+        this.innerErrors = innerErrors;
+    }
+}
 
 export class RxReplicationStateBase<RxDocType> {
     public readonly subs: Subscription[] = [];

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1983,6 +1983,53 @@ describe('replication-graphql.test.js', () => {
                 replicationState.cancel();
                 c.database.destroy();
             });
+            it('should contain include replication action data in pull request failure', async () => {
+                const c = await humansCollection.createHumanWithTimestamp(0);
+                const replicationState = c.syncGraphQL({
+                    url: ERROR_URL,
+                    pull: {
+                        queryBuilder
+                    },
+                    deletedFlag: 'deleted'
+                });
+
+                const error = await replicationState.error$.pipe(
+                    first()
+                ).toPromise();
+
+                assert.strictEqual(error.payload.type, 'pull');
+
+                replicationState.cancel();
+                c.database.destroy();
+            });
+            it('should contain include replication action data in push request failure', async () => {
+                const c = await humansCollection.createHumanWithTimestamp(0);
+                const replicationState = c.syncGraphQL({
+                    url: ERROR_URL,
+                    push: {
+                        queryBuilder: pushQueryBuilder,
+                    },
+                    deletedFlag: 'deleted'
+                });
+
+                const localDoc = schemaObjects.humanWithTimestamp();
+                await c.insert(localDoc);
+
+                const error = await replicationState.error$.pipe(
+                    first()
+                ).toPromise();
+
+                const { documentData: actual } = error.payload;
+
+                assert.strictEqual(error.payload.type, 'push');
+                assert.strictEqual(actual.id, localDoc.id);
+                assert.strictEqual(actual.name, localDoc.name);
+                assert.strictEqual(actual.age, localDoc.age);
+                assert.strictEqual(actual.updatedAt, localDoc.updatedAt);
+
+                replicationState.cancel();
+                c.database.destroy();
+            });
             it('should not exit .run() before the batch is inserted and its events have been emitted', async () => {
                 const c = await humansCollection.createHumanWithTimestamp(0);
                 const server = await SpawnServer.spawn(getTestData(1));


### PR DESCRIPTION
## This PR contains:

 - A NEW FEATURE

## Describe the problem you have without this PR

This PR is a proposed solution to #3622. Errors encountered during GraphQL replication are wrapped in a new `ReplicationError` object that records whether it was a pull or push replication that failed, and if a push failure, the associated document data in the failed request.

For the time being, I've only applied these changes to GraphQL replication, although I think it could be handled for all forms of replication. There were a variety of design decisions made in getting this far and I'm happy to adjust as necessary. I just wanted to get something functional that could then be evaluated. Some areas that would be helpful to get feedback on are:

* Should the replication error payload be a discriminated union or just fields in the class? I went with the discriminated union because it made the constructor cleaner (less optional data), but I could also see that the replication type (pull or push) should be a field directly in the error.
* Should the replication error wrap all errors upon replication or just logical errors? E.g., GraphQL can have an HTTP 200 response with server-side logic errors encoded in the GraphQL response and I think those should always be wrapped/recorded. But, should we also wrap network errors, authentication errors, HTTP errors and so on? This PR does do that for consistency and because I think it could make logging and error handling easier in a client, but it makes the code a little uglier.
* If all errors are wrapped, I think we can safely indicate that the object supplied to `error$` in this case is a `ReplicationError`. I have kept it as `any` for the time being to avoid any future issues with the type definition changing. When typed as `any`, a client should not be relying on anything about the object structure.
* Should the replication error include all of the push document data or just the document ID?

To give an example of how I'm making use of this new feature, here's code from my client handling a uniqueness constraint violation from the GraphQL server:

```ts
replicationState.error$.subscribe((error: ReplicationError<Todo>) => {
  if (error.payload.type === 'push') {
    const { documentData } = error.payload;
    if (error.innerErrors && error.innerErrors[0].message === 'Uniqueness violation. duplicate key value violates unique constraint "todos_profile_id_rank_key"') {
      this.db.todos.findOne(documentData.id).exec().then((doc) => {
        doc?.update({
          $set: {
            rank: LexoRank.parse(documentData.rank).genNext().toString()
          }
        });
      })
    }
  }
```

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->

- [ ] Documentation
- [ ] Changelog
- [ ] Evaluate design decisions
- [ ] Ensure testing is sufficient

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
