### PR TITLE
add new option `runInitialReplication`.

### DIFF
--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -54,6 +54,7 @@ The deleted field must always be exactly `_deleted`. If your remote endpoint use
 ## The replication cycle
 
 The replication works in cycles. A cycle is triggered when:
+  - When calling `replicateRxCollection()` by default
   - Automatically on writes to non-[local](./rx-local-document.md) documents.
   - When `liveInterval` is reached from the time of last `run()` cycle.
   - The `run()` method is called manually.
@@ -124,6 +125,13 @@ const replicationState = await replicateRxCollection({
      * (optional), default is 5 seconds.
      */
     retryTime: number,
+    /**
+     * By default `replicateRxCollection()` implies to run a replication.
+     * If set to false, it will not run replication on `replicateRxCollection()`.
+     * This means you need to call replicationState.run() to trigger the first replication.
+     * (optional), default is true.
+     */
+    runInitialReplication: true,
     /**
      * Optional,
      * only needed when you want to replicate remote changes to the local state.

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -93,6 +93,7 @@ export class RxReplicationStateBase<RxDocType> {
         public readonly live?: boolean,
         public liveInterval?: number,
         public retryTime?: number,
+        public runInitialReplication?: boolean,
     ) {
         let replicationStates = REPLICATION_STATE_BY_COLLECTION.get(collection);
         if (!replicationStates) {
@@ -137,7 +138,7 @@ export class RxReplicationStateBase<RxDocType> {
 
     /**
      * Returns a promise that resolves when:
-     * - All local data is repliacted with the remote
+     * - All local data is replicated with the remote
      * - No replication cycle is running or in retry-state
      */
     async awaitInSync(): Promise<true> {
@@ -534,7 +535,8 @@ export function replicateRxCollection<RxDocType>(
         live = false,
         liveInterval = 1000 * 10,
         retryTime = 1000 * 5,
-        waitForLeadership
+        waitForLeadership,
+        runInitialReplication = true,
     }: ReplicationOptions<RxDocType>
 ): RxReplicationState<RxDocType> {
 
@@ -555,6 +557,7 @@ export function replicateRxCollection<RxDocType>(
         live,
         liveInterval,
         retryTime,
+        runInitialReplication
     );
 
     /**
@@ -568,8 +571,9 @@ export function replicateRxCollection<RxDocType>(
             return;
         }
 
-        // trigger run() once
-        replicationState.run();
+        if(runInitialReplication) {
+            replicationState.run();
+        }
 
         /**
          * Start sync-interval and listeners

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -104,4 +104,10 @@ export type ReplicationOptions<RxDocType> = {
      * 
      */
     waitForLeadership?: boolean; // default=true
+    /**
+     * Calling `replicateRxCollection()` implies to run a replication.
+     * If set to false, it will not run replication on `replicateRxCollection()`.
+     * This means you need to call replicationState.run() to trigger the first replication.
+     */
+    runInitialReplication?: boolean; // default=true
 }

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -570,9 +570,39 @@ describe('replication.test.js', () => {
         });
     });
     config.parallel('other', () => {
+        describe('runInitialReplication', () => {
+            it('should run first replication by default', async () => {
+                const replicationState = replicateRxCollection({
+                    collection: {
+                        database: {},
+                        onDestroy: {then(){}}
+                    } as RxCollection,
+                    replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                    live: false,
+                    runInitialReplication: true,
+                    waitForLeadership: false
+                });
+                await replicationState.awaitInitialReplication();
+                assert.strictEqual(replicationState.runCount,1);
+            });
+            it('should not run first replication when runInitialReplication is set to false', async () => {
+                const replicationState = replicateRxCollection({
+                    collection: {
+                        database: {},
+                        onDestroy: {then(){}}
+                    } as RxCollection,
+                    replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                    live: false,
+                    runInitialReplication: false,
+                    waitForLeadership: false
+                });
+                // by definition awaitInitialReplication would be infinite
+                assert.strictEqual(replicationState.runCount,0);
+            });
+        });
         describe('.awaitInSync()', () => {
             it('should resolve after some time', async () => {
-                const { localCollection, remoteCollection } = await getTestCollections({ local: 5, remote: 5 });
+                const {localCollection, remoteCollection} = await getTestCollections({local: 5, remote: 5});
 
                 const replicationState = replicateRxCollection({
                     collection: localCollection,


### PR DESCRIPTION
## This PR contains:
- A NEW FEATURE PROPOSAL

## Describe the problem you have without this PR

`replicateRxCollection()` provides a way to configure the way to replicate a given collection.
However, by default, this function also run an initial replication as *side effect*.

IMHO, it's a matter of separation of concerns: 
- The moment to configure collections and replications is not always the same we get ready to do the first replication.
- I would like to trigger replications collection by collection and keep control on the order, the timing... and separately from the replication definition.

I suggest to add an option to prevent the default first replication and separate the replication configuration and triggering.

This PR adds new option `runInitialReplication`.
It could be set to `false` to avoid  initialReplication on replicateRxCollection().
default to true to avoid breaking change

Please consider this PR as a draft and support for discussions.
I know this issue is an opinionated one, feel free to challenge it ;)

- TODO `liveInterval>0` case (poll from the first `run()` call instead of starting on `replicateRxCollection()`)