### PR TITLE
TYPOFIX: Fix a run-on sentence.

### DIFF
--- a/docs-src/replication.md
+++ b/docs-src/replication.md
@@ -2,7 +2,7 @@
 
 The RxDB replication protocol allows to replicate the database state in **realtime** between the clients and the server.
 
-The backend server does not have to be a RxDB instance, you can build a replication with **any infrastructure**.
+The backend server does not have to be a RxDB instance; you can build a replication with **any infrastructure**.
 For example you can replicate with a custom GraphQL endpoint or a http server on top of a PostgreSQL database.
 
 The replication is made to support the [Offline-First](http://offlinefirst.org/) paradigm, so that when the client goes offline, the RxDB database can still read and write locally and will continue the replication when the client goes online again.


### PR DESCRIPTION
This one is a little tricky. The original sentence with just a comma (,) delimiter reads like a run-on sentence. I tried replacing it with a period/full-stop (.) to make two sentences, but I think that loses some of the impact the original version intended. A semi-colon (;) strikes me as being appropriate because the second part really builds on the first part, but needs a stronger separator than a comma. While I think it works here, the semi-colon is fairly niche use in most English writing. Other options that I think could work in place of the semi-colon would be a colon (:) or mdash (—).