### PR TITLE
fix behaviour to fit with documentation in back channel use.

### DIFF
--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -575,7 +575,7 @@ export function replicateRxCollection<RxDocType>(
          * if it is a live replication.
          */
         if (replicationState.live) {
-            if (pull) {
+            if (pull && replicationState.liveInterval > 0) {
                 (async () => {
                     while (!replicationState.isStopped()) {
                         await collection.promiseWait(ensureNotFalsy(replicationState.liveInterval));

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -28,6 +28,7 @@ import {
     setLastPushCheckpoint
 } from './replication-checkpoint';
 import {
+    ensureInteger,
     ensureNotFalsy,
     flatClone,
     getDefaultRevision,
@@ -575,10 +576,11 @@ export function replicateRxCollection<RxDocType>(
          * if it is a live replication.
          */
         if (replicationState.live) {
-            if (pull && replicationState.liveInterval > 0) {
+            const liveInterval: number = ensureInteger(replicationState.liveInterval);
+            if (pull && liveInterval > 0) {
                 (async () => {
                     while (!replicationState.isStopped()) {
-                        await collection.promiseWait(ensureNotFalsy(replicationState.liveInterval));
+                        await collection.promiseWait(liveInterval);
                         if (replicationState.isStopped()) {
                             return;
                         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -208,7 +208,7 @@ export function ensureNotFalsy<T>(obj: T | false | undefined | null): T {
 
 export function ensureInteger(obj: unknown): number {
     if (!Number.isInteger(obj)) {
-        throw new Error('ensurePositiveInteger() is falsy');
+        throw new Error('ensureInteger() is falsy');
     }
     return obj as number;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -206,6 +206,13 @@ export function ensureNotFalsy<T>(obj: T | false | undefined | null): T {
     return obj;
 }
 
+export function ensureInteger(obj: unknown):number {
+    if (Number.isInteger(obj)) {
+        throw new Error('ensurePositiveInteger() is falsy');
+    }
+    return obj as number;
+}
+
 /**
  * deep-sort an object so its attributes are in lexical order.
  * Also sorts the arrays inside of the object if no-array-sort not set

--- a/src/util.ts
+++ b/src/util.ts
@@ -206,7 +206,7 @@ export function ensureNotFalsy<T>(obj: T | false | undefined | null): T {
     return obj;
 }
 
-export function ensureInteger(obj: unknown):number {
+export function ensureInteger(obj: unknown): number {
     if (!Number.isInteger(obj)) {
         throw new Error('ensurePositiveInteger() is falsy');
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -207,7 +207,7 @@ export function ensureNotFalsy<T>(obj: T | false | undefined | null): T {
 }
 
 export function ensureInteger(obj: unknown):number {
-    if (Number.isInteger(obj)) {
+    if (!Number.isInteger(obj)) {
         throw new Error('ensurePositiveInteger() is falsy');
     }
     return obj as number;

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -2176,7 +2176,7 @@ describe('replication-graphql.test.ts', () => {
                     live: true,
                     deletedFlag: 'deleted',
                     retryTime: 500,
-                    liveInterval: Infinity
+                    liveInterval: 0
                 });
                 const replicationState = graphqlReplicationState.replicationState;
 

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -11,7 +11,8 @@ import {
     blobBufferUtil,
     createRevision,
     sortDocumentsByLastWriteTime,
-    RxDocumentData
+    RxDocumentData,
+    ensureInteger
 } from '../../';
 
 import {
@@ -21,7 +22,7 @@ import {
 import {
     rev as pouchCreateRevisison
 } from 'pouchdb-utils';
-import { EXAMPLE_REVISION_1 } from '../helper/revisions';
+import {EXAMPLE_REVISION_1} from '../helper/revisions';
 
 describe('util.test.js', () => {
     describe('.fastUnsecureHash()', () => {
@@ -316,5 +317,24 @@ describe('util.test.js', () => {
             assert.strictEqual(sorted[0].id, 'a');
             assert.strictEqual(sorted[1].id, 'b');
         });
+    });
+    describe('.ensureInteger()', () => {
+        it('should return the given argument in case of integer', () => {
+             assert.doesNotThrow(() => ensureInteger(56));
+             assert.strictEqual(ensureInteger(56),56);
+        });
+        [
+            undefined,
+            true,
+            [],
+            {},
+            1.2,
+            Infinity,
+            ''
+        ].map(value =>{
+            it(`should throw error for ${value} argument`, () => {
+                assert.throws(() => ensureInteger(value));
+            });
+        })
     });
 });


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
Actual:
- no push on document updates if live=false
- no way to disable polling: liveInterval=0 is rejected by ensureNotFalsy() line 581 when live=true

Expected:
- do not poll if liveInterval=0 and live=true
- push triggered on document updates
