### PR TITLE
fix: import path of RxDBReplicationCouchDBPlugin in documentation

### DIFF
--- a/docs-src/custom-build.md
+++ b/docs-src/custom-build.md
@@ -125,7 +125,7 @@ addRxPlugin(RxDBMigrationPlugin);
 Adds the [CouchDB replication](./replication-couchdb.md)-functionality to RxDB which allows you to replicate the database with a CouchDB compliant endpoint.
 
 ```javascript
-import { RxDBReplicationCouchDBPlugin } from 'rxdb/plugins/replication';
+import { RxDBReplicationCouchDBPlugin } from 'rxdb/plugins/replication-couchdb';
 addRxPlugin(RxDBReplicationCouchDBPlugin);
 ```
 


### PR DESCRIPTION
## This PR contains:

 - IMPROVED DOCS

## Describe the problem you have without this PR
In docs: 
```js
import { RxDBReplicationCouchDBPlugin } from 'rxdb/plugins/replication';
addRxPlugin(RxDBReplicationCouchDBPlugin);
``` 
but the right path shold be: `'rxdb/plugins/replication-couchdb'`

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Typings
- [ ] Changelog
