### PR TITLE
 export 'getLastPushSequence' was not found in 'rxdb/plugins/replicat…

### DIFF
--- a/examples/graphql/client/index.js
+++ b/examples/graphql/client/index.js
@@ -35,7 +35,7 @@ import {
     pushQueryBuilderFromRxSchema
 } from 'rxdb/plugins/replication-graphql';
 import {
-    getLastPushSequence
+    getLastPushCheckpoint
 } from 'rxdb/plugins/replication';
 addRxPlugin(RxDBReplicationGraphQLPlugin);
 
@@ -207,7 +207,7 @@ async function run() {
         });
 
         setInterval(async () => {
-            var last = await getLastPushSequence(
+            var last = await getLastPushCheckpoint(
                 db.hero,
                 replicationState.endpointHash
             );


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains: 
- A BUGFIX
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
I was trying the graphql example project (https://github.com/pubkey/rxdb/tree/master/examples/graphql), after the last  `npm start` I got:
 _export 'getLastPushSequence' (imported as 'getLastPushSequence') was not found in 'rxdb/plugins/replication'_

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
