### PR TITLE
Add missing obligatory fields to commented ex

### DIFF
--- a/examples/graphql/server/index.js
+++ b/examples/graphql/server/index.js
@@ -263,7 +263,9 @@ export async function run() {
                 documents: [{
                     id: 'foobar-' + flag,
                     name: 'name-' + flag,
-                    color: 'green'
+                    color: 'green',
+                    updatedAt: flag,
+                    deleted: false
                 }],
                 checkpoint: {
                     id: 'foobar-' + flag,


### PR DESCRIPTION
When uncommented, the example causes errors

## This PR contains:
A DOCUMENTATION BUGFIX

## Describe the problem you have without this PR
There is an incomplete (commented) example of how to use subscriptions. Uncommenting, as per the instructions, causes errors to be raised rather than a functioning example. This PR gets rid of the errors and produces the expected behaviour.

