### PR TITLE
Update quickstart.md

### DIFF
--- a/docs-src/quickstart.md
+++ b/docs-src/quickstart.md
@@ -15,7 +15,7 @@ import { createRxDatabase } from 'rxdb';
 import { getRxStoragePouch, addPouchPlugin } from 'rxdb/plugins/pouchdb';
 addPouchPlugin(require('pouchdb-adapter-idb'));
 
-const db = await createRxDatabase({
+const myDatabase = await createRxDatabase({
   name: 'heroesdb',
   storage: getRxStoragePouch('idb')
 });
@@ -47,7 +47,7 @@ const mySchema = {
             // number fields that are used in an index, must have set minium, maximum and multipleOf
             minimum: 0,
             maximum: 150,
-            multipleOf: '1'
+            multipleOf: 1
         }
     },
     required: ['firstName', 'lastName', 'passportId'],


### PR DESCRIPTION
The database was first introduced as `db` and then referenced as `myDatabase`.

## This PR contains:
- Small docs improvement

## Describe the problem you have without this PR
Following the quick-start guide led to a reference to an undeclared variable.
Following the guide in TypeScript suggested that the age should be a number, rather than a string.