### PR TITLE
REFACTOR Attachments are now internally handled as string instead of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added `doesBroadcastChangestream()` to `RxStorageStatics`
 - Fix (replication primitives) only drop pulled documents when a relevant document was changed locally.
 - Add `_meta` property to stored document data.
-
+- Attachments are now internally handled as string instead of `Blob` or `Buffer`
 
 ### 11.6.0 (4 February 2022)
 

--- a/src/plugins/dexie/rx-storage-instance-dexie.ts
+++ b/src/plugins/dexie/rx-storage-instance-dexie.ts
@@ -25,7 +25,6 @@ import type {
     RxStorageBulkWriteResponse,
     RxStorageBulkWriteError,
     RxStorageQueryResult,
-    BlobBuffer,
     ChangeStreamOnceOptions,
     RxJsonSchema,
     RxStorageChangedDocumentMeta,
@@ -485,7 +484,7 @@ export class RxStorageInstanceDexie<RxDocType> implements RxStorageInstance<
         return this.changes$.asObservable();
     }
 
-    getAttachmentData(_documentId: string, _attachmentId: string): Promise<BlobBuffer> {
+    getAttachmentData(_documentId: string, _attachmentId: string): Promise<string> {
         throw new Error('Attachments are not implemented in the dexie RxStorage. Make a pull request.');
     }
 

--- a/src/plugins/encryption.ts
+++ b/src/plugins/encryption.ts
@@ -31,8 +31,21 @@ export function encrypt(value: string, password: any): string {
 }
 
 export function decrypt(cipherText: string, password: any): string {
+    /**
+     * Trying to decrypt non-strings
+     * will cause no errors and will be hard to debug.
+     * So instead we do this check here.
+     */
+    if (typeof cipherText !== 'string') {
+        throw newRxError('SNH', {
+            args: {
+                cipherText
+            }
+        });
+    }
     const decrypted = AES.decrypt(cipherText, password);
-    return decrypted.toString(cryptoEnc);
+    const ret = decrypted.toString(cryptoEnc);
+    return ret;
 }
 
 const _encryptString = function (this: Crypter, value: string) {

--- a/src/plugins/lokijs/rx-storage-instance-loki.ts
+++ b/src/plugins/lokijs/rx-storage-instance-loki.ts
@@ -26,7 +26,6 @@ import type {
     RxStorageBulkWriteResponse,
     RxStorageBulkWriteError,
     RxStorageQueryResult,
-    BlobBuffer,
     ChangeStreamOnceOptions,
     RxJsonSchema,
     MangoQuery,
@@ -425,7 +424,7 @@ export class RxStorageInstanceLoki<RxDocType> implements RxStorageInstance<
             documents: foundDocuments
         };
     }
-    getAttachmentData(_documentId: string, _attachmentId: string): Promise<BlobBuffer> {
+    getAttachmentData(_documentId: string, _attachmentId: string): Promise<string> {
         throw new Error('Attachments are not implemented in the lokijs RxStorage. Make a pull request.');
     }
     async getChangedDocuments(

--- a/src/plugins/pouchdb/pouchdb-helper.ts
+++ b/src/plugins/pouchdb/pouchdb-helper.ts
@@ -16,6 +16,7 @@ import type {
     RxStorageKeyObjectInstancePouch
 } from './rx-storage-key-object-instance-pouch';
 import {
+    blobBufferUtil,
     flatClone,
     getHeightOfRevision
 } from '../../util';
@@ -127,8 +128,12 @@ export function rxDocumentDataToPouchDocumentData<T>(
         Object.entries(doc._attachments).forEach(([key, value]) => {
             const useValue: RxAttachmentWriteData & RxAttachmentData = value as any;
             if (useValue.data) {
+                const asBlobBuffer = blobBufferUtil.createBlobBufferFromBase64(
+                    useValue.data,
+                    useValue.type
+                );
                 (pouchDoc as any)._attachments[key] = {
-                    data: useValue.data,
+                    data: asBlobBuffer,
                     content_type: useValue.type
                 };
             } else {

--- a/src/plugins/pouchdb/pouchdb-helper.ts
+++ b/src/plugins/pouchdb/pouchdb-helper.ts
@@ -16,7 +16,6 @@ import type {
     RxStorageKeyObjectInstancePouch
 } from './rx-storage-key-object-instance-pouch';
 import {
-    blobBufferUtil,
     flatClone,
     getHeightOfRevision
 } from '../../util';
@@ -332,18 +331,17 @@ export async function writeAttachmentsToAttachments(
             if (!obj.type) {
                 throw newRxError('SNH', { args: { obj } });
             }
+            /**
+             * Is write attachment,
+             * so we have to remove the data to have a
+             * non-write attachment.
+             */
             if ((obj as RxAttachmentWriteData).data) {
-                const asWrite = (obj as RxAttachmentWriteData);
-                const [hash, asString] = await Promise.all([
-                    pouchHash(asWrite.data),
-                    blobBufferUtil.toString(asWrite.data)
-                ]);
-
-                const length = asString.length;
+                const asWriteAttachment = (obj as RxAttachmentWriteData);
                 ret[key] = {
-                    digest: POUCH_HASH_KEY + '-' + hash,
-                    length,
-                    type: asWrite.type
+                    digest: asWriteAttachment.digest,
+                    length: asWriteAttachment.length,
+                    type: asWriteAttachment.type
                 };
             } else {
                 ret[key] = obj as RxAttachmentData;

--- a/src/plugins/pouchdb/rx-storage-instance-pouch.ts
+++ b/src/plugins/pouchdb/rx-storage-instance-pouch.ts
@@ -7,7 +7,6 @@ import {
 import { newRxError } from '../../rx-error';
 import { getPrimaryFieldOfPrimaryKey } from '../../rx-schema';
 import type {
-    BlobBuffer,
     BulkWriteRow,
     ChangeStreamOnceOptions,
     EventBulk,
@@ -34,6 +33,7 @@ import {
     writeAttachmentsToAttachments
 } from './pouchdb-helper';
 import {
+    blobBufferUtil,
     flatClone,
     getFromMapOrThrow,
     PROMISE_RESOLVE_VOID
@@ -225,7 +225,6 @@ export class RxStorageInstancePouch<RxDocType> implements RxStorageInstance<
                 }
             })
         );
-
         return ret;
     }
 
@@ -248,12 +247,12 @@ export class RxStorageInstancePouch<RxDocType> implements RxStorageInstance<
     async getAttachmentData(
         documentId: string,
         attachmentId: string
-    ): Promise<BlobBuffer> {
+    ): Promise<string> {
         const attachmentData = await this.internals.pouch.getAttachment(
             documentId,
             attachmentId
         );
-        return attachmentData;
+        return blobBufferUtil.tobase64String(attachmentData);
     }
 
     async findDocumentsById(ids: string[], deleted: boolean): Promise<{ [documentId: string]: RxDocumentData<RxDocType> }> {

--- a/src/plugins/worker/in-worker.ts
+++ b/src/plugins/worker/in-worker.ts
@@ -3,7 +3,6 @@
  * that is supposed to run inside of the worker.
  */
 import type {
-    BlobBuffer,
     BulkWriteLocalRow,
     BulkWriteRow,
     ChangeStreamOnceOptions,
@@ -48,7 +47,7 @@ export type InWorkerStorage = {
         instanceId: number,
         documentId: string,
         attachmentId: string
-    ): Promise<BlobBuffer>;
+    ): Promise<string>;
     getChangedDocuments(
         instanceId: number,
         options: ChangeStreamOnceOptions
@@ -126,7 +125,7 @@ export function wrappedRxStorage<T, D>(
             instanceId: number,
             documentId: string,
             attachmentId: string
-        ): Promise<BlobBuffer> {
+        ): Promise<string> {
             const instance = getFromMapOrThrow(instanceById, instanceId);
             return instance.getAttachmentData(
                 documentId,

--- a/src/plugins/worker/non-worker.ts
+++ b/src/plugins/worker/non-worker.ts
@@ -5,7 +5,6 @@ import type {
     RxStorage,
     RxStorageInstanceCreationParams,
     RxStorageInstance,
-    BlobBuffer,
     BulkWriteRow,
     ChangeStreamOnceOptions,
     RxDocumentData,
@@ -143,7 +142,7 @@ export class RxStorageInstanceWorker<DocumentData> implements RxStorageInstance<
             preparedQuery
         );
     }
-    getAttachmentData(documentId: string, attachmentId: string): Promise<BlobBuffer> {
+    getAttachmentData(documentId: string, attachmentId: string): Promise<string> {
         return this.internals.worker.getAttachmentData(
             this.internals.instanceId,
             documentId,

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -238,7 +238,6 @@ export function getWrappedStorageInstance<RxDocumentType, Internals, InstanceCre
                     previous: row.previous ? transformDocumentDataFromRxDBToRxStorage(collection, row.previous, false) : undefined,
                 }
             });
-
             return database.lockedRun(
                 () => storageInstance.bulkWrite(
                     toStorageWriteRows

--- a/src/types/pouch.d.ts
+++ b/src/types/pouch.d.ts
@@ -348,7 +348,7 @@ export declare class PouchDBInstance {
         docId: string,
         attachmentId: string,
         options?: { rev?: string },
-    ): Promise<any>;
+    ): Promise<BlobBuffer>;
     removeAttachment(
         docId: string,
         attachmentId: string,

--- a/src/types/rx-storage.d.ts
+++ b/src/types/rx-storage.d.ts
@@ -1,5 +1,4 @@
 import type { ChangeEvent } from 'event-reduce-js';
-import { BlobBuffer } from './pouch';
 import { RxDocumentMeta } from './rx-document';
 import { MangoQuery } from './rx-query';
 import { RxJsonSchema } from './rx-schema';
@@ -147,9 +146,16 @@ export type RxAttachmentData = RxAttachmentDataMeta & {
  */
 export type RxAttachmentWriteData = RxAttachmentData & {
     /**
-     * The data of the attachment.
+     * The data of the attachment. As string in base64 format.
+     * In the past we used BlobBuffer internally but it created many
+     * problems because of then we need the full data (for encryption/compression)
+     * so we anyway have to get the string value out of the BlobBuffer.
+     * 
+     * Also using BlobBuffer has no performance benefit because in some RxStorage implementations,
+     * like PouchDB, it just keeps the transaction open for longer because the BlobBuffer
+     * has be be read.
      */
-    data: BlobBuffer;
+    data: string;
 }
 
 

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -20,7 +20,6 @@ import type {
     RxStorageQueryResult
 } from './rx-storage';
 import type {
-    BlobBuffer,
     MangoQuery,
     MangoQuerySortPart,
     RxJsonSchema
@@ -341,7 +340,7 @@ export interface RxStorageInstance<
     getAttachmentData(
         documentId: string,
         attachmentId: string
-    ): Promise<BlobBuffer>;
+    ): Promise<string>;
 
     /**
      * Returns the ids of all documents that have been

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -18,9 +18,9 @@ import './unit/rx-schema.test.js';
 import './unit/key-compression.test.js';
 import './unit/bug-report.test.js';
 import './unit/rx-database.test.js';
-import './unit/local-documents.test.js'; // MOVE DOWN
 import './unit/rx-collection.test.js';
 import './unit/rx-document.test.js';
+import './unit/attachments.test.js'; // TODO move down
 import './unit/rx-query.test.js';
 import './unit/primary.test.js';
 import './unit/temporary-document.test.js';
@@ -28,13 +28,13 @@ import './unit/change-event-buffer.test.js';
 import './unit/cache-replacement-policy.test';
 import './unit/query-builder.test.js';
 import './unit/idle-queue.test.js';
+import './unit/local-documents.test.js'; // MOVE DOWN
 import './unit/event-reduce.test.js';
 import './unit/reactive-collection.test.js';
 import './unit/reactive-query.test.js';
 import './unit/reactive-document.test.js';
 import './unit/data-migration.test.js';
 import './unit/hooks.test.js';
-import './unit/attachments.test.js';
 import './unit/orm.test.js';
 import './unit/population.test.js';
 import './unit/backup.test.js';

--- a/test/unit/rx-storage-implementations.test.ts
+++ b/test/unit/rx-storage-implementations.test.ts
@@ -1821,8 +1821,9 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                     attachmentData,
                     'text/plain'
                 );
-                const dataString = await blobBufferUtil.tobase64String(dataBlobBuffer);
                 const attachmentHash = await statics.hash(dataBlobBuffer);
+                const dataString = await blobBufferUtil.tobase64String(dataBlobBuffer);
+                const dataLength = blobBufferUtil.size(dataBlobBuffer);
 
                 const writeData: RxDocumentWriteData<TestDocType> = {
                     key: 'foobar',
@@ -1835,7 +1836,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                     _attachments: {
                         foo: {
                             digest: statics.hashKey + '-' + attachmentHash,
-                            length: blobBufferUtil.size(dataBlobBuffer),
+                            length: dataLength,
                             data: dataString,
                             type: 'text/plain'
                         }
@@ -1865,6 +1866,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                         }
                     )
                 );
+
                 assert.strictEqual(queryResult.documents[0]._attachments.foo.type, 'text/plain');
                 assert.strictEqual(queryResult.documents[0]._attachments.foo.length, attachmentData.length);
 

--- a/test/unit/rx-storage-implementations.test.ts
+++ b/test/unit/rx-storage-implementations.test.ts
@@ -1821,6 +1821,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                     attachmentData,
                     'text/plain'
                 );
+                const dataString = await blobBufferUtil.tobase64String(dataBlobBuffer);
                 const attachmentHash = await statics.hash(dataBlobBuffer);
 
                 const writeData: RxDocumentWriteData<TestDocType> = {
@@ -1835,7 +1836,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                         foo: {
                             digest: statics.hashKey + '-' + attachmentHash,
                             length: blobBufferUtil.size(dataBlobBuffer),
-                            data: dataBlobBuffer,
+                            data: dataString,
                             type: 'text/plain'
                         }
                     }
@@ -1906,6 +1907,7 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
 
                 const data = blobBufferUtil.createBlobBuffer(randomString(20), 'text/plain');
                 const attachmentHash = await config.storage.getStorage().statics.hash(data);
+                const dataString = await blobBufferUtil.tobase64String(data);
                 const writeData: RxDocumentWriteData<TestDocType> = {
                     key: 'foobar',
                     value: 'one',
@@ -1916,9 +1918,9 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
                     },
                     _attachments: {
                         foo: {
-                            digest: attachmentHash,
+                            digest: config.storage.getStorage().statics.hashKey + '-' + attachmentHash,
                             length: blobBufferUtil.size(data),
-                            data,
+                            data: dataString,
                             type: 'text/plain'
                         }
                     }
@@ -1940,9 +1942,10 @@ config.parallel('rx-storage-implementations.test.js (implementation: ' + config.
 
                 const data2 = blobBufferUtil.createBlobBuffer(randomString(20), 'text/plain');
                 const attachmentHash2 = await config.storage.getStorage().statics.hash(data2);
+                const dataString2 = await blobBufferUtil.tobase64String(data2);
                 writeData._attachments.bar = {
-                    data: data2,
-                    digest: attachmentHash2,
+                    data: dataString2,
+                    digest: config.storage.getStorage().statics.hashKey + '-' + attachmentHash2,
                     length: blobBufferUtil.size(data2),
                     type: 'text/plain'
                 };

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -155,6 +155,13 @@ describe('util.test.js', () => {
 
             assert.strictEqual(text, asString);
         });
+        it('.size() should return a deterministic value', () => {
+            const amount = 30;
+            const str = randomCouchString(amount);
+            const blobBuffer = blobBufferUtil.createBlobBuffer(str, 'plain/text');
+            const size = blobBufferUtil.size(blobBuffer);
+            assert.strictEqual(size, amount);
+        });
     });
     describe('.deepFreezeWhenDevMode()', () => {
         it('should not allow to mutate the object', () => {


### PR DESCRIPTION
…`Blob` or `Buffer`

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
