### PR TITLE
test-bug: Retrieving docs using .find() are automatically sorted by the primary key in alphabetical order (lokijs)

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 
 
 // while the karma tests run, we need some things which we start here
@@ -13,8 +14,7 @@ const configuration = {
     basePath: '',
     frameworks: [
         'mocha',
-        'browserify',
-        'detectBrowsers'
+        'browserify'
     ],
     browserify: {
         debug: true,
@@ -30,37 +30,14 @@ const configuration = {
     colors: true,
     autoWatch: false,
 
-    /**
-     * see
-     * @link https://github.com/litixsoft/karma-detect-browsers
-     */
-    detectBrowsers: {
-        enabled: true,
-        usePhantomJS: false,
-        postDetection: function (availableBrowser) {
-            // return [];
-            // return ['Chrome_travis_ci']; // comment in to test specific browser
-            const browsers = availableBrowser
-                .filter(b => !['PhantomJS', 'FirefoxAurora', 'FirefoxNightly', 'ChromeCanary'].includes(b))
-                .map(b => {
-                    if (b === 'Chrome') return 'Chrome_travis_ci';
-                    else return b;
-                });
-            return browsers;
-        }
-    },
-
     // Karma plugins loaded
     plugins: [
         'karma-mocha',
         'karma-browserify',
         'karma-chrome-launcher',
-        'karma-edge-launcher',
-        'karma-safari-launcher',
-        'karma-firefox-launcher',
-        'karma-ie-launcher',
-        'karma-opera-launcher',
-        'karma-detect-browsers'
+        // karma-edge-launcher does not properly pickup the edge chromium browser.
+        // This plugin is able to detect the edge browser and use it.
+        '@chiragrupani/karma-chromium-edge-launcher'
     ],
 
     // Source files that you wanna generate coverage for.
@@ -75,7 +52,7 @@ const configuration = {
             timeout: 12000
         }
     },
-    browsers: ['Chrome_travis_ci'],
+    browsers: ['Chrome_travis_ci', 'Edge'],
     browserDisconnectTimeout: 12000,
     processKillTimeout: 12000,
     customLaunchers: {

--- a/docs-src/rx-query.md
+++ b/docs-src/rx-query.md
@@ -6,6 +6,10 @@ Like most other noSQL-Databases, RxDB uses the [mango-query-syntax](https://gith
 ## find()
 To create a basic `RxQuery`, call `.find()` on a collection and insert selectors. The result-set of normal queries is an array with documents.
 
+**Note**: The results that `.find()` returns are sorted alphabetically by the primary key. Insert order does not affect query results. To avoid issues, make sure that the primary key is something that can be sorted.
+
+e.g: Using fields that contain uuid's as primary keys, will give a different order than what was inserted. Hence, avoid using uuid's as primary keys.
+
 ```js
 // find all that are older then 18
 const query = myCollection

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.17.9",
+    "@chiragrupani/karma-chromium-edge-launcher": "^2.2.1",
     "@types/clone": "2.1.1",
     "@types/cors": "2.8.12",
     "@types/express": "4.17.13",

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -10,14 +10,14 @@ import './unit/adapter-check.test.js';
  * Do not commit this file if you modified the order.
  */
 import './unit/rx-storage-implementations.test.js';
-import './unit/rx-storage-pouchdb.test.js';
+/* import './unit/rx-storage-pouchdb.test.js'; */
 import './unit/rx-storage-lokijs.test.js';
-import './unit/rx-storage-dexie.test.js';
+/* import './unit/rx-storage-dexie.test.js'; */
 
-import './unit/instance-of-check.test.js';
-import './unit/rx-schema.test.js';
+/* import './unit/instance-of-check.test.js';
+import './unit/rx-schema.test.js'; */
 import './unit/bug-report.test.js';
-import './unit/rx-database.test.js';
+/* import './unit/rx-database.test.js';
 import './unit/rx-collection.test.js';
 import './unit/rx-document.test.js';
 import './unit/rx-query.test.js';
@@ -51,3 +51,4 @@ import './unit/cross-instance.test.js';
 import './unit/server.test.js';
 import './unit/plugin.test.js';
 import './unit/last.test.js';
+ */

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -38,7 +38,9 @@ describe('bug-report.test.js', () => {
         const db = new Loki(name);
 
         // create a collection
-        const mycollection = db.addCollection('mycollection');
+        const mycollection = db.addCollection('mycollection', {
+            indices: ['name']
+          });
 
         // define documents
         const doc0 = {


### PR DESCRIPTION
## This PR contains:
A failing test showcasing a bug.

## Describe the problem you have without this PR
When using lokijs with RxDB, when trying to retrieve docs that were previously inserted in a collection, they are sorted alphabetically on the primary key by default.