### PR TITLE
add undefined to typing of RxDocumentData._deleted

### DIFF
--- a/src/types/rx-storage.d.ts
+++ b/src/types/rx-storage.d.ts
@@ -16,7 +16,7 @@ export type RxDocumentData<T> = T & {
      * Instead the documents are stored with _deleted: true
      * which means they will not be returned at queries.
      */
-    _deleted: boolean;
+    _deleted: boolean | undefined;
 
     /**
      * The attachments meta data is stored besides to document.


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains: A typing fix
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
The type of the `_deleted` field on `RxDocumentData<T>` is boolean, however it's observed to also be undefined. When replicated, this is the difference between the deleted flag being sent to the server and omitted. It also means eslint thinks `doc._deleted ?? false` is unnecessary since it incorrectly believes `_deleted` cannot be nullish.


<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
