### PR TITLE
FIX dev-mode fail (patternProperties with regex)

### DIFF
--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -3,550 +3,561 @@
  * to ensure nothing is broken or not supported
  */
 
-import objectPath from 'object-path';
-import {
-    newRxError
-} from '../../rx-error';
-import { getPrimaryFieldOfPrimaryKey, getSchemaByObjectPath } from '../../rx-schema-helper';
-import type {
-    CompositePrimaryKey,
-    JsonSchema,
-    JsonSchemaTypes,
-    RxJsonSchema,
-    TopLevelProperty
-} from '../../types';
-import {
-    flattenObject, isMaybeReadonlyArray,
-    trimDots
-} from '../../util';
-import { rxDocumentProperties } from './entity-properties';
+ import objectPath from 'object-path';
+ import {
+     newRxError
+ } from '../../rx-error';
+ import { getPrimaryFieldOfPrimaryKey, getSchemaByObjectPath } from '../../rx-schema-helper';
+ import type {
+     CompositePrimaryKey,
+     JsonSchema,
+     JsonSchemaTypes,
+     RxJsonSchema,
+     TopLevelProperty
+ } from '../../types';
+ import {
+     flattenObject, isMaybeReadonlyArray,
+     trimDots
+ } from '../../util';
+ import { rxDocumentProperties } from './entity-properties';
 
-/**
- * checks if the fieldname is allowed
- * this makes sure that the fieldnames can be transformed into javascript-vars
- * and does not conquer the observe$ and populate_ fields
- * @throws {Error}
- */
-export function checkFieldNameRegex(fieldName: string) {
-    if (fieldName === '_deleted') {
-        return;
-    }
+ /**
+  * checks if the fieldname is allowed
+  * this makes sure that the fieldnames can be transformed into javascript-vars
+  * and does not conquer the observe$ and populate_ fields
+  * @throws {Error}
+  */
+ export function checkFieldNameRegex(fieldName: string, path: string) {
+     if (fieldName === '_deleted') {
+         return;
+     }
 
-    if (['properties', 'language'].includes(fieldName)) {
-        throw newRxError('SC23', {
-            fieldName
-        });
-    }
+     if (['properties', 'language'].includes(fieldName)) {
+         throw newRxError('SC23', {
+             fieldName
+         });
+     }
 
-    const regexStr = '^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$';
-    const regex = new RegExp(regexStr);
-    if (
-        /**
-         * It must be allowed to set _id as primaryKey.
-         * This makes it sometimes easier to work with RxDB+CouchDB
-         * @link https://github.com/pubkey/rxdb/issues/681
-         */
-        fieldName !== '_id' &&
-        !fieldName.match(regex)
-    ) {
-        throw newRxError('SC1', {
-            regex: regexStr,
-            fieldName
-        });
-    }
-}
+     if (/\.patternProperties$/.test(path)) {
+         /**
+          * excludes keys of patternProperties from field name check,
+          * since they're supposed to be regular expressions
+          * (https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2)
+          *
+          * this only affects property attributes
+          */
+         return;
+     }
 
-/**
- * validate that all schema-related things are ok
- */
-export function validateFieldsDeep(rxJsonSchema: RxJsonSchema<any>): true {
+     const regexStr = '^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$';
+     const regex = new RegExp(regexStr);
+     if (
+         /**
+          * It must be allowed to set _id as primaryKey.
+          * This makes it sometimes easier to work with RxDB+CouchDB
+          * @link https://github.com/pubkey/rxdb/issues/681
+          */
+         fieldName !== '_id' &&
+         !fieldName.match(regex)
+     ) {
+         throw newRxError('SC1', {
+             regex: regexStr,
+             fieldName
+         });
+     }
+ }
 
-    const primaryPath = getPrimaryFieldOfPrimaryKey(rxJsonSchema.primaryKey);
+ /**
+  * validate that all schema-related things are ok
+  */
+ export function validateFieldsDeep(rxJsonSchema: RxJsonSchema<any>): true {
 
-    function checkField(
-        fieldName: string,
-        schemaObj: any,
-        path: string
-    ) {
-        if (
-            typeof fieldName === 'string' &&
-            typeof schemaObj === 'object' &&
-            !Array.isArray(schemaObj)
-        ) checkFieldNameRegex(fieldName);
+     const primaryPath = getPrimaryFieldOfPrimaryKey(rxJsonSchema.primaryKey);
 
-        // 'item' only allowed it type=='array'
-        if (schemaObj.hasOwnProperty('item') && schemaObj.type !== 'array') {
-            throw newRxError('SC2', {
-                fieldName
-            });
-        }
+     function checkField(
+         fieldName: string,
+         schemaObj: any,
+         path: string
+     ) {
+         if (
+             typeof fieldName === 'string' &&
+             typeof schemaObj === 'object' &&
+             !Array.isArray(schemaObj)
+         ) checkFieldNameRegex(fieldName, path);
 
-        /**
-         * required fields cannot be set via 'required: true',
-         * but must be set via required: []
-         */
-        if (schemaObj.hasOwnProperty('required') && typeof schemaObj.required === 'boolean') {
-            throw newRxError('SC24', {
-                fieldName
-            });
-        }
+         // 'item' only allowed it type=='array'
+         if (schemaObj.hasOwnProperty('item') && schemaObj.type !== 'array') {
+             throw newRxError('SC2', {
+                 fieldName
+             });
+         }
 
-
-        // if ref given, must be type=='string', type=='array' with string-items or type==['string','null']
-        if (schemaObj.hasOwnProperty('ref')) {
-            if (Array.isArray(schemaObj.type)) {
-                if (schemaObj.type.length > 2 || !schemaObj.type.includes('string') || !schemaObj.type.includes('null')) {
-                    throw newRxError('SC4', {
-                        fieldName
-                    });
-                }
-            } else {
-                switch (schemaObj.type) {
-                    case 'string':
-                        break;
-                    case 'array':
-                        if (!schemaObj.items || !schemaObj.items.type || schemaObj.items.type !== 'string') {
-                            throw newRxError('SC3', {
-                                fieldName
-                            });
-                        }
-                        break;
-                    default:
-                        throw newRxError('SC4', {
-                            fieldName
-                        });
-                }
-            }
-        }
-
-        const isNested = path.split('.').length >= 2;
-
-        // nested only
-        if (isNested) {
-            if (schemaObj.primary) {
-                throw newRxError('SC6', {
-                    path,
-                    primary: schemaObj.primary
-                });
-            }
-
-            if (schemaObj.default) {
-                throw newRxError('SC7', {
-                    path
-                });
-            }
-        }
-
-        // first level
-        if (!isNested) {
-
-            // if _id is used, it must be primaryKey
-            if (
-                fieldName === '_id' &&
-                primaryPath !== '_id'
-            ) {
-                throw newRxError('COL2', {
-                    fieldName
-                });
-            }
-
-            // check underscore fields
-            if (fieldName.charAt(0) === '_') {
-                if (
-                    // exceptional allow underscore on these fields.
-                    fieldName === '_id' ||
-                    fieldName === '_deleted'
-                ) {
-                    return;
-                }
-                throw newRxError('SC8', {
-                    fieldName
-                });
-            }
-        }
-    }
-
-    function traverse(currentObj: any, currentPath: any) {
-        if (typeof currentObj !== 'object') return;
-        Object.keys(currentObj).forEach(attributeName => {
-            if (!currentObj.properties) {
-                checkField(
-                    attributeName,
-                    currentObj[attributeName],
-                    currentPath
-                );
-            }
-            let nextPath = currentPath;
-            if (attributeName !== 'properties') nextPath = nextPath + '.' + attributeName;
-            traverse(currentObj[attributeName], nextPath);
-        });
-    }
-    traverse(rxJsonSchema, '');
-    return true;
-}
-
-export function checkPrimaryKey(
-    jsonSchema: RxJsonSchema<any>
-) {
-    if (!jsonSchema.primaryKey) {
-        throw newRxError('SC30', { schema: jsonSchema });
-    }
+         /**
+          * required fields cannot be set via 'required: true',
+          * but must be set via required: []
+          */
+         if (schemaObj.hasOwnProperty('required') && typeof schemaObj.required === 'boolean') {
+             throw newRxError('SC24', {
+                 fieldName
+             });
+         }
 
 
+         // if ref given, must be type=='string', type=='array' with string-items or type==['string','null']
+         if (schemaObj.hasOwnProperty('ref')) {
+             if (Array.isArray(schemaObj.type)) {
+                 if (schemaObj.type.length > 2 || !schemaObj.type.includes('string') || !schemaObj.type.includes('null')) {
+                     throw newRxError('SC4', {
+                         fieldName
+                     });
+                 }
+             } else {
+                 switch (schemaObj.type) {
+                     case 'string':
+                         break;
+                     case 'array':
+                         if (!schemaObj.items || !schemaObj.items.type || schemaObj.items.type !== 'string') {
+                             throw newRxError('SC3', {
+                                 fieldName
+                             });
+                         }
+                         break;
+                     default:
+                         throw newRxError('SC4', {
+                             fieldName
+                         });
+                 }
+             }
+         }
 
-    function validatePrimarySchemaPart(
-        schemaPart: JsonSchema | TopLevelProperty
-    ) {
-        if (!schemaPart) {
-            throw newRxError('SC33', { schema: jsonSchema });
-        }
+         const isNested = path.split('.').length >= 2;
 
-        const type: string = schemaPart.type as any;
-        if (
-            !type ||
-            !['string', 'number', 'integer'].includes(type)
-        ) {
-            throw newRxError('SC32', { schema: jsonSchema, args: { schemaPart } });
-        }
-    }
+         // nested only
+         if (isNested) {
+             if (schemaObj.primary) {
+                 throw newRxError('SC6', {
+                     path,
+                     primary: schemaObj.primary
+                 });
+             }
 
-    if (typeof jsonSchema.primaryKey === 'string') {
-        const key = jsonSchema.primaryKey;
-        const schemaPart = jsonSchema.properties[key];
-        validatePrimarySchemaPart(schemaPart);
-    } else {
-        const compositePrimaryKey: CompositePrimaryKey<any> = jsonSchema.primaryKey as any;
+             if (schemaObj.default) {
+                 throw newRxError('SC7', {
+                     path
+                 });
+             }
+         }
 
-        const keySchemaPart = getSchemaByObjectPath(jsonSchema, compositePrimaryKey.key);
-        validatePrimarySchemaPart(keySchemaPart);
+         // first level
+         if (!isNested) {
 
-        compositePrimaryKey.fields.forEach(field => {
-            const schemaPart = getSchemaByObjectPath(jsonSchema, field);
-            validatePrimarySchemaPart(schemaPart);
-        });
-    }
+             // if _id is used, it must be primaryKey
+             if (
+                 fieldName === '_id' &&
+                 primaryPath !== '_id'
+             ) {
+                 throw newRxError('COL2', {
+                     fieldName
+                 });
+             }
 
+             // check underscore fields
+             if (fieldName.charAt(0) === '_') {
+                 if (
+                     // exceptional allow underscore on these fields.
+                     fieldName === '_id' ||
+                     fieldName === '_deleted'
+                 ) {
+                     return;
+                 }
+                 throw newRxError('SC8', {
+                     fieldName
+                 });
+             }
+         }
+     }
 
-    /**
-     * The primary key must have a maxLength set
-     * which is required by some RxStorage implementations
-     * to ensure we can craft custom index strings.
-     */
-    const primaryPath = getPrimaryFieldOfPrimaryKey(jsonSchema.primaryKey);
-    const primaryPathSchemaPart = jsonSchema.properties[primaryPath];
-    if (!primaryPathSchemaPart.maxLength) {
-        throw newRxError('SC39', { schema: jsonSchema, args: { primaryPathSchemaPart } });
-    }
-}
+     function traverse(currentObj: any, currentPath: any) {
+         if (typeof currentObj !== 'object') return;
+         Object.keys(currentObj).forEach(attributeName => {
+             if (!currentObj.properties) {
+                 checkField(
+                     attributeName,
+                     currentObj[attributeName],
+                     currentPath
+                 );
+             }
+             let nextPath = currentPath;
+             if (attributeName !== 'properties') nextPath = nextPath + '.' + attributeName;
+             traverse(currentObj[attributeName], nextPath);
+         });
+     }
+     traverse(rxJsonSchema, '');
+     return true;
+ }
 
-/**
- * computes real path of the object path in the collection schema
- */
-function getSchemaPropertyRealPath(shortPath: string) {
-    const pathParts = shortPath.split('.');
-    let realPath = '';
-    for (let i = 0; i < pathParts.length; i += 1) {
-        if (pathParts[i] !== '[]') {
-            realPath = realPath.concat('.properties.'.concat(pathParts[i]));
-        } else {
-            realPath = realPath.concat('.items');
-        }
-    }
-    return trimDots(realPath);
-}
-
-/**
- * does the checking
- * @throws {Error} if something is not ok
- */
-export function checkSchema(jsonSchema: RxJsonSchema<any>) {
-
-    if (!jsonSchema.primaryKey) {
-        throw newRxError('SC30', {
-            schema: jsonSchema
-        });
-    }
-
-    if (!jsonSchema.hasOwnProperty('properties')) {
-        throw newRxError('SC29', {
-            schema: jsonSchema
-        });
-    }
-
-    // _rev MUST NOT exist, it is added by RxDB
-    if (jsonSchema.properties._rev) {
-        throw newRxError('SC10', {
-            schema: jsonSchema
-        });
-    }
-
-    // check version
-    if (!jsonSchema.hasOwnProperty('version') ||
-        typeof jsonSchema.version !== 'number' ||
-        jsonSchema.version < 0
-    ) {
-        throw newRxError('SC11', {
-            version: jsonSchema.version
-        });
-    }
-
-    validateFieldsDeep(jsonSchema);
-    checkPrimaryKey(jsonSchema);
-
-    Object.keys(jsonSchema.properties).forEach(key => {
-        const value: any = jsonSchema.properties[key];
-        // check primary
-        if (key === jsonSchema.primaryKey) {
-            if (jsonSchema.indexes && jsonSchema.indexes.includes(key)) {
-                throw newRxError('SC13', {
-                    value,
-                    schema: jsonSchema
-                });
-            }
-            if (value.unique) {
-                throw newRxError('SC14', {
-                    value,
-                    schema: jsonSchema
-                });
-            }
-            if (jsonSchema.encrypted && jsonSchema.encrypted.includes(key)) {
-                throw newRxError('SC15', {
-                    value,
-                    schema: jsonSchema
-                });
-            }
-            if (value.type !== 'string') {
-                throw newRxError('SC16', {
-                    value,
-                    schema: jsonSchema
-                });
-            }
-        }
-
-        // check if RxDocument-property
-        if (rxDocumentProperties().includes(key)) {
-            throw newRxError('SC17', {
-                key,
-                schema: jsonSchema
-            });
-        }
-    });
-
-    // check format of jsonSchema.indexes
-    if (jsonSchema.indexes) {
-        // should be an array
-        if (!isMaybeReadonlyArray(jsonSchema.indexes)) {
-            throw newRxError('SC18', {
-                indexes: jsonSchema.indexes,
-                schema: jsonSchema
-            });
-        }
-
-        jsonSchema.indexes.forEach(index => {
-            // should contain strings or array of strings
-            if (!(typeof index === 'string' || Array.isArray(index))) {
-                throw newRxError('SC19', { index, schema: jsonSchema });
-            }
-            // if is a compound index it must contain strings
-            if (Array.isArray(index)) {
-                for (let i = 0; i < index.length; i += 1) {
-                    if (typeof index[i] !== 'string') {
-                        throw newRxError('SC20', { index, schema: jsonSchema });
-                    }
-                }
-            }
-
-            /**
-             * To be able to craft custom indexable string with compound fields,
-             * we need to know the maximum fieldlength of the fields values
-             * when they are transformed to strings.
-             * Therefore we need to enforce some properties inside of the schema.
-             */
-            const indexAsArray = isMaybeReadonlyArray(index) ? index : [index];
-            indexAsArray.forEach(fieldName => {
-                const schemaPart = getSchemaByObjectPath(
-                    jsonSchema,
-                    fieldName
-                );
+ export function checkPrimaryKey(
+     jsonSchema: RxJsonSchema<any>
+ ) {
+     if (!jsonSchema.primaryKey) {
+         throw newRxError('SC30', { schema: jsonSchema });
+     }
 
 
-                const type: JsonSchemaTypes = schemaPart.type as any;
-                switch (type) {
-                    case 'string':
-                        const maxLength = schemaPart.maxLength;
-                        if (!maxLength) {
-                            throw newRxError('SC34', {
-                                index,
-                                field: fieldName,
-                                schema: jsonSchema
-                            });
-                        }
-                        break;
-                    case 'number':
-                    case 'integer':
-                        const multipleOf = schemaPart.multipleOf;
-                        if (!multipleOf) {
-                            throw newRxError('SC35', {
-                                index,
-                                field: fieldName,
-                                schema: jsonSchema
-                            });
-                        }
-                        const maximum = schemaPart.maximum;
-                        const minimum = schemaPart.minimum;
-                        if (
-                            typeof maximum === 'undefined' ||
-                            typeof minimum === 'undefined'
-                        ) {
-                            throw newRxError('SC37', {
-                                index,
-                                field: fieldName,
-                                schema: jsonSchema
-                            });
-                        }
-                        break;
-                    case 'boolean':
-                        /**
-                         * If a boolean field is used as an index,
-                         * it must be required.
-                         */
-                        let parentPath = '';
-                        let lastPathPart = fieldName;
-                        if (fieldName.includes('.')) {
-                            const partParts = fieldName.split('.');
-                            lastPathPart = partParts.pop();
-                            parentPath = partParts.join('.');
-                        }
-                        const parentSchemaPart = getSchemaByObjectPath(
-                            jsonSchema,
-                            parentPath
-                        );
-                        if (
-                            !parentSchemaPart.required ||
-                            !parentSchemaPart.required.includes(lastPathPart)
-                        ) {
-                            throw newRxError('SC38', {
-                                index,
-                                field: fieldName,
-                                schema: jsonSchema
-                            });
-                        }
-                        break;
 
-                    default:
-                        throw newRxError('SC36', {
-                            fieldName,
-                            type: schemaPart.type as any,
-                            schema: jsonSchema,
-                        });
-                }
-            });
+     function validatePrimarySchemaPart(
+         schemaPart: JsonSchema | TopLevelProperty
+     ) {
+         if (!schemaPart) {
+             throw newRxError('SC33', { schema: jsonSchema });
+         }
 
-        });
-    }
+         const type: string = schemaPart.type as any;
+         if (
+             !type ||
+             !['string', 'number', 'integer'].includes(type)
+         ) {
+             throw newRxError('SC32', { schema: jsonSchema, args: { schemaPart } });
+         }
+     }
 
-    // remove backward-compatibility for index: true
-    Object.keys(flattenObject(jsonSchema))
-        .map(key => {
-            // flattenObject returns only ending paths, we need all paths pointing to an object
-            const splitted = key.split('.');
-            splitted.pop(); // all but last
-            return splitted.join('.');
-        })
-        .filter(key => key !== '')
-        .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // unique
-        .filter(key => { // check if this path defines an index
-            const value = objectPath.get(jsonSchema, key);
-            return !!value.index;
-        })
-        .forEach(key => { // replace inner properties
-            key = key.replace('properties.', ''); // first
-            key = key.replace(/\.properties\./g, '.'); // middle
-            throw newRxError('SC26', {
-                index: trimDots(key),
-                schema: jsonSchema
-            });
-        });
+     if (typeof jsonSchema.primaryKey === 'string') {
+         const key = jsonSchema.primaryKey;
+         const schemaPart = jsonSchema.properties[key];
+         validatePrimarySchemaPart(schemaPart);
+     } else {
+         const compositePrimaryKey: CompositePrimaryKey<any> = jsonSchema.primaryKey as any;
 
-    /* check types of the indexes */
-    (jsonSchema.indexes || [])
-        .reduce((indexPaths: string[], currentIndex) => {
-            if (isMaybeReadonlyArray(currentIndex)) {
-                indexPaths.concat(currentIndex);
-            } else {
-                indexPaths.push(currentIndex);
-            }
-            return indexPaths;
-        }, [])
-        .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // from now on working only with unique indexes
-        .map(indexPath => {
-            const realPath = getSchemaPropertyRealPath(indexPath); // real path in the collection schema
-            const schemaObj = objectPath.get(jsonSchema, realPath); // get the schema of the indexed property
-            if (!schemaObj || typeof schemaObj !== 'object') {
-                throw newRxError('SC21', {
-                    index: indexPath,
-                    schema: jsonSchema
-                });
-            }
-            return { indexPath, schemaObj };
-        })
-        .filter(index =>
-            index.schemaObj.type !== 'string' &&
-            index.schemaObj.type !== 'integer' &&
-            index.schemaObj.type !== 'number'
-        )
-        .forEach(index => {
-            throw newRxError('SC22', {
-                key: index.indexPath,
-                type: index.schemaObj.type,
-                schema: jsonSchema
-            });
-        });
+         const keySchemaPart = getSchemaByObjectPath(jsonSchema, compositePrimaryKey.key);
+         validatePrimarySchemaPart(keySchemaPart);
+
+         compositePrimaryKey.fields.forEach(field => {
+             const schemaPart = getSchemaByObjectPath(jsonSchema, field);
+             validatePrimarySchemaPart(schemaPart);
+         });
+     }
 
 
-    /**
-     * TODO
-     * in 9.0.0 we changed the way encrypted fields are defined
-     * This check ensures people do not oversee the breaking change
-     * Remove this check in the future
-     */
-    Object.keys(flattenObject(jsonSchema))
-        .map(key => {
-            // flattenObject returns only ending paths, we need all paths pointing to an object
-            const splitted = key.split('.');
-            splitted.pop(); // all but last
-            return splitted.join('.');
-        })
-        .filter(key => key !== '' && key !== 'attachments')
-        .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // unique
-        .filter(key => {
-            // check if this path defines an encrypted field
-            const value = objectPath.get(jsonSchema, key);
-            return !!value.encrypted;
-        })
-        .forEach(key => { // replace inner properties
-            key = key.replace('properties.', ''); // first
-            key = key.replace(/\.properties\./g, '.'); // middle
-            throw newRxError('SC27', {
-                index: trimDots(key),
-                schema: jsonSchema
-            });
-        });
+     /**
+      * The primary key must have a maxLength set
+      * which is required by some RxStorage implementations
+      * to ensure we can craft custom index strings.
+      */
+     const primaryPath = getPrimaryFieldOfPrimaryKey(jsonSchema.primaryKey);
+     const primaryPathSchemaPart = jsonSchema.properties[primaryPath];
+     if (!primaryPathSchemaPart.maxLength) {
+         throw newRxError('SC39', { schema: jsonSchema, args: { primaryPathSchemaPart } });
+     }
+ }
 
-    /* ensure encrypted fields exist in the schema */
-    if (jsonSchema.encrypted) {
-        jsonSchema.encrypted
-            .forEach(propPath => {
-                // real path in the collection schema
-                const realPath = getSchemaPropertyRealPath(propPath);
-                // get the schema of the indexed property
-                const schemaObj = objectPath.get(jsonSchema, realPath);
-                if (!schemaObj || typeof schemaObj !== 'object') {
-                    throw newRxError('SC28', {
-                        field: propPath,
-                        schema: jsonSchema
-                    });
-                }
-            });
-    }
-}
+ /**
+  * computes real path of the object path in the collection schema
+  */
+ function getSchemaPropertyRealPath(shortPath: string) {
+     const pathParts = shortPath.split('.');
+     let realPath = '';
+     for (let i = 0; i < pathParts.length; i += 1) {
+         if (pathParts[i] !== '[]') {
+             realPath = realPath.concat('.properties.'.concat(pathParts[i]));
+         } else {
+             realPath = realPath.concat('.items');
+         }
+     }
+     return trimDots(realPath);
+ }
+
+ /**
+  * does the checking
+  * @throws {Error} if something is not ok
+  */
+ export function checkSchema(jsonSchema: RxJsonSchema<any>) {
+
+     if (!jsonSchema.primaryKey) {
+         throw newRxError('SC30', {
+             schema: jsonSchema
+         });
+     }
+
+     if (!jsonSchema.hasOwnProperty('properties')) {
+         throw newRxError('SC29', {
+             schema: jsonSchema
+         });
+     }
+
+     // _rev MUST NOT exist, it is added by RxDB
+     if (jsonSchema.properties._rev) {
+         throw newRxError('SC10', {
+             schema: jsonSchema
+         });
+     }
+
+     // check version
+     if (!jsonSchema.hasOwnProperty('version') ||
+         typeof jsonSchema.version !== 'number' ||
+         jsonSchema.version < 0
+     ) {
+         throw newRxError('SC11', {
+             version: jsonSchema.version
+         });
+     }
+
+     validateFieldsDeep(jsonSchema);
+     checkPrimaryKey(jsonSchema);
+
+     Object.keys(jsonSchema.properties).forEach(key => {
+         const value: any = jsonSchema.properties[key];
+         // check primary
+         if (key === jsonSchema.primaryKey) {
+             if (jsonSchema.indexes && jsonSchema.indexes.includes(key)) {
+                 throw newRxError('SC13', {
+                     value,
+                     schema: jsonSchema
+                 });
+             }
+             if (value.unique) {
+                 throw newRxError('SC14', {
+                     value,
+                     schema: jsonSchema
+                 });
+             }
+             if (jsonSchema.encrypted && jsonSchema.encrypted.includes(key)) {
+                 throw newRxError('SC15', {
+                     value,
+                     schema: jsonSchema
+                 });
+             }
+             if (value.type !== 'string') {
+                 throw newRxError('SC16', {
+                     value,
+                     schema: jsonSchema
+                 });
+             }
+         }
+
+         // check if RxDocument-property
+         if (rxDocumentProperties().includes(key)) {
+             throw newRxError('SC17', {
+                 key,
+                 schema: jsonSchema
+             });
+         }
+     });
+
+     // check format of jsonSchema.indexes
+     if (jsonSchema.indexes) {
+         // should be an array
+         if (!isMaybeReadonlyArray(jsonSchema.indexes)) {
+             throw newRxError('SC18', {
+                 indexes: jsonSchema.indexes,
+                 schema: jsonSchema
+             });
+         }
+
+         jsonSchema.indexes.forEach(index => {
+             // should contain strings or array of strings
+             if (!(typeof index === 'string' || Array.isArray(index))) {
+                 throw newRxError('SC19', { index, schema: jsonSchema });
+             }
+             // if is a compound index it must contain strings
+             if (Array.isArray(index)) {
+                 for (let i = 0; i < index.length; i += 1) {
+                     if (typeof index[i] !== 'string') {
+                         throw newRxError('SC20', { index, schema: jsonSchema });
+                     }
+                 }
+             }
+
+             /**
+              * To be able to craft custom indexable string with compound fields,
+              * we need to know the maximum fieldlength of the fields values
+              * when they are transformed to strings.
+              * Therefore we need to enforce some properties inside of the schema.
+              */
+             const indexAsArray = isMaybeReadonlyArray(index) ? index : [index];
+             indexAsArray.forEach(fieldName => {
+                 const schemaPart = getSchemaByObjectPath(
+                     jsonSchema,
+                     fieldName
+                 );
+
+
+                 const type: JsonSchemaTypes = schemaPart.type as any;
+                 switch (type) {
+                     case 'string':
+                         const maxLength = schemaPart.maxLength;
+                         if (!maxLength) {
+                             throw newRxError('SC34', {
+                                 index,
+                                 field: fieldName,
+                                 schema: jsonSchema
+                             });
+                         }
+                         break;
+                     case 'number':
+                     case 'integer':
+                         const multipleOf = schemaPart.multipleOf;
+                         if (!multipleOf) {
+                             throw newRxError('SC35', {
+                                 index,
+                                 field: fieldName,
+                                 schema: jsonSchema
+                             });
+                         }
+                         const maximum = schemaPart.maximum;
+                         const minimum = schemaPart.minimum;
+                         if (
+                             typeof maximum === 'undefined' ||
+                             typeof minimum === 'undefined'
+                         ) {
+                             throw newRxError('SC37', {
+                                 index,
+                                 field: fieldName,
+                                 schema: jsonSchema
+                             });
+                         }
+                         break;
+                     case 'boolean':
+                         /**
+                          * If a boolean field is used as an index,
+                          * it must be required.
+                          */
+                         let parentPath = '';
+                         let lastPathPart = fieldName;
+                         if (fieldName.includes('.')) {
+                             const partParts = fieldName.split('.');
+                             lastPathPart = partParts.pop();
+                             parentPath = partParts.join('.');
+                         }
+                         const parentSchemaPart = getSchemaByObjectPath(
+                             jsonSchema,
+                             parentPath
+                         );
+                         if (
+                             !parentSchemaPart.required ||
+                             !parentSchemaPart.required.includes(lastPathPart)
+                         ) {
+                             throw newRxError('SC38', {
+                                 index,
+                                 field: fieldName,
+                                 schema: jsonSchema
+                             });
+                         }
+                         break;
+
+                     default:
+                         throw newRxError('SC36', {
+                             fieldName,
+                             type: schemaPart.type as any,
+                             schema: jsonSchema,
+                         });
+                 }
+             });
+
+         });
+     }
+
+     // remove backward-compatibility for index: true
+     Object.keys(flattenObject(jsonSchema))
+         .map(key => {
+             // flattenObject returns only ending paths, we need all paths pointing to an object
+             const splitted = key.split('.');
+             splitted.pop(); // all but last
+             return splitted.join('.');
+         })
+         .filter(key => key !== '')
+         .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // unique
+         .filter(key => { // check if this path defines an index
+             const value = objectPath.get(jsonSchema, key);
+             return !!value.index;
+         })
+         .forEach(key => { // replace inner properties
+             key = key.replace('properties.', ''); // first
+             key = key.replace(/\.properties\./g, '.'); // middle
+             throw newRxError('SC26', {
+                 index: trimDots(key),
+                 schema: jsonSchema
+             });
+         });
+
+     /* check types of the indexes */
+     (jsonSchema.indexes || [])
+         .reduce((indexPaths: string[], currentIndex) => {
+             if (isMaybeReadonlyArray(currentIndex)) {
+                 indexPaths.concat(currentIndex);
+             } else {
+                 indexPaths.push(currentIndex);
+             }
+             return indexPaths;
+         }, [])
+         .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // from now on working only with unique indexes
+         .map(indexPath => {
+             const realPath = getSchemaPropertyRealPath(indexPath); // real path in the collection schema
+             const schemaObj = objectPath.get(jsonSchema, realPath); // get the schema of the indexed property
+             if (!schemaObj || typeof schemaObj !== 'object') {
+                 throw newRxError('SC21', {
+                     index: indexPath,
+                     schema: jsonSchema
+                 });
+             }
+             return { indexPath, schemaObj };
+         })
+         .filter(index =>
+             index.schemaObj.type !== 'string' &&
+             index.schemaObj.type !== 'integer' &&
+             index.schemaObj.type !== 'number'
+         )
+         .forEach(index => {
+             throw newRxError('SC22', {
+                 key: index.indexPath,
+                 type: index.schemaObj.type,
+                 schema: jsonSchema
+             });
+         });
+
+
+     /**
+      * TODO
+      * in 9.0.0 we changed the way encrypted fields are defined
+      * This check ensures people do not oversee the breaking change
+      * Remove this check in the future
+      */
+     Object.keys(flattenObject(jsonSchema))
+         .map(key => {
+             // flattenObject returns only ending paths, we need all paths pointing to an object
+             const splitted = key.split('.');
+             splitted.pop(); // all but last
+             return splitted.join('.');
+         })
+         .filter(key => key !== '' && key !== 'attachments')
+         .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // unique
+         .filter(key => {
+             // check if this path defines an encrypted field
+             const value = objectPath.get(jsonSchema, key);
+             return !!value.encrypted;
+         })
+         .forEach(key => { // replace inner properties
+             key = key.replace('properties.', ''); // first
+             key = key.replace(/\.properties\./g, '.'); // middle
+             throw newRxError('SC27', {
+                 index: trimDots(key),
+                 schema: jsonSchema
+             });
+         });
+
+     /* ensure encrypted fields exist in the schema */
+     if (jsonSchema.encrypted) {
+         jsonSchema.encrypted
+             .forEach(propPath => {
+                 // real path in the collection schema
+                 const realPath = getSchemaPropertyRealPath(propPath);
+                 // get the schema of the indexed property
+                 const schemaObj = objectPath.get(jsonSchema, realPath);
+                 if (!schemaObj || typeof schemaObj !== 'object') {
+                     throw newRxError('SC28', {
+                         field: propPath,
+                         schema: jsonSchema
+                     });
+                 }
+             });
+     }
+ }

--- a/test/helper/schema-objects.ts
+++ b/test/helper/schema-objects.ts
@@ -2,405 +2,436 @@
  * this file contains objects which match the schemas in schemas.js
  */
 
-import faker from 'faker';
+ import faker from 'faker';
 
-import {
-    randomNumber,
-    randomString
-} from 'async-test-util';
-import { HumanDocumentType } from './schemas';
+ import {
+     randomNumber,
+     randomString
+ } from 'async-test-util';
+ import { HumanDocumentType } from './schemas';
 
 
-export interface SimpleHumanDocumentType {
-    passportId: string;
-    firstName: string;
-    lastName: string;
-}
+ export interface SimpleHumanDocumentType {
+     passportId: string;
+     firstName: string;
+     lastName: string;
+ }
 
-export function human(
-    passportId: string = randomString(12),
-    age: number = randomNumber(10, 50)
-): HumanDocumentType {
-    return {
-        passportId: passportId,
-        firstName: faker.name.firstName(),
-        lastName: faker.name.lastName(),
-        age
-    };
-}
+ export function human(
+     passportId: string = randomString(12),
+     age: number = randomNumber(10, 50)
+ ): HumanDocumentType {
+     return {
+         passportId: passportId,
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName(),
+         age
+     };
+ }
 
-export function simpleHuman(): SimpleHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        firstName: faker.name.firstName(),
-        lastName: faker.name.lastName()
-    };
-}
+ export function simpleHuman(): SimpleHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName()
+     };
+ }
 
-export interface SimpleHumanV3DocumentType {
-    passportId: string;
-    age: number;
-    oneOptional?: string;
-}
-export function simpleHumanV3(passportId = randomString(12)): SimpleHumanV3DocumentType {
-    return {
-        passportId,
-        age: randomNumber(10, 50)
-    };
-}
+ export interface SimpleHumanV3DocumentType {
+     passportId: string;
+     age: number;
+     oneOptional?: string;
+ }
+ export function simpleHumanV3(passportId = randomString(12)): SimpleHumanV3DocumentType {
+     return {
+         passportId,
+         age: randomNumber(10, 50)
+     };
+ }
 
-export interface SimpleHumanAgeDocumentType {
-    passportId: string;
-    age: string;
-}
-export function simpleHumanAge(): SimpleHumanAgeDocumentType {
-    return {
-        passportId: randomString(12),
-        age: randomNumber(10, 50) + ''
-    };
-}
+ export interface SimpleHumanAgeDocumentType {
+     passportId: string;
+     age: string;
+ }
+ export function simpleHumanAge(): SimpleHumanAgeDocumentType {
+     return {
+         passportId: randomString(12),
+         age: randomNumber(10, 50) + ''
+     };
+ }
 
-export interface HumanWithSubOtherDocumentType {
-    passportId: string;
-    other: {
-        age: number;
-    };
-}
-export function humanWithSubOther(): HumanWithSubOtherDocumentType {
-    return {
-        passportId: randomString(12),
-        other: {
-            age: randomNumber(10, 50)
+ export interface HumanWithSubOtherDocumentType {
+     passportId: string;
+     other: {
+         age: number;
+     };
+ }
+ export function humanWithSubOther(): HumanWithSubOtherDocumentType {
+     return {
+         passportId: randomString(12),
+         other: {
+             age: randomNumber(10, 50)
+         }
+     };
+ }
+
+ export interface NoIndexHumanDocumentType {
+     firstName: string;
+     lastName: string;
+ }
+ export function NoIndexHuman(): NoIndexHumanDocumentType {
+     return {
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName()
+     };
+ }
+
+ export interface NestedHumanDocumentType {
+     passportId: string;
+     firstName: string;
+     mainSkill: {
+         name: string;
+         level: number;
+     };
+ }
+ export function nestedHuman(): NestedHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         mainSkill: {
+             name: randomString(6),
+             level: 5
+         }
+     };
+ }
+
+ export interface DeepNestedHumanDocumentType {
+     passportId: string;
+     mainSkill: {
+         name: string;
+         attack: {
+             good: boolean;
+             count: number;
+         };
+     };
+ }
+ export function deepNestedHuman(): DeepNestedHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         mainSkill: {
+             name: randomString(6),
+             attack: {
+                 good: false,
+                 count: 5
+             }
+         }
+     };
+ }
+
+ export interface BigHumanDocumentType {
+     passportId: string;
+     dnaHash: string;
+     firstName: string;
+     lastName: string;
+     age: number;
+ }
+ export function bigHumanDocumentType(): BigHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         dnaHash: randomString(12),
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName(),
+         age: randomNumber(10, 50)
+     };
+ }
+
+ export interface HeroArrayDocumentType {
+     name: string;
+     skills: {
+         name: string;
+         damage: number;
+     }[];
+ }
+ export function heroArray(): HeroArrayDocumentType {
+     return {
+         name: randomString(6),
+         skills: new Array(3).fill(0).map(() => {
+             return {
+                 name: randomString(6),
+                 damage: randomNumber(10, 50)
+             };
+         })
+     };
+ }
+
+ export interface SimpleHeroArrayDocumentType {
+     name: string;
+     skills: string[];
+ }
+ export function simpleHeroArray(): SimpleHeroArrayDocumentType {
+     return {
+         name: randomString(6),
+         skills: new Array(3).fill(0).map(() => randomString(6))
+     };
+ }
+
+ export interface EncryptedHumanDocumentType {
+     passportId: string;
+     firstName: string;
+     secret: string;
+ }
+ export function encryptedHuman(): EncryptedHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         secret: randomString(12)
+     };
+ }
+
+ export interface EncryptedObjectHumanDocumentType {
+     passportId: string;
+     firstName: string;
+     secret: {
+         name: string;
+         subname: string;
+     };
+ }
+ export function encryptedObjectHuman(): EncryptedObjectHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         secret: {
+             name: randomString(12),
+             subname: randomString(12)
+         }
+     };
+ }
+
+ export interface EncryptedDeepHumanDocumentType {
+     passportId: string;
+     firstName: string;
+     firstLevelPassword: string;
+     secretData: {
+         pw: string;
+     };
+     deepSecret: {
+         darkhole: {
+             pw: string
+         }
+     };
+     nestedSecret: {
+         darkhole: {
+             pw: string;
+         }
+     };
+ }
+ export function encryptedDeepHumanDocumentType(): EncryptedDeepHumanDocumentType {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         firstLevelPassword: randomString(12),
+         secretData: {
+             pw: randomString(12)
+         },
+         deepSecret: {
+             darkhole: {
+                 pw: randomString(12)
+             }
+         },
+         nestedSecret: {
+             darkhole: {
+                 pw: randomString(12)
+             }
+         }
+     };
+ }
+
+ export interface CompoundIndexDocumentType {
+     passportId: string;
+     passportCountry: string;
+     age: number;
+ }
+ export function compoundIndex(): CompoundIndexDocumentType {
+     return {
+         passportId: randomString(12),
+         passportCountry: randomString(12),
+         age: randomNumber(10, 50)
+     };
+ }
+
+ export interface CompoundIndexNoStringDocumentType {
+     passportId: string;
+     passportCountry: { [prop: string]: string };
+     age: number;
+ }
+ export function compoundIndexNoString(): CompoundIndexNoStringDocumentType {
+     return {
+         passportId: randomString(12),
+         passportCountry: { [randomString(12)]: randomString(12) },
+         age: randomNumber(10, 50)
+     };
+ }
+
+ export interface NostringIndexDocumentType {
+     passportId: {};
+     firstName: string;
+ }
+ export function nostringIndex(): NostringIndexDocumentType {
+     return {
+         passportId: {},
+         firstName: faker.name.firstName()
+     };
+ }
+
+ export interface RefHumanDocumentType {
+     name: string;
+     bestFriend: string;
+ }
+ export function refHuman(bestFriend?: string): RefHumanDocumentType {
+     return {
+         name: randomString(12),
+         bestFriend
+     } as any;
+ }
+
+ export interface RefHumanNestedDocumentType {
+     name: string;
+     foo: {
+         bestFriend: string;
+     };
+ }
+ export function refHumanNested(bestFriend?: string): RefHumanNestedDocumentType {
+     return {
+         name: randomString(12),
+         foo: {
+             bestFriend
+         } as any
+     };
+ }
+
+ export interface HumanWithTimestampDocumentType {
+     id: string;
+     name: string;
+     age: number;
+     updatedAt: number;
+     deletedAt?: number;
+ }
+ export function humanWithTimestamp(givenData: Partial<HumanWithTimestampDocumentType> = {}): HumanWithTimestampDocumentType {
+     const now = new Date().getTime() / 1000;
+     let ret = {
+         id: randomString(12),
+         name: faker.name.firstName(),
+         age: randomNumber(1, 100),
+         // use some time in the past week
+         updatedAt: Math.round(randomNumber(now - 60 * 60 * 24 * 7, now))
+     };
+     ret = Object.assign({}, ret, givenData);
+     return ret;
+ }
+
+ export interface AverageSchemaDocumentType {
+     id: string;
+     var1: string;
+     var2: number;
+     deep: {
+         deep1: string;
+         deep2: string;
+     };
+     list: {
+         deep1: string;
+         deep2: string;
+     }[];
+ }
+ export function averageSchema(): AverageSchemaDocumentType {
+     return {
+         id: randomString(12),
+         var1: randomString(12),
+         var2: randomNumber(100, 50000),
+         deep: {
+             deep1: randomString(5),
+             deep2: randomString(8)
+         },
+         list: new Array(5).fill(0).map(() => ({
+             deep1: randomString(5),
+             deep2: randomString(8)
+         }))
+     };
+ }
+
+ export interface PointDocumentType {
+     id: string;
+     x: number;
+     y: number;
+ }
+ export function point(): PointDocumentType {
+     return {
+         id: randomString(12),
+         x: faker.datatype.number(),
+         y: faker.datatype.number()
+     };
+ }
+
+ export interface HumanWithIdAndAgeIndexDocumentType {
+     id: string;
+     name: string;
+     age: number;
+ }
+ export function humanWithIdAndAgeIndexDocumentType(
+     age: number = randomNumber(1, 100)
+ ): HumanWithIdAndAgeIndexDocumentType {
+     return {
+         id: randomString(12),
+         name: faker.name.firstName(),
+         age
+     };
+ }
+
+ export type HumanWithCompositePrimary = {
+     // optional because it might be created by RxDB and not known before
+     id?: string;
+     firstName: string;
+     lastName: string;
+     info: {
+         age: number;
+     }
+ };
+ export function humanWithCompositePrimary(): HumanWithCompositePrimary {
+     return {
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName(),
+         info: {
+             age: randomNumber(10, 50)
+         }
+     };
+ }
+
+ export interface HumanWithPatternProperties {
+     passportId: string;
+     firstName: string;
+     lastName: string;
+     numericallyIndexedJSONData: {
+         [x: string]: boolean
+     }
+ }
+ export function humanWithPatternProperties(): HumanWithPatternProperties {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName(),
+         numericallyIndexedJSONData: {
+             1:true,
+             4:false
         }
-    };
-}
+     };
+ }
 
-export interface NoIndexHumanDocumentType {
-    firstName: string;
-    lastName: string;
-}
-export function NoIndexHuman(): NoIndexHumanDocumentType {
-    return {
-        firstName: faker.name.firstName(),
-        lastName: faker.name.lastName()
-    };
-}
-
-export interface NestedHumanDocumentType {
-    passportId: string;
-    firstName: string;
-    mainSkill: {
-        name: string;
-        level: number;
-    };
-}
-export function nestedHuman(): NestedHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        firstName: faker.name.firstName(),
-        mainSkill: {
-            name: randomString(6),
-            level: 5
-        }
-    };
-}
-
-export interface DeepNestedHumanDocumentType {
-    passportId: string;
-    mainSkill: {
-        name: string;
-        attack: {
-            good: boolean;
-            count: number;
-        };
-    };
-}
-export function deepNestedHuman(): DeepNestedHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        mainSkill: {
-            name: randomString(6),
-            attack: {
-                good: false,
-                count: 5
-            }
-        }
-    };
-}
-
-export interface BigHumanDocumentType {
-    passportId: string;
-    dnaHash: string;
-    firstName: string;
-    lastName: string;
-    age: number;
-}
-export function bigHumanDocumentType(): BigHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        dnaHash: randomString(12),
-        firstName: faker.name.firstName(),
-        lastName: faker.name.lastName(),
-        age: randomNumber(10, 50)
-    };
-}
-
-export interface HeroArrayDocumentType {
-    name: string;
-    skills: {
-        name: string;
-        damage: number;
-    }[];
-}
-export function heroArray(): HeroArrayDocumentType {
-    return {
-        name: randomString(6),
-        skills: new Array(3).fill(0).map(() => {
-            return {
-                name: randomString(6),
-                damage: randomNumber(10, 50)
-            };
-        })
-    };
-}
-
-export interface SimpleHeroArrayDocumentType {
-    name: string;
-    skills: string[];
-}
-export function simpleHeroArray(): SimpleHeroArrayDocumentType {
-    return {
-        name: randomString(6),
-        skills: new Array(3).fill(0).map(() => randomString(6))
-    };
-}
-
-export interface EncryptedHumanDocumentType {
-    passportId: string;
-    firstName: string;
-    secret: string;
-}
-export function encryptedHuman(): EncryptedHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        firstName: faker.name.firstName(),
-        secret: randomString(12)
-    };
-}
-
-export interface EncryptedObjectHumanDocumentType {
-    passportId: string;
-    firstName: string;
-    secret: {
-        name: string;
-        subname: string;
-    };
-}
-export function encryptedObjectHuman(): EncryptedObjectHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        firstName: faker.name.firstName(),
-        secret: {
-            name: randomString(12),
-            subname: randomString(12)
-        }
-    };
-}
-
-export interface EncryptedDeepHumanDocumentType {
-    passportId: string;
-    firstName: string;
-    firstLevelPassword: string;
-    secretData: {
-        pw: string;
-    };
-    deepSecret: {
-        darkhole: {
-            pw: string
-        }
-    };
-    nestedSecret: {
-        darkhole: {
-            pw: string;
-        }
-    };
-}
-export function encryptedDeepHumanDocumentType(): EncryptedDeepHumanDocumentType {
-    return {
-        passportId: randomString(12),
-        firstName: faker.name.firstName(),
-        firstLevelPassword: randomString(12),
-        secretData: {
-            pw: randomString(12)
-        },
-        deepSecret: {
-            darkhole: {
-                pw: randomString(12)
-            }
-        },
-        nestedSecret: {
-            darkhole: {
-                pw: randomString(12)
-            }
-        }
-    };
-}
-
-export interface CompoundIndexDocumentType {
-    passportId: string;
-    passportCountry: string;
-    age: number;
-}
-export function compoundIndex(): CompoundIndexDocumentType {
-    return {
-        passportId: randomString(12),
-        passportCountry: randomString(12),
-        age: randomNumber(10, 50)
-    };
-}
-
-export interface CompoundIndexNoStringDocumentType {
-    passportId: string;
-    passportCountry: { [prop: string]: string };
-    age: number;
-}
-export function compoundIndexNoString(): CompoundIndexNoStringDocumentType {
-    return {
-        passportId: randomString(12),
-        passportCountry: { [randomString(12)]: randomString(12) },
-        age: randomNumber(10, 50)
-    };
-}
-
-export interface NostringIndexDocumentType {
-    passportId: {};
-    firstName: string;
-}
-export function nostringIndex(): NostringIndexDocumentType {
-    return {
-        passportId: {},
-        firstName: faker.name.firstName()
-    };
-}
-
-export interface RefHumanDocumentType {
-    name: string;
-    bestFriend: string;
-}
-export function refHuman(bestFriend?: string): RefHumanDocumentType {
-    return {
-        name: randomString(12),
-        bestFriend
-    } as any;
-}
-
-export interface RefHumanNestedDocumentType {
-    name: string;
-    foo: {
-        bestFriend: string;
-    };
-}
-export function refHumanNested(bestFriend?: string): RefHumanNestedDocumentType {
-    return {
-        name: randomString(12),
-        foo: {
-            bestFriend
-        } as any
-    };
-}
-
-export interface HumanWithTimestampDocumentType {
-    id: string;
-    name: string;
-    age: number;
-    updatedAt: number;
-    deletedAt?: number;
-}
-export function humanWithTimestamp(givenData: Partial<HumanWithTimestampDocumentType> = {}): HumanWithTimestampDocumentType {
-    const now = new Date().getTime() / 1000;
-    let ret = {
-        id: randomString(12),
-        name: faker.name.firstName(),
-        age: randomNumber(1, 100),
-        // use some time in the past week
-        updatedAt: Math.round(randomNumber(now - 60 * 60 * 24 * 7, now))
-    };
-    ret = Object.assign({}, ret, givenData);
-    return ret;
-}
-
-export interface AverageSchemaDocumentType {
-    id: string;
-    var1: string;
-    var2: number;
-    deep: {
-        deep1: string;
-        deep2: string;
-    };
-    list: {
-        deep1: string;
-        deep2: string;
-    }[];
-}
-export function averageSchema(): AverageSchemaDocumentType {
-    return {
-        id: randomString(12),
-        var1: randomString(12),
-        var2: randomNumber(100, 50000),
-        deep: {
-            deep1: randomString(5),
-            deep2: randomString(8)
-        },
-        list: new Array(5).fill(0).map(() => ({
-            deep1: randomString(5),
-            deep2: randomString(8)
-        }))
-    };
-}
-
-export interface PointDocumentType {
-    id: string;
-    x: number;
-    y: number;
-}
-export function point(): PointDocumentType {
-    return {
-        id: randomString(12),
-        x: faker.datatype.number(),
-        y: faker.datatype.number()
-    };
-}
-
-export interface HumanWithIdAndAgeIndexDocumentType {
-    id: string;
-    name: string;
-    age: number;
-}
-export function humanWithIdAndAgeIndexDocumentType(
-    age: number = randomNumber(1, 100)
-): HumanWithIdAndAgeIndexDocumentType {
-    return {
-        id: randomString(12),
-        name: faker.name.firstName(),
-        age
-    };
-}
-
-export type HumanWithCompositePrimary = {
-    // optional because it might be created by RxDB and not known before
-    id?: string;
-    firstName: string;
-    lastName: string;
-    info: {
-        age: number;
-    }
-};
-export function humanWithCompositePrimary(): HumanWithCompositePrimary {
-    return {
-        firstName: faker.name.firstName(),
-        lastName: faker.name.lastName(),
-        info: {
-            age: randomNumber(10, 50)
-        }
-    };
-}
+ export function humanWithPatternPropertiesFail(): HumanWithPatternProperties {
+     return {
+         passportId: randomString(12),
+         firstName: faker.name.firstName(),
+         lastName: faker.name.lastName(),
+         numericallyIndexedJSONData: {
+             somefield: true,
+         }
+     };
+ }

--- a/test/helper/schemas.ts
+++ b/test/helper/schemas.ts
@@ -1226,3 +1226,40 @@ export const humanIdAndAgeIndex: RxJsonSchema<{ id: string; name: string; age: n
         ['age', 'id']
     ]
 });
+
+export const humanWithPatternProperties: RxJsonSchema<HumanDocumentType & {numericallyIndexedJSONData: {[x: string]: boolean}}> = overwritable.deepFreezeWhenDevMode({
+    title: 'human schema',
+    description: 'describes a human being',
+    version: 0,
+    keyCompression: true,
+    primaryKey: 'passportId',
+    type: 'object',
+    properties: {
+        numericallyIndexedJSONData: {
+            additionalProperties:false,
+            patternProperties: {
+                '^[0-9]+$': {
+                    type: 'boolean'
+                }
+            }
+        },
+        passportId: {
+            type: 'string',
+            maxLength: 100
+        },
+        firstName: {
+            type: 'string',
+            maxLength: 100
+        },
+        lastName: {
+            type: 'string'
+        },
+        age: {
+            description: 'age in years',
+            type: 'integer',
+            minimum: 0,
+            maximum: 150
+        },
+    }
+})
+

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -78,6 +78,9 @@ config.parallel('rx-schema.test.js', () => {
                 it('validates deep nested indexes', () => {
                     checkSchema(schemas.humanWithDeepNestedIndexes);
                 });
+                it('validates with pattern properties as a property attribute', () => {
+                    checkSchema(schemas.humanWithPatternProperties);
+                });
             });
             describe('negative', () => {
                 it('break when index defined at object property level', () => {
@@ -638,8 +641,18 @@ config.parallel('rx-schema.test.js', () => {
                     const obj: any = schemaObjects.nestedHuman();
                     schema.validate(obj);
                 });
+                it('validates object with pattern properties', () => {
+                    const schema = createRxSchema(schemas.humanWithPatternProperties);
+                    const obj: any = schemaObjects.humanWithPatternProperties();
+                    schema.validate(obj);
+                });
             });
             describe('negative', () => {
+                it('field data does not match pattern properties regex', () => {
+                    const schema = createRxSchema(schemas.humanWithPatternProperties);
+                    const obj: any = schemaObjects.humanWithPatternPropertiesFail();
+                    assert.throws(() => schema.validate(obj), Error);
+                });
                 it('required field not given', () => {
                     const schema = createRxSchema(schemas.human);
                     const obj: any = schemaObjects.human();


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
Dev-mode fails when you use patternProperties as a property attribute with the expected regex
See: [JSON schema](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2)

This change narrowly affects the field name check for a patternProperties object when it's used in a schema to define a property