### PR TITLE
bug on vanilla example

### DIFF
--- a/examples/vanilla/main.js
+++ b/examples/vanilla/main.js
@@ -32,6 +32,7 @@ const syncURL = 'http://' + window.location.hostname + ':10102/';
 window.RxDB
     .createRxDatabase({
         name: 'heroesdb',
+        // some change on commit 93e174bbab9515e8f8fe3ed21c58d18cb2095314 made getRxStoragePouch brake
         storage: RxDB.getRxStoragePouch('idb'),
         password: 'myLongAndStupidPassword'
     })


### PR DESCRIPTION

## This PR contains:
 - A BUG report 
## Describe the problem you have without this PR
examples/vanilla stopped working on commit 93e174bbab9515e8f8fe3ed21c58d18cb2095314 (12.0.0-beta.2).  You can check in the previous commit it was working.

> git checkout 12.0.0-beta.2
> cd /examples/vanilla
> npm i
> npm start
===>>> error: Uncaught TypeError: RxDB.getRxStoragePouch is not a function at main.js:35:23

> git checkout HEAD~1
Previous HEAD position was 93e174bb 12.0.0-beta.2
HEAD is now at 3fd2a9e2 FIX docs

> npm start
==> works fine!
