### PR TITLE
feat: include crededentials in graphql client

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -372,6 +372,18 @@ replicationState.setHeaders({
 });
 ```
 
+#### Sending Cookies
+
+The underlying fetch framework uses a `same-origin` policy for credentials per default. That means, cookies and session data is only shared if you backend and frontend run on the same domain and port. Pass the credential parameter to `include` cookies in requests to servers from different origins via:
+
+```js
+replicationState.setHeaders({
+    // ...
+}, `include`);
+```
+
+See [the fetch spec](https://fetch.spec.whatwg.org/#concept-request-credentials-mode) form more information.
+
 
 **NOTICE:** To play around, check out the full example of the RxDB [GraphQL replication with server and client](https://github.com/pubkey/rxdb/tree/master/examples/graphql)
 

--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -377,12 +377,20 @@ replicationState.setHeaders({
 The underlying fetch framework uses a `same-origin` policy for credentials per default. That means, cookies and session data is only shared if you backend and frontend run on the same domain and port. Pass the credential parameter to `include` cookies in requests to servers from different origins via:
 
 ```js
-replicationState.setHeaders({
-    // ...
-}, `include`);
+replicationState.setCredentials('include');
 ```
 
-See [the fetch spec](https://fetch.spec.whatwg.org/#concept-request-credentials-mode) form more information.
+or directly pass it in the the `syncGraphQL`:
+
+```js
+syncGraphQL({
+    /* ... */
+    credentials: 'include',
+    /* ... */
+})
+```
+
+See [the fetch spec](https://fetch.spec.whatwg.org/#concept-request-credentials-mode) for more information about available options.
 
 
 **NOTICE:** To play around, check out the full example of the RxDB [GraphQL replication with server and client](https://github.com/pubkey/rxdb/tree/master/examples/graphql)

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -43,7 +43,7 @@ import { Subject } from 'rxjs';
 export class RxGraphQLReplicationState<RxDocType, CheckpointType> extends RxReplicationState<RxDocType, CheckpointType> {
     constructor(
         public readonly url: GraphQLServerUrl,
-        public readonly clientState: { headers: any; client: any },
+        public readonly clientState: { headers: any; client: any, credentials: string | undefined },
         public readonly replicationIdentifierHash: string,
         public readonly collection: RxCollection<RxDocType>,
         public readonly deletedField: string,
@@ -69,7 +69,17 @@ export class RxGraphQLReplicationState<RxDocType, CheckpointType> extends RxRepl
         this.clientState.headers = headers;
         this.clientState.client = GraphQLClient({
             url: this.url.http,
-            headers
+            headers,
+            credentials: this.clientState.credentials
+        });
+    }
+
+    setCredentials(credentials: string | undefined) {
+        this.clientState.credentials = credentials
+        this.clientState.client = GraphQLClient({
+            url: this.url.http,
+            headers: this.clientState.headers,
+            credentials
         });
     }
 }
@@ -79,6 +89,7 @@ export function syncGraphQL<RxDocType, CheckpointType>(
     {
         url,
         headers = {},
+        credentials,
         deletedField = '_deleted',
         waitForLeadership = true,
         pull,
@@ -96,9 +107,11 @@ export function syncGraphQL<RxDocType, CheckpointType>(
      */
     const mutateableClientState = {
         headers,
+        credentials,
         client: GraphQLClient({
             url: url.http,
-            headers
+            headers,
+            credentials
         })
     };
 

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -48,6 +48,7 @@ export type SyncOptionsGraphQL<RxDocType, CheckpointType> = Omit<
 > & {
     url: GraphQLServerUrl;
     headers?: { [k: string]: string }; // send with all requests to the endpoint
+    credentials?: string;
     pull?: GraphQLSyncPullOptions<RxDocType, CheckpointType>;
     push?: GraphQLSyncPushOptions<RxDocType>;
 }


### PR DESCRIPTION
## This PR contains:

 - A NEW FEATURE

## Describe the problem you have without this PR

This is a feature for https://github.com/pubkey/rxdb/issues/3439

This Pull Request adds the option to pass the credential parameter to the underlying GraphQL client. Without it the application will not send any cookies to other domains since the credentials option is `same-origin` per default. See the spec documentation at https://fetch.spec.whatwg.org/#concept-request-credentials-mode

## Todos
- [x] Tests
- [x] Documentation
- [x] Typings
- [ ] Changelog

> How should I update the changelog?
