### PR TITLE
 add new option autoStart.

### DIFF
--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -54,6 +54,7 @@ The deleted field must always be exactly `_deleted`. If your remote endpoint use
 ## The replication cycle
 
 The replication works in cycles. A cycle is triggered when:
+  - When calling `replicateRxCollection()` by default
   - Automatically on writes to non-[local](./rx-local-document.md) documents.
   - When `liveInterval` is reached from the time of last `run()` cycle.
   - The `run()` method is called manually.
@@ -124,6 +125,13 @@ const replicationState = await replicateRxCollection({
      * (optional), default is 5 seconds.
      */
     retryTime: number,
+    /**
+     * By default `replicateRxCollection()` implies to run a replication.
+     * If set to false, it will not run replication on `replicateRxCollection()`.
+     * This means you need to call replicationState.run() to trigger the first replication.
+     * (optional), default is true.
+     */
+    runInitialReplication: true,
     /**
      * Optional,
      * only needed when you want to replicate remote changes to the local state.

--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -54,7 +54,7 @@ The deleted field must always be exactly `_deleted`. If your remote endpoint use
 ## The replication cycle
 
 The replication works in cycles. A cycle is triggered when:
-  - When calling `replicateRxCollection()` by default
+  - When calling `replicateRxCollection()` (if `autoStart` is `true` as by default)
   - Automatically on writes to non-[local](./rx-local-document.md) documents.
   - When `liveInterval` is reached from the time of last `run()` cycle.
   - The `run()` method is called manually.
@@ -126,10 +126,13 @@ const replicationState = await replicateRxCollection({
      */
     retryTime: number,
     /**
-     * By default `replicateRxCollection()` implies to run a replication.
-     * If set to false, it will not run replication on `replicateRxCollection()`.
-     * This means you need to call replicationState.run() to trigger the first replication.
-     * (optional), default is true.
+     * Trigger or not a first replication
+     * if `false`, the first replication should be trigged by : 
+     *  - `replicationState.run()`
+     *  - a write to non-[local](./rx-local-document.md) document
+     * Used with `liveInterval` greater than `0`, the polling for remote changes starts 
+     * after the first triggered replication. 
+     * (optional), only needed when live=true, default is true.
      */
     autoStart: true,
     /**

--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -131,7 +131,7 @@ const replicationState = await replicateRxCollection({
      * This means you need to call replicationState.run() to trigger the first replication.
      * (optional), default is true.
      */
-    runInitialReplication: true,
+    autoStart: true,
     /**
      * Optional,
      * only needed when you want to replicate remote changes to the local state.

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -106,7 +106,7 @@ export function syncGraphQL<RxDocType>(
         live = false,
         liveInterval = 1000 * 10, // in ms
         retryTime = 1000 * 5, // in ms
-        runInitialReplication = true,
+        autoStart = true,
     }: SyncOptionsGraphQL<RxDocType>
 ): RxGraphQLReplicationState<RxDocType> {
     const collection = this;
@@ -255,7 +255,7 @@ export function syncGraphQL<RxDocType>(
         live,
         liveInterval,
         retryTime,
-        runInitialReplication
+        autoStart
     });
 
     const graphqlReplicationState = new RxGraphQLReplicationState(

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -106,6 +106,7 @@ export function syncGraphQL<RxDocType>(
         live = false,
         liveInterval = 1000 * 10, // in ms
         retryTime = 1000 * 5, // in ms
+        runInitialReplication = true,
     }: SyncOptionsGraphQL<RxDocType>
 ): RxGraphQLReplicationState<RxDocType> {
     const collection = this;
@@ -253,7 +254,8 @@ export function syncGraphQL<RxDocType>(
         waitForLeadership,
         live,
         liveInterval,
-        retryTime
+        retryTime,
+        runInitialReplication
     });
 
     const graphqlReplicationState = new RxGraphQLReplicationState(

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -93,6 +93,7 @@ export class RxReplicationStateBase<RxDocType> {
         public readonly live?: boolean,
         public liveInterval?: number,
         public retryTime?: number,
+        public runInitialReplication?: boolean,
     ) {
         let replicationStates = REPLICATION_STATE_BY_COLLECTION.get(collection);
         if (!replicationStates) {
@@ -137,7 +138,7 @@ export class RxReplicationStateBase<RxDocType> {
 
     /**
      * Returns a promise that resolves when:
-     * - All local data is repliacted with the remote
+     * - All local data is replicated with the remote
      * - No replication cycle is running or in retry-state
      */
     async awaitInSync(): Promise<true> {
@@ -534,7 +535,8 @@ export function replicateRxCollection<RxDocType>(
         live = false,
         liveInterval = 1000 * 10,
         retryTime = 1000 * 5,
-        waitForLeadership
+        waitForLeadership,
+        runInitialReplication = true,
     }: ReplicationOptions<RxDocType>
 ): RxReplicationState<RxDocType> {
 
@@ -555,6 +557,7 @@ export function replicateRxCollection<RxDocType>(
         live,
         liveInterval,
         retryTime,
+        runInitialReplication
     );
 
     /**
@@ -568,8 +571,9 @@ export function replicateRxCollection<RxDocType>(
             return;
         }
 
-        // trigger run() once
-        replicationState.run();
+        if(runInitialReplication) {
+            replicationState.run();
+        }
 
         /**
          * Start sync-interval and listeners

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -207,7 +207,7 @@ export class RxReplicationStateBase<RxDocType> {
                 }
                 this.runQueueCount--;
             });
-        if (this.live && this.pull && this.liveInterval > 0) {
+        if (this.live && this.pull && this.liveInterval > 0 && this.pendingRetries < 1) {
             this.runningPromise.then(() => this.continuePolling());
         }
         return this.runningPromise;

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -95,7 +95,7 @@ export class RxReplicationStateBase<RxDocType> {
         public readonly live?: boolean,
         liveInterval?: number,
         public retryTime?: number,
-        public runInitialReplication?: boolean,
+        public autoStart?: boolean,
     ) {
         let replicationStates = REPLICATION_STATE_BY_COLLECTION.get(collection);
         if (!replicationStates) {
@@ -551,7 +551,7 @@ export function replicateRxCollection<RxDocType>(
         liveInterval = 1000 * 10,
         retryTime = 1000 * 5,
         waitForLeadership,
-        runInitialReplication = true,
+        autoStart = true,
     }: ReplicationOptions<RxDocType>
 ): RxReplicationState<RxDocType> {
 
@@ -572,7 +572,7 @@ export function replicateRxCollection<RxDocType>(
         live,
         liveInterval,
         retryTime,
-        runInitialReplication
+        autoStart
     );
     ensureInteger(replicationState.liveInterval);
     /**
@@ -585,7 +585,7 @@ export function replicateRxCollection<RxDocType>(
         if (replicationState.isStopped()) {
             return;
         }
-        if (runInitialReplication) {
+        if (autoStart) {
             replicationState.run();
         }
         if (replicationState.live && push) {

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -45,4 +45,5 @@ export type SyncOptionsGraphQL<RxDocType> = {
     live?: boolean; // default=false
     liveInterval?: number; // time in milliseconds
     retryTime?: number; // time in milliseconds
+    runInitialReplication?: boolean; // default=true
 };

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -45,5 +45,5 @@ export type SyncOptionsGraphQL<RxDocType> = {
     live?: boolean; // default=false
     liveInterval?: number; // time in milliseconds
     retryTime?: number; // time in milliseconds
-    runInitialReplication?: boolean; // default=true
+    autoStart?: boolean; // default=true
 };

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -104,4 +104,10 @@ export type ReplicationOptions<RxDocType> = {
      * 
      */
     waitForLeadership?: boolean; // default=true
+    /**
+     * Calling `replicateRxCollection()` implies to run a replication.
+     * If set to false, it will not run replication on `replicateRxCollection()`.
+     * This means you need to call replicationState.run() to trigger the first replication.
+     */
+    runInitialReplication?: boolean; // default=true
 }

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -109,5 +109,5 @@ export type ReplicationOptions<RxDocType> = {
      * If set to false, it will not run replication on `replicateRxCollection()`.
      * This means you need to call replicationState.run() to trigger the first replication.
      */
-    runInitialReplication?: boolean; // default=true
+    autoStart?: boolean; // default=true
 }

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -570,9 +570,39 @@ describe('replication.test.js', () => {
         });
     });
     config.parallel('other', () => {
+        describe('runInitialReplication', () => {
+            it('should run first replication by default', async () => {
+                const replicationState = replicateRxCollection({
+                    collection: {
+                        database: {},
+                        onDestroy: {then(){}}
+                    } as RxCollection,
+                    replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                    live: false,
+                    runInitialReplication: true,
+                    waitForLeadership: false
+                });
+                await replicationState.awaitInitialReplication();
+                assert.strictEqual(replicationState.runCount,1);
+            });
+            it('should not run first replication when runInitialReplication is set to false', async () => {
+                const replicationState = replicateRxCollection({
+                    collection: {
+                        database: {},
+                        onDestroy: {then(){}}
+                    } as RxCollection,
+                    replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                    live: false,
+                    runInitialReplication: false,
+                    waitForLeadership: false
+                });
+                // by definition awaitInitialReplication would be infinite
+                assert.strictEqual(replicationState.runCount,0);
+            });
+        });
         describe('.awaitInSync()', () => {
             it('should resolve after some time', async () => {
-                const { localCollection, remoteCollection } = await getTestCollections({ local: 5, remote: 5 });
+                const {localCollection, remoteCollection} = await getTestCollections({local: 5, remote: 5});
 
                 const replicationState = replicateRxCollection({
                     collection: localCollection,

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -570,7 +570,7 @@ describe('replication.test.js', () => {
         });
     });
     config.parallel('other', () => {
-        describe('runInitialReplication', () => {
+        describe('autoStart', () => {
             it('should run first replication by default', async () => {
                 const replicationState = replicateRxCollection({
                     collection: {
@@ -579,13 +579,13 @@ describe('replication.test.js', () => {
                     } as RxCollection,
                     replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
                     live: false,
-                    runInitialReplication: true,
+                    autoStart: true,
                     waitForLeadership: false
                 });
                 await replicationState.awaitInitialReplication();
                 assert.strictEqual(replicationState.runCount,1);
             });
-            it('should not run first replication when runInitialReplication is set to false', async () => {
+            it('should not run first replication when autoStart is set to false', async () => {
                 const replicationState = replicateRxCollection({
                     collection: {
                         database: {},
@@ -593,7 +593,7 @@ describe('replication.test.js', () => {
                     } as RxCollection,
                     replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
                     live: false,
-                    runInitialReplication: false,
+                    autoStart: false,
                     waitForLeadership: false
                 });
                 // by definition awaitInitialReplication would be infinite

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -545,7 +545,7 @@ describe('replication.test.js', () => {
             localCollection.database.destroy();
             remoteCollection.database.destroy();
         });
-        it.only('should push data even if liveInterval is set to 0', async () => {
+        it('should push data even if liveInterval is set to 0', async () => {
             const {localCollection, remoteCollection} = await getTestCollections({local: 0, remote: 0});
             let callProof = null;
             replicateRxCollection({

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -5,7 +5,7 @@
  */
 
 import assert from 'assert';
-import {
+import AsyncTestUtil, {
     clone,
     wait,
     waitUntil
@@ -545,7 +545,7 @@ describe('replication.test.js', () => {
             localCollection.database.destroy();
             remoteCollection.database.destroy();
         });
-        it('should push data even if liveInterval is set to 0', async () => {
+        it.only('should push data even if liveInterval is set to 0', async () => {
             const {localCollection, remoteCollection} = await getTestCollections({local: 0, remote: 0});
             let callProof = null;
             replicateRxCollection({
@@ -561,12 +561,14 @@ describe('replication.test.js', () => {
                     }
                 },
             });
+            // ensure proof is still null once replicateRxCollection()
             assert.strictEqual(callProof, null, 'replicateRxCollection should not trigger a push on init.');
 
             // insert a new doc to trigger a push
-            const docData = schemaObjects.humanWithTimestamp();
-            docData.age = 0;
-            await localCollection.insert(docData);
+            await localCollection.insert(schemaObjects.humanWithTimestamp());
+
+            // wait for storage propagation
+            await AsyncTestUtil.wait(100);
 
             assert.strictEqual(callProof, 'yeah', 'Throwing pull handler should be called');
             localCollection.database.destroy();

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -602,6 +602,9 @@ describe('replication.test.js', () => {
                     autoStart: false,
                     waitForLeadership: false
                 });
+
+                await wait(100);
+
                 // by definition awaitInitialReplication would be infinite
                 assert.strictEqual(replicationState.runCount,0);
             });


### PR DESCRIPTION
## This PR contains:

- A NEW FEATURE PROPOSAL

## Describe the problem you have without this PR

`replicateRxCollection()` provides a way to configure the way to replicate a given collection.
However, by default, this function also run an initial replication as side effect.

IMHO, it's a matter of separation of concerns:

The moment to configure collections and replications is not always the same we get ready to do the first replication.
I would like to trigger replications collection by collection and keep control on the order, the timing... and separately from the replication definition.

I suggest to add an option to prevent the default first replication and separate the replication configuration and triggering.

This PR adds new option `runInitialReplication`.
It could be set to false to avoid  `initialReplication` on `replicateRxCollection()`.
default to `true` to avoid breaking change

Please consider this PR as a draft and support for discussions.
I know this issue is an opinionated one, feel free to challenge it ;)
