### PR TITLE
Array order test case for sortObject

### DIFF
--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -139,6 +139,11 @@ describe('util.test.js', () => {
             const sorted = sortObject(obj);
             assert.ok(sorted.color.$regex instanceof RegExp);
         });
+        it('should sort object arrays in a deterministic order', () => {
+            const arr = [{a: 1}, {b: 2}];
+            const sorted = sortObject(arr);
+            assert.deepStrictEqual(sorted, [{a: 1}, {b: 2}]);
+        });
     });
     describe('.validateDatabaseName()', () => {
         describe('positive', () => {


### PR DESCRIPTION
## This PR contains:
A test case failing in Firefox but not Chrome

## Describe the problem you have without this PR

I'm working on a replication library that compares the client's RxSchema hash with the one on the server side. I realized the hash provided by RxDB is not the same across browsers (Chrome, Firefox) if the schema contains an array of objects (an `anyOf` in my case). This could also be a problem in the future if a browser update changes the browser's implementation of the sort algorithm.

## Cause of the issue

src/util.ts has the following lines for sorting arrays:
```ts
.sort((a, b) => {
  if (typeof a === 'string' && typeof b === 'string')
    return a.localeCompare(b);

  if (typeof a === 'object') return 1;
  else return -1;
})
```

It returns `1` if the left operand is an object and `-1` otherwise. The spec has no constraints for the order of `a` and `b` in the compare function. It seems to be different in Chrome and Firefox.

## Possible solutions

- Return `0` if one operand is not a string (`sort` is stable, it will preserve the order in this case)
- Don't sort arrays at all

Both solutions would be a breaking change.