### PR TITLE
FIX `RxDatabase.remove()` must properly remove the collection storage…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - FIX(sqlite) use dollar params instead of named params
 - CHANGE run performance tests without the `dev-mode` plugin
 - IMPROVE performance of document writes by not using try-catch in a hot path.
+- FIX `RxDatabase.remove()` must properly remove the collection storage together with the replication states.
 
 <!-- ADD new changes here! -->
 

--- a/docs-src/questions-answers.md
+++ b/docs-src/questions-answers.md
@@ -9,13 +9,14 @@ This means you have created a collection before and added document-data to it.
 When you now just change the schema, it is likely that the new schema does not match the saved documents inside of the collection.
 This would cause strange bugs and would be hard to debug, so RxDB check's if your schema has changed and throws an error.
 
-To change the schema in **production**-mode, do the following
+To change the schema in **production**-mode, do the following steps:
+
 - Increase the `version` by 1
 - Add the appropriate [migrationStrategies](https://pubkey.github.io/rxdb/data-migration.html) so the saved data will be modified to match the new schema
 
 
-In **development**-mode, the schema-change can be simplified by one of these strategies:
+In **development**-mode, the schema-change can be simplified by **one of these** strategies:
 
--   Use the memory-adapter so your db resets on restart and your schema is not safed permanently
--   Call `removeRxDatabase('mydatabasename', 'adapter');` before creating a new RxDatabase-instance
+-   Use the memory-storage so your db resets on restart and your schema is not safed permanently
+-   Call `removeRxDatabase('mydatabasename', RxStorage);` before creating a new RxDatabase-instance
 -   Add a timestamp as suffix to the database-name to create a new one each run like `name: 'heroesDB' + new Date().getTime()`

--- a/src/rx-collection-helper.ts
+++ b/src/rx-collection-helper.ts
@@ -9,7 +9,8 @@ import type {
 } from './types';
 import {
     getDefaultRevision,
-    getDefaultRxDocumentMeta
+    getDefaultRxDocumentMeta,
+    now
 } from './util';
 import {
     fillPrimaryKey
@@ -134,6 +135,7 @@ export async function removeCollectionStorages(
     // remove the meta documents
     const writeRows = relevantCollectionMetaDocs.map(doc => {
         const writeDoc = flatCloneDocWithMeta(doc);
+        writeDoc._meta.lwt = now();
         writeDoc._deleted = true;
         return {
             previous: doc,

--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -907,7 +907,8 @@ export class RxCollectionBase<
             this.database.internalStore,
             this.database.token,
             this.database.name,
-            this.name
+            this.name,
+            this.database.hashFunction
         );
     }
 

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -409,9 +409,6 @@ describe('replication.test.js', () => {
                 return result.documents.length;
             }
 
-            const docsInMetaBefore = await docsInMeta(replicationState1);
-            console.log('docsInMetaBefore: ' + docsInMetaBefore);
-
             await localCollection.remove();
             await localCollection.database.destroy();
 

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -398,7 +398,6 @@ describe('replication.test.js', () => {
 
             async function docsInMeta(repState: typeof replicationState1): Promise<number> {
                 const metaInstance = ensureNotFalsy(repState.metaInstance);
-                console.log('metaInstance ' + metaInstance.databaseName + ' -- ' + metaInstance.collectionName);
                 const prepared = repState.collection.database.storage.statics.prepareQuery(
                     metaInstance.schema,
                     normalizeMangoQuery(


### PR DESCRIPTION
… together with the replication states.

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
