### PR TITLE
GraphQL replication: should stop syncing if we receive less docs than pull.batchSize

### DIFF
--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -521,6 +521,43 @@ describe('replication-graphql.test.ts', () => {
                 server.close();
                 c.database.destroy();
             });
+            // https://github.com/pubkey/rxdb/blob/d7c3aca4f49d605ceae8997df32f713d0fe21ee2/src/types/plugins/replication.d.ts#L47-L53
+            it('should stop pulling when response returns less documents than the pull.batchSize', async () => {
+                const amount = batchSize + 1;
+                const [c, server] = await Promise.all([
+                    humansCollection.createHumanWithTimestamp(0),
+                    SpawnServer.spawn(getTestData(amount)),
+                ]);
+                let responseHaveBeenCalledTimes = 0;
+                const replicationState = c.syncGraphQL({
+                    url: server.url,
+                    pull: {
+                        batchSize,
+                        queryBuilder: pullQueryBuilder,
+                        responseModifier: (res: any) => {
+                            responseHaveBeenCalledTimes += 1;
+                            return res;
+                        },
+                    },
+                    live: false,
+                    deletedField: 'deleted',
+                });
+
+                // wait until first replication is done
+                await replicationState.awaitInitialReplication();
+
+                const docs = await c.find().exec();
+                assert.strictEqual(docs.length, amount);
+
+                // do not send a request if the server returned less documents than the batch size
+                assert.strictEqual(
+                    responseHaveBeenCalledTimes,
+                    Math.ceil(amount / batchSize)
+                );
+
+                server.close();
+                c.database.destroy();
+            });
             it('should retry on errors', async () => {
                 const amount = batchSize * 4;
                 const testData = getTestData(amount);
@@ -745,48 +782,6 @@ describe('replication-graphql.test.ts', () => {
 
                 server.close();
                 c.database.destroy();
-            });
-             // https://github.com/pubkey/rxdb/blob/d7c3aca4f49d605ceae8997df32f713d0fe21ee2/src/types/plugins/replication.d.ts#L47-L53
-             it('should stop pulling when response returns less documents than the pull.batchSize', async () => {
-                const amount = batchSize + 1;
-                const [c, server] = await Promise.all([
-                    humansCollection.createHumanWithTimestamp(0),
-                    SpawnServer.spawn(getTestData(amount)),
-                ]);
-                let responseHaveBeenCalledTimes = 0;
-                const replicationState = c.syncGraphQL({
-                    url: server.url,
-                    pull: {
-                        batchSize,
-                        queryBuilder: pullQueryBuilder,
-                        responseModifier: (res: any) => {
-                            responseHaveBeenCalledTimes += 1;
-                            return res;
-                        },
-                    },
-                    live: true,
-                    deletedField: 'deleted',
-                });
-
-                // wait until first replication is done
-                await replicationState.awaitInitialReplication();
-
-                const docs = await c.find().exec();
-                assert.strictEqual(docs.length, amount);
-
-                await wait(250);
-
-                // do not send a request if the server returned less documents than the batch size
-                assert.strictEqual(
-                    responseHaveBeenCalledTimes,
-                    Math.ceil(amount / batchSize)
-                );
-
-                server.close();
-                await c.database.destroy();
-
-                // replication should be canceled when collection is destroyed
-                assert.ok(replicationState.isStopped());
             });
         });
 


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS (fail test)

## Describe the problem you have without this PR
If we send the initialSync with a batchSize of `5`, the server last response will contain less than the batchSize (let say `2`) and instead of finishing the initial replication, rxdb will always request a last time because it ends only if there are no document in the response. [Actually the batchSize interface tells us, that the replication will stops if the response contains less documents than the batchSize, which is currently not true](https://github.com/pubkey/rxdb/blob/d7c3aca4f49d605ceae8997df32f713d0fe21ee2/src/types/plugins/replication.d.ts#L47-L53)

 It will also be preferrable to resolve this case, cause we also prevent relying on the server to stop the sync process.
Currently we have, at work, a endpoint that need to be fix, it includes in the response the document that fits the checkpoint.updatedAt, so the initialSync() never stop.

- [x] Tests

