### PR TITLE
Remove legacy triple slash directives

### DIFF
--- a/dist/types/plugins/pouchdb/pouchdb-helper.d.ts
+++ b/dist/types/plugins/pouchdb/pouchdb-helper.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-/// <reference types="pouchdb-core" />
 import type { ChangeStreamEvent, DeepReadonly, JsonSchema, MaybeReadonly, PouchChangeRow, PouchCheckpoint, PouchDBInstance, RxAttachmentData, RxAttachmentWriteData, RxDocumentData, RxDocumentWriteData, RxLocalDocumentData, StringKeys, WithAttachments } from '../../types';
 import type { RxStorageInstancePouch } from './rx-storage-instance-pouch';
 import type { ChangeEvent } from 'event-reduce-js';


### PR DESCRIPTION
I'm facing build issue when using RxDB from Angular project due to triple-slash directive usage in `pouchdb-helper.d.ts`.

Minimal project to reproduce issue
* `packages.json`
```json
{
  "dependencies": {
    "rxdb": "^13.4.5"
  }
}
```
* `main.ts`
```typescript
import { addPouchPlugin, getRxStoragePouch } from 'rxdb/plugins/pouchdb'

console.log("Hello world")
```
* `tsconfig`
```json
{
  "compilerOptions": {
    "types": []
  }
}
```
Build command line
```bash
npm i && tsc
```
Build error
```
...
node_modules/@types/node/ts4.8/buffer.d.ts:97:14 - error TS2661: Cannot export 'Buffer'. Only local declarations can be exported from a module.

97     export { Buffer };
                ~~~~~~


Found 1 error in node_modules/@types/node/ts4.8/buffer.d.ts:97
```
