### PR TITLE
fix async issue with createRxCollection

### DIFF
--- a/src/plugins/dexie/rx-storage-instance-dexie.ts
+++ b/src/plugins/dexie/rx-storage-instance-dexie.ts
@@ -398,7 +398,7 @@ export async function createDexieStorageInstance<RxDocType>(
     params: RxStorageInstanceCreationParams<RxDocType, DexieSettings>,
     settings: DexieSettings
 ): Promise<RxStorageInstanceDexie<RxDocType>> {
-    const internals = getDexieDbWithTables(
+    const internals = await getDexieDbWithTables(
         params.databaseName,
         params.collectionName,
         settings,


### PR DESCRIPTION
 - A BUGFIX
`await createRxCollection()` is resolved before the collection effectively exists.

see https://github.com/pubkey/rxdb/pull/3785/files#diff-8ea39e301dabaa32bb709cda31fb3daba268eda0f3ca80b9d55496af53edb96dR691
where `wait(100)` is required before testing the `createRxCollection` result.

@pubkey I'm not really sure about underlying impacts of that change.
