### PR TITLE
Added example config for Vite/Sveltekit

### DIFF
--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -1,0 +1,22 @@
+// Only required for Sveltekit
+// import { sveltekit } from '@sveltejs/kit/vite';
+
+import type { UserConfig } from 'vite';
+import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfill';
+
+const config: UserConfig = {
+	resolve: {
+		alias: {
+			events: 'rollup-plugin-node-polyfills/polyfills/events'
+		}
+	},
+	// Only required for Sveltekit
+	// plugins: [sveltekit()],
+	optimizeDeps: {
+		esbuildOptions: {
+			plugins: [NodeModulesPolyfillPlugin()]
+		}
+	}
+};
+
+export default config;


### PR DESCRIPTION
## This PR contains:
A configuration for Vite for use with Sveltekit. 

## Describe the problem you have without this PR
`RxDBDevModePlugin` does not work in Vite/Sveltekit.


I was having troubles getting rxdb to work with Sveltekit - so did someone else in the Discord, but to no avail. Having spent some time getting the right polyfill working I thought this might help someone in the future on a similar path.

This is working for me with the newest version of Sveltekit and it should work the same in Vite.