### PR TITLE
test to recreate issue with `find` query containing "$or" and "$regex"

### DIFF
--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -46,17 +46,22 @@ describe('bug-report.test.js', () => {
                     primary: true,
                 },
                 firstName: {
-                    type: 'string'
+                    type: 'string',
+                    maxLength: 100,
                 },
                 lastName: {
-                    type: 'string'
+                    type: 'string',
+                    maxLength: 100,
                 },
                 age: {
                     type: 'integer',
                     minimum: 0,
                     maximum: 150
                 }
-            }
+            },
+            indexes: [
+                'firstName', 'lastName'
+            ]
         };
 
         // generate a random database-name


### PR DESCRIPTION
## This PR contains:
Bug with querying database collections

## Describe the problem you have without this PR
Since upgrading to `12.5.3` from `11.6.0` - when trying to query a collection using both `$or` and `$regex` elements something is barfing meaning code will exit with an error 

`TypeError: userValue.every is not a function`

I've also created a standalone repos that shows this error that if run with the pouchdb deb mode on outputs the following to the console

![image](https://user-images.githubusercontent.com/16895748/174608467-28463a52-8f4e-4954-9a93-fb6eaca712a1.png)

Repos URL if you want it - https://github.com/pete-hotchkiss/rxdb-or-regex-example


