### PR TITLE
Test for an error when replicating deleted document (LokiJS)

### DIFF
--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -115,9 +115,10 @@ describe('replication.test.js', () => {
                     doc.updatedAt = now();
 
                     // Workaround to have `_deleted` flag in for both push and pull
+                    // We don't actually delete document from remote collection but treat it as deleted if `deletedAt` is present
                     if (doc._deleted) {
                         doc.deletedAt = now()
-                        delete doc._deleted;
+                        doc._deleted = false;
                     }
 
                     return doc;


### PR DESCRIPTION
I was trying the latest build of `rxdb` from master with replication primitives + LokiJS and found an exception when a deleted item is being replicated: 

```
     RxError (SNH): RxError (SNH):
This should never happen
Given parameters: {
args:{
  "writeRow": {
    "document": {
      "id": "eefmhqsigsvj",
      "name": "Maurine",
      "age": 38,
      "updatedAt": 1647285514096,
      "deletedAt": 1647285514097,
      "_deleted": true,
      "_attachments": {},
      "_meta": {
        "lwt": 1647285514109,
        "rep-ec577b929edb9a3d22248bcfc64ece66": 4
      },
      "_rev": "4-4704ef680036ec6222ba8fdc6c7dfddc"
    },
    "previous": {
      "id": "eefmhqsigsvj",
      "name": "Maurine",
      "age": 38,
      "updatedAt": 1647285514065,
      "_deleted": true,
      "_attachments": {},
      "_meta": {
        "lwt": 1647285514093,
        "rep-ec577b929edb9a3d22248bcfc64ece66": 2
      },
      "_rev": "3-a5c9e842b88de679788a9bc0b4c977cf"
    }
  }
}}
```