### PR TITLE
Allow truthy values for the GraphQL replication `deletedFlag` field.

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -22,7 +22,10 @@ Cons:
 
 ### Data Design
 
-To use the GraphQL-replication you first have to ensure that your data is sortable by update time and your documents never get deleted, only have a deleted-flag set.
+To use the GraphQL-replication you first have to ensure that your data is sortable by update time and your documents never get deleted.
+Instead, your response object should have a field indicating that a document has been deleted.
+The name of the field is configurable and handles truthy values follow JavaScript's rules, so you can use a GraphQL `Boolean` value or something more complex such as a string or timestamp, depending on your remote data source schema.
+
 
 For example if your documents look like this,
 
@@ -41,6 +44,8 @@ Then your data is always sortable by `updatedAt`. This ensures that when RxDB fe
 
 Deleted documents still exist but have `deleted: true` set. This ensures that when RxDB fetches new documents, even the deleted documents are send back and can be known at the client-side.
 
+RxDB documents also have an internal `_deleted` field that is managed by RxDB when deleting documents or pulling deleted documents from a GraphQL server.
+If you use something like a `deletedAt` field instead and configure the `deletedFlag` option in the `syncGraphQL` to use the timestamp field, RxDB will still be able to keep track of deleted documents with an efficient Boolean flag.
 
 ### GraphQL Server
 
@@ -160,7 +165,7 @@ const replicationState = myCollection.syncGraphQL({
     url: 'http://example.com/graphql', // url to the GraphQL endpoint
     pull: {
         queryBuilder: pullQueryBuilder, // the queryBuilder from above
-        modifier: doc => doc // (optional) modifies all pulled documents before they are handeled by RxDB. Returning null will skip the document.
+        modifier: doc => doc, // (optional) modifies all pulled documents before they are handeled by RxDB. Returning null will skip the document.
         dataPath: undefined // (optional) specifies the object path to access the document(s). Otherwise, the first result of the response data is used.
     },
     deletedFlag: 'deleted', // the flag which indicates if a pulled document is deleted

--- a/src/plugins/lokijs/lokijs-helper.ts
+++ b/src/plugins/lokijs/lokijs-helper.ts
@@ -126,7 +126,7 @@ export function getLokiDatabase(
             /**
              * Wait until all data is loaded from persistence adapter.
              * Wrap the loading into the saveQueue to ensure that when many
-             * collections are created a the same time, the load-calls do not interfer
+             * collections are created at the same time, the load-calls do not interfere
              * with each other and cause error logs.
              */
             if (hasPersistence) {

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -423,7 +423,7 @@ export class RxGraphQLReplicationState<RxDocType> {
 
         for (const doc of docs) {
             const documentId = doc[this.collection.schema.primaryPath];
-            const deletedValue = doc[this.deletedFlag];
+            const deletedValue = !!doc[this.deletedFlag];
 
             doc._deleted = deletedValue;
             delete doc[this.deletedFlag];

--- a/test/helper/graphql-server.ts
+++ b/test/helper/graphql-server.ts
@@ -105,7 +105,8 @@ export async function spawn(
             name: String!,
             age: Int!,
             updatedAt: Int!,
-            deleted: Boolean!
+            deleted: Boolean!,
+            deletedAt: Int
         }
         type HumanCollection {
             collection: [Human!]

--- a/test/helper/schema-objects.ts
+++ b/test/helper/schema-objects.ts
@@ -313,6 +313,7 @@ export interface HumanWithTimestampDocumentType {
     name: string;
     age: number;
     updatedAt: number;
+    deletedAt?: number;
 }
 export function humanWithTimestamp(): HumanWithTimestampDocumentType {
     const now = new Date().getTime() / 1000;

--- a/test/helper/schemas.ts
+++ b/test/helper/schemas.ts
@@ -1012,6 +1012,9 @@ export const humanWithTimestamp: RxJsonSchema<HumanWithTimestampDocumentType> = 
         },
         updatedAt: {
             type: 'number'
+        },
+        deletedAt: {
+            type: 'number'
         }
     },
     indexes: ['updatedAt'],
@@ -1037,6 +1040,9 @@ export const humanWithTimestampAllIndex: RxJsonSchema<HumanWithTimestampDocument
             type: 'number'
         },
         updatedAt: {
+            type: 'number'
+        },
+        deletedAt: {
             type: 'number'
         }
     },


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE

## Describe the problem you have without this PR

I'm replicating from a GraphQL store in front of a PostgreSQL database. Handling soft deletion in relational databases by storing a `deletedAt`|`deleted_at` timestamp column rather than a boolean flag is a common practice.  While I could wrap the whole thing with a view to expose a boolean flag, it would be handy if I could use this timestamp directly.

I thought maybe RxDB handled truthy values for the `deletedFlag` by default. This seemed to work fine with PouchDB, but when I tried LokiJS, I ran into a confusing problem. When data was pulled from the GraphQL service, it would show in the web app immediately. But, when the web app was reloaded, the data wouldn't show. I tracked that down to queries having the `where('_deleted').eq(false)` selector appended by default. In my case, the `_deleted` value was a nullable timestamp, so either there was a string present with an ISO 8601 datetime string or the JavaScript value `null`. Neither of those value is `false`, so Loki would fail to find any documents.

I think supporting truthy values here would allow RxDB to work with a more diverse set of GraphQL servers. If someone needs more advanced rules (e.g., maybe they use an enum and values are always "true" in JavaScript) then a more comprehensive solution would be needed, maybe in the `modifier` callback. But, allowing truthy values here supports real world cases that were not well-supported before.

Moreover, I think this PR closes a usability gap with RxDB. By allowing non-Boolean values to be stored in the `_deleted` property of the store document, there's a confusing situation where freshly pulled documents show up in query results because they already exist in memory but fail to load from persisted storage because of the malformed `_deleted` value.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [X] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

I added documentation for this change, but I was unable to run GitBook locally. I tried all of the NPM scripts in _package.json_ and each time I got the following:

```
> npm run docs:serve

> rxdb@11.3.0 docs:serve
> gitbook serve docs-src

Installing GitBook 3.2.3
/home/nirvdrum/dev/workspaces/rxdb/node_modules/npm/node_modules/graceful-fs/polyfills.js:287
      if (cb) cb.apply(this, arguments)
                 ^

TypeError: cb.apply is not a function
    at /home/nirvdrum/dev/workspaces/rxdb/node_modules/npm/node_modules/graceful-fs/polyfills.js:287:18
    at FSReqCallback.oncomplete (node:fs:199:5)
```

I'll try to figure out what is going on there. But, the point is I wrote the docs with a local Markdown editor plugin but was not able to verify the build documentation looks good.