### PR TITLE
fix: emit false on active$ after replication is done

### DIFF
--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -368,15 +368,23 @@ describe('replication.test.js', () => {
                 throw err;
             });
 
-            let wasActive = false;
+            const values: boolean[] = [];
             replicationState.active$.subscribe((active) => {
-                if (active) wasActive = active;
+                values.push(active);
             });
 
             await replicationState.awaitInitialReplication();
             assert.strictEqual(
-                wasActive,
+                values.length > 0,
                 true
+            );
+            assert.strictEqual(
+                values.includes(true),
+                true
+            );
+            assert.strictEqual(
+                values[values.length - 1],
+                false
             );
 
             localCollection.database.destroy();


### PR DESCRIPTION
It seems that the fix for #4117 in #4124 was not complete. However, the provided test case wasn't complete either.
I've extend the test case to also test if `false` is emitted after replication has completed.