### PR TITLE
CHORE graphql pull.responseModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 <!-- CHANGELOG NEWEST -->
 
 - FIX respect the `prefers-reduced-motion` media query to not show blinking animations to neurodiverse people at the landingpage.
-
+- ADD `pull.responseModifier` to the graphql replication plugin so that you can aggregate the checkpoint from the returned graphql respones.
 <!-- ADD new changes here! -->
 
 <!-- /CHANGELOG NEWEST -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 <!-- CHANGELOG NEWEST -->
 
 - FIX respect the `prefers-reduced-motion` media query to not show blinking animations to neurodiverse people at the landingpage.
-- ADD `pull.responseModifier` to the graphql replication plugin so that you can aggregate the checkpoint from the returned graphql respones.
+- ADD `pull.responseModifier` to the graphql replication plugin so that you can aggregate the checkpoint from the returned graphql response.
 <!-- ADD new changes here! -->
 
 <!-- /CHANGELOG NEWEST -->

--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -369,7 +369,7 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = collection.syncGr
     pull: {
         responseModifier: async function(
             plainResponse, // the exact response that was returned from the server
-            origin, // either 'handler' if it came from the pull.handler, or 'stream' if it came from the pull.stream
+            origin, // either 'handler' if plainResponse came from the pull.handler, or 'stream' if it came from the pull.stream
             requestCheckpoint // if origin==='handler', the requestCheckpoint contains the checkpoint that was send to the backend
         ) {
             /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,7 @@ export type {
     RxErrorParameters,
     RxGraphQLReplicationPushQueryBuilder,
     RxGraphQLReplicationPullQueryBuilder,
+    RxGraphQLPullResponseModifier,
     RxJsonSchema,
     RxLocalDocument,
     RxPlugin,

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export type {
     RxStorageReplicationMeta,
     DocumentsWithCheckpoint,
     RxReplicationPullStreamItem,
+    ReplicationPullHandlerResult,
 
     // other stuff
     RxDumpCollectionBase,

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -132,7 +132,15 @@ export function syncGraphQL<RxDocType, CheckpointType>(
                 }
 
                 const dataPath = pull.dataPath || ['data', Object.keys(result.data)[0]];
-                const data: any = objectPath.get(result, dataPath);
+                let data: any = objectPath.get(result, dataPath);
+
+                if (pull.responseModifier) {
+                    data = await pull.responseModifier(
+                        data,
+                        'handler',
+                        lastPulledCheckpoint
+                    );
+                }
 
                 const docsData: WithDeleted<RxDocType>[] = data.documents;
                 const newCheckpoint = data.checkpoint;

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -208,9 +208,16 @@ export function syncGraphQL<RxDocType, CheckpointType>(
             wsClient.subscribe(
                 query,
                 {
-                    next: (data: any) => {
-                        const firstField = Object.keys(data.data)[0];
-                        pullStream$.next(data.data[firstField]);
+                    next: async (streamResponse: any) => {
+                        const firstField = Object.keys(streamResponse.data)[0];
+                        let data = streamResponse.data[firstField];
+                        if (pull.responseModifier) {
+                            data = await pull.responseModifier(
+                                data,
+                                'stream'
+                            );
+                        }
+                        pullStream$.next(data);
                     },
                     error: (error: any) => {
                         pullStream$.error(error);

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -189,7 +189,7 @@ export class RxReplicationState<RxDocType, CheckpointType> {
                      * error handling.
                      */
                     let done = false;
-                    let result: ReplicationPullHandlerResult<RxDocType> = {} as any;
+                    let result: ReplicationPullHandlerResult<RxDocType, CheckpointType> = {} as any;
                     while (!done) {
                         try {
                             result = await this.pull.handler(

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -1,5 +1,6 @@
 import { RxReplicationWriteToMasterRow } from '../replication-protocol';
-import { ReplicationOptions, ReplicationPullOptions, ReplicationPushOptions } from './replication';
+import { MaybePromise } from '../util';
+import { ReplicationOptions, ReplicationPullHandlerResult, ReplicationPullOptions, ReplicationPushOptions } from './replication';
 
 export interface RxGraphQLReplicationQueryBuilderResponseObject {
     query: string;
@@ -26,7 +27,16 @@ export type GraphQLSyncPullOptions<RxDocType, CheckpointType> = Omit<
     queryBuilder: RxGraphQLReplicationPullQueryBuilder<CheckpointType>;
     streamQueryBuilder?: RxGraphQLReplicationPullStreamQueryBuilder;
     dataPath?: string;
+    responseModifier?: RxGraphQLPullResponseModifier<RxDocType, CheckpointType>;
 }
+
+export type RxGraphQLPullResponseModifier<RxDocType, CheckpointType> = (
+    // the exact response that was returned from the server
+    plainResponse: any,
+    // either 'handler' if it came from the pull.handler, or 'stream' if it came from the pull.stream
+    origin: 'handler' | 'stream',
+    requestCheckpoint?: CheckpointType
+) => MaybePromise<ReplicationPullHandlerResult<RxDocType, CheckpointType>>;
 
 export type RxGraphQLReplicationPullStreamQueryBuilder = (headers: { [k: string]: string }) => RxGraphQLReplicationQueryBuilderResponse;
 

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -32,7 +32,7 @@ export type GraphQLSyncPullOptions<RxDocType, CheckpointType> = Omit<
 
 export type RxGraphQLPullResponseModifier<RxDocType, CheckpointType> = (
     // the exact response that was returned from the server
-    plainResponse: any,
+    plainResponse: ReplicationPullHandlerResult<RxDocType, CheckpointType> | any,
     // either 'handler' if it came from the pull.handler, or 'stream' if it came from the pull.stream
     origin: 'handler' | 'stream',
     requestCheckpoint?: CheckpointType

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -17,12 +17,15 @@ export type InternalStoreReplicationPullDocType<RxDocType> = InternalStoreDocTyp
     lastPulledDoc: RxDocumentData<RxDocType>;
 }>;
 
-export type ReplicationPullHandlerResult<RxDocType> = {
-    checkpoint: any;
+export type ReplicationPullHandlerResult<RxDocType, CheckpointType> = {
+    checkpoint: CheckpointType;
     documents: WithDeleted<RxDocType>[];
 };
 
-export type ReplicationPullHandler<RxDocType, CheckpointType> = (lastPulledCheckpoint: CheckpointType, batchSize: number) => Promise<ReplicationPullHandlerResult<RxDocType>>;
+export type ReplicationPullHandler<RxDocType, CheckpointType> = (
+    lastPulledCheckpoint: CheckpointType,
+    batchSize: number
+) => Promise<ReplicationPullHandlerResult<RxDocType, CheckpointType>>;
 export type ReplicationPullOptions<RxDocType, CheckpointType> = {
     /**
      * A handler that pulls the new remote changes

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -390,6 +390,30 @@ describe('replication-graphql.test.ts', () => {
                 server.close();
                 c.database.destroy();
             });
+            it('should respect the pull.responseModifier', async () => {
+                const [c, server] = await Promise.all([
+                    humansCollection.createHumanWithTimestamp(0),
+                    SpawnServer.spawn(getTestData(10))
+                ]);
+
+                const replicationState = c.syncGraphQL({
+                    url: server.url,
+                    pull: {
+                        batchSize,
+                        queryBuilder: pullQueryBuilder,
+
+                    },
+                    live: false,
+                    deletedField: 'deleted'
+                });
+
+                await replicationState.awaitInitialReplication();
+
+
+                process.exit();
+                server.close();
+                c.database.destroy();
+            });
             it('should pull all documents when they have the same timestamp because they are also sorted by id', async () => {
                 const amount = batchSize * 2;
                 const testData = getTestData(amount);


### PR DESCRIPTION
WORK IN PROGRESS

ADD `pull.responseModifier` to the graphql replication plugin so that you can aggregate the checkpoint from the returned graphql respones.