### PR TITLE
Stop retries

### DIFF
--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -576,7 +576,8 @@ describe('replication-graphql.test.ts', () => {
                     replicationState.cancel()
                 });
 
-                const timeout = new Promise((resolve, _) => setTimeout(resolve, 500, 'timeout'));
+
+                const timeout = wait(500).then(() => 'timeout');
 
                 assert.notStrictEqual(await Promise.race([replicationState.awaitInitialReplication(), timeout]), 'timeout',)
 
@@ -930,7 +931,7 @@ describe('replication-graphql.test.ts', () => {
                     replicationState.cancel()
                 });
 
-                const timeout = new Promise((resolve, _) => setTimeout(resolve, 500, 'timeout'));
+                const timeout = wait(500).then(() => 'timeout');
 
                 assert.notStrictEqual(await Promise.race([replicationState.awaitInitialReplication(), timeout]), 'timeout',)
 
@@ -962,7 +963,7 @@ describe('replication-graphql.test.ts', () => {
                     replicationState.cancel()
                 });
 
-                const timeout = new Promise((resolve, _) => setTimeout(resolve, 500, 'timeout'));
+                const timeout = wait(500).then(() => 'timeout');
 
                 assert.notStrictEqual(await Promise.race([replicationState.awaitInitialReplication(), timeout]), 'timeout',)
 


### PR DESCRIPTION
## This PR contains:
* A bugfix

## Describe the problem you have without this PR
At this time it doesn't appear to be possible to stop RxDB from retrying requests after a non-recoverable error (ex 401). A simple example:
```typescript
const state = db.test.syncGraphQL({
    url: { http: "/badurl" },
    pull: {
      queryBuilder: pullQueryBuilderFromRxSchema("test", {
        schema: schema,
        checkpointFields: ["id", "updatedAt"],
      }),
    },
    live: false,
  });

state.error$.subscribe((err) => {
    console.log("error", err);
    void state
      .cancel()
      .catch((err) => console.log("cancel error", err))
      .then(() => console.log("cancel done"));
  });
```
"Cancel done" is logged to the console however a new request is still sent every 5 seconds.
