### PR TITLE
Fix the `_rev` that is passed to an RxStorage must be respected by th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Only check if final field have been changed in dev-mode.
 - Fix `atomicUpsert()` broken when document was replicated before. [#3856](https://github.com/pubkey/rxdb/pull/3856). Thanks [@AntonOfTheWoods](https://github.com/AntonOfTheWoods)
 - Refactor revision handling
+- Fix the `_rev` that is passed to an RxStorage must be respected by the RxStorage.
 
 <!-- ADD new changes here! -->
 

--- a/src/plugins/pouchdb/custom-events-plugin.ts
+++ b/src/plugins/pouchdb/custom-events-plugin.ts
@@ -296,7 +296,7 @@ export function addCustomEventsPluginToPouch() {
                     });
                 } else {
                     const useRevisions = {
-                        start: docInDb ? docInDb._revisions.start + 1 : newRev.height,
+                        start: newRev.height,
                         ids: docInDb ? docInDb._revisions.ids.slice(0) : []
                     };
                     useRevisions.ids.unshift(newRev.hash);

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -431,7 +431,6 @@ export const basePrototype = {
         newData._rev = createRevision(newData, oldData);
         this.collection.schema.validate(newData);
 
-
         const writeResult = await this.collection.storageInstance.bulkWrite([{
             previous: oldData,
             document: newData


### PR DESCRIPTION
…e RxStorage

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
