### PR TITLE
ADD data extraction function for GraphQL replication

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -151,9 +151,14 @@ export function syncGraphQL<RxDocType>(
                     }
                 }
 
-                const dataPath = pull.dataPath || ['data', Object.keys(result.data)[0]];
-                const docsData: any[] = objectPath.get(result, dataPath);
-
+                let docsData: any[] = [] 
+                if (!pull.dataPath || typeof pull.dataPath === 'string') {
+                    const dataPath = pull.dataPath || ['data', Object.keys(result.data)[0]];
+                    docsData = objectPath.get(result, dataPath);
+                } else {
+                    docsData = pull.dataPath(result)
+                }
+                
                 // optimization shortcut, do not proceed if there are no documents.
                 if (docsData.length === 0) {
                     return {

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -27,7 +27,7 @@ export interface GraphQLSyncPullOptions<RxDocType> {
      */
     batchSize: number;
     modifier?: (doc: RxDocType | any) => Promise<any> | any;
-    dataPath?: string;
+    dataPath?: string | ((result: any) => any[]);
 }
 export interface GraphQLSyncPushOptions<RxDocType> {
     queryBuilder: RxGraphQLReplicationPushQueryBuilder;


### PR DESCRIPTION
## This PR contains:
 - A NEW FEATURE

## Describe the problem you have without this PR
Currently the ability to extract data from the GraphQL query result inside the pull handler for GraphQL replication feels very limited. There is no way to handle nested arrays using only data path based extraction

## Todos
- [x] Tests
- [ ] Documentation
- [x] Typings
- [ ] Changelog