### PR TITLE
fix: typings

### DIFF
--- a/src/types/rx-query.d.ts
+++ b/src/types/rx-query.d.ts
@@ -83,8 +83,8 @@ export declare class RxQuery<RxDocumentType = any, RxQueryResult = RxDocumentTyp
     equals(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     eq(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     or(queryObj: keyof RxDocumentType | string | any[]): RxQuery<RxDocumentType, RxQueryResult>;
-    nor(queryObj: keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
-    and(queryObj: keyof RxDocumentType | string): RxQuery<RxDocumentType, RxQueryResult>;
+    nor(queryObj: keyof RxDocumentType | string | any[]): RxQuery<RxDocumentType, RxQueryResult>;
+    and(queryObj: keyof RxDocumentType | string | any[]): RxQuery<RxDocumentType, RxQueryResult>;
     gt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     gte(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;
     lt(queryObj: any): RxQuery<RxDocumentType, RxQueryResult>;


### PR DESCRIPTION
fix types for `nor` and `and` query

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->


## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
According to the [query doc](https://github.com/aheckmann/mquery/blob/master/README.md#and), `and` and `nor` methods accept an array of query filters. Without this PR I need to do `query.and([] as any)`

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
