### PR TITLE
Support JsonSchema for nested additionalProperties

### DIFF
--- a/src/types/rx-schema.d.ts
+++ b/src/types/rx-schema.d.ts
@@ -36,7 +36,7 @@ export type JsonSchema<RxDocType = any> = {
     anyOf?: JsonSchema[];
     oneOf?: JsonSchema[];
     additionalItems?: boolean | JsonSchema;
-    additionalProperties?: boolean;
+    additionalProperties?: boolean | JsonSchema;
     type?: JsonSchemaTypes | JsonSchemaTypes[];
     description?: string;
     dependencies?: {

--- a/test/unit/validate.test.ts
+++ b/test/unit/validate.test.ts
@@ -163,7 +163,44 @@ validationImplementations.forEach(
                     );
                     await instance.close();
                 });
+                it('should work with a schema as nested additionalProperties', async () => {
+                    const jsonSchema: any = clone(schemas.heroArray);
+                    jsonSchema.properties.skills.items['additionalProperties'] = {type: 'number'};
+                    const instance = await getRxStorageInstance(jsonSchema);
 
+                    // valid
+                    await instance.bulkWrite([{
+                        document: toRxDocumentData({
+                            name: 'foobar',
+                            skills: [
+                                {
+                                    name: 'foo',
+                                    damage: 10,
+                                    nonDefinedField: 42
+                                }
+                            ],
+                        })
+                    }], testContext);
+
+                    // non valid
+                    await assertThrows(
+                        () => instance.bulkWrite([{
+                            document: toRxDocumentData({
+                                name: 'foobar',
+                                skills: [
+                                    {
+                                        name: 'foo',
+                                        damage: 10,
+                                        nonDefinedField: 'foobar'
+                                    }
+                                ],
+                            })
+                        }], testContext),
+                        'RxError',
+                        'VD2'
+                    );
+                    await instance.close();
+                });
             });
             describe('negative', () => {
                 it('not validate other object', async () => {


### PR DESCRIPTION
## This PR contains:

Fixed types for `additionalProperties` with a corresponding tests

## Describe the problem you have without this PR

Unable to use a json schema for nested `additionalProperties`