### PR TITLE
bug in query results type

### DIFF
--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -60,7 +60,7 @@ const newQueryID = function (): number {
 export class RxQueryBase<
     RxDocumentType = any,
     // TODO also pass DocMethods here
-    RxQueryResult = RxDocument<RxDocumentType[]> | RxDocument<RxDocumentType>
+    RxQueryResult = RxDocument<RxDocumentType>[] | RxDocument<RxDocumentType>
     > {
 
     public id: number = newQueryID();


### PR DESCRIPTION
I'm pretty sure this type is incorrect. It should be an array of documents.

## This PR contains:

 - IMPROVED typings