### PR TITLE
Typo in CRDT Plugin: RxDDcrdtPlugin

### DIFF
--- a/dist/types/plugins/crdt/index.d.ts
+++ b/dist/types/plugins/crdt/index.d.ts
@@ -9,4 +9,4 @@ export declare function mergeCRDTFields<RxDocType>(hashFunction: HashFunction, c
 export declare function rebuildFromCRDT<RxDocType>(storageStatics: RxStorageStatics, schema: RxJsonSchema<RxDocumentData<RxDocType>>, docData: WithDeleted<RxDocType>, crdts: CRDTDocumentField<RxDocType>): WithDeleted<RxDocType>;
 export declare function getCRDTConflictHandler<RxDocType>(hashFunction: HashFunction, storageStatics: RxStorageStatics, schema: RxJsonSchema<RxDocumentData<RxDocType>>): RxConflictHandler<RxDocType>;
 export declare const RX_CRDT_CONTEXT = "rx-crdt";
-export declare const RxDDcrdtPlugin: RxPlugin;
+export declare const RxDBcrdtPlugin: RxPlugin;

--- a/src/plugins/crdt/index.ts
+++ b/src/plugins/crdt/index.ts
@@ -351,7 +351,7 @@ export function getCRDTConflictHandler<RxDocType>(
 
 export const RX_CRDT_CONTEXT = 'rx-crdt';
 
-export const RxDDcrdtPlugin: RxPlugin = {
+export const RxDBcrdtPlugin: RxPlugin = {
     name: 'crdt',
     rxdb: true,
     prototypes: {

--- a/test/unit/crdt.test.ts
+++ b/test/unit/crdt.test.ts
@@ -24,10 +24,10 @@ import {
 
 import {
     getCRDTSchemaPart,
-    RxDDcrdtPlugin,
+    RxDBcrdtPlugin,
     getCRDTConflictHandler
 } from '../../plugins/crdt';
-addRxPlugin(RxDDcrdtPlugin);
+addRxPlugin(RxDBcrdtPlugin);
 import config from './config';
 import { replicateRxCollection, RxReplicationState } from '../../plugins/replication';
 import { ReplicationPullHandler, ReplicationPushHandler } from '../../src/types';


### PR DESCRIPTION
## This PR contains:

 - A BREAKING CHANGE, a plugin typo


## Describe the problem you have without this PR
All plugin have RxDB as a prefix, CRDT plugin did not have it. Also, if you want to merge it, it will probably better to fix the lowercase crtd to all uppercase since its an abbreviation.

