### PR TITLE
fix typo on replication.md

### DIFF
--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -32,7 +32,7 @@ When document states are transfered, all handlers are using bulks of documents f
 The server has to implement the following methods to be compatible with the replication:
 
 - **pullHandler** Get the last checkpoint (or null) as input. Returns all documents that have been written **after** the given checkpoint. Also returns the checkpoint of the latest written returned document.
-- **pushHandler** a method that can be called by the client to send client side writes to the master. It gets and array with the the `assumedMasterState` and the `newForkState` of each document write as input. It must return an array that contains the master document states of all conflicts. If there are no conflicts, it must return an empty array.
+- **pushHandler** a method that can be called by the client to send client side writes to the master. It gets an array with the the `assumedMasterState` and the `newForkState` of each document write as input. It must return an array that contains the master document states of all conflicts. If there are no conflicts, it must return an empty array.
 - **pullStream** an observable that emits batches of all master writes and the latest checkpoint of the write batches.
 
 


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:
A fix for a typo in the docs.
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
The word "and" was used instead of the correct "an".
