### PR TITLE
Fix Node example

### DIFF
--- a/examples/node/src/database.js
+++ b/examples/node/src/database.js
@@ -14,6 +14,9 @@ const {
 addPouchPlugin(require('pouchdb-adapter-node-websql'));
 addPouchPlugin(require('pouchdb-adapter-http'));
 
+const { RxDBQueryBuilderPlugin } = require('../../../plugins/query-builder');
+addRxPlugin(RxDBQueryBuilderPlugin);
+
 const { RxDBEncryptionPlugin } = require('../../../plugins/encryption');
 addRxPlugin(RxDBEncryptionPlugin);
 


### PR DESCRIPTION

## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
In Node example, this pr fix  the following error:
_Error: You are using a function which must be overwritten by a plugin.
        You should either prevent the usage of this function or add the plugin via:
            import { RxDBQueryBuilderPlugin } from 'rxdb/plugins/query-builder';
            addRxPlugin(RxDBQueryBuilderPlugin);_
