### PR TITLE
Composite Primary Keys broken on replicated collections

### DIFF
--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,70 +1,70 @@
-import './unit/init.test';
-import './unit/util.test';
-import './unit/pouch-db-integration.test';
-import './unit/adapter-check.test';
+// import './unit/init.test';
+// import './unit/util.test';
+// import './unit/pouch-db-integration.test';
+// import './unit/adapter-check.test';
 
 
-/**
- * Helpers that
- * do not fully test RxDB but
- * just single methods
- */
-import './unit/custom-index.test';
-import './unit/query-planner.test';
+// /**
+//  * Helpers that
+//  * do not fully test RxDB but
+//  * just single methods
+//  */
+// import './unit/custom-index.test';
+// import './unit/query-planner.test';
 
 
-/**
- * Move these tests around so that
- * when you focus on one part of RxDB,
- * your relevant tests run first.
- * Do not commit this file if you modified the order.
- */
-import './unit/rx-storage-implementations.test';
-import './unit/rx-storage-query-correctness.test';
+// /**
+//  * Move these tests around so that
+//  * when you focus on one part of RxDB,
+//  * your relevant tests run first.
+//  * Do not commit this file if you modified the order.
+//  */
+// import './unit/rx-storage-implementations.test';
+// import './unit/rx-storage-query-correctness.test';
 
-import './unit/rx-storage-pouchdb.test';
-import './unit/rx-storage-lokijs.test';
-import './unit/rx-storage-dexie.test';
+// import './unit/rx-storage-pouchdb.test';
+// import './unit/rx-storage-lokijs.test';
+// import './unit/rx-storage-dexie.test';
 
-import './unit/instance-of-check.test';
-import './unit/rx-schema.test';
+// import './unit/instance-of-check.test';
+// import './unit/rx-schema.test';
 import './unit/bug-report.test';
-import './unit/rx-database.test';
-import './unit/rx-collection.test';
-import './unit/validate.test';
-import './unit/attachments.test';
-import './unit/encryption.test';
-import './unit/rx-document.test';
-import './unit/rx-query.test';
-import './unit/primary.test';
-import './unit/local-documents.test';
-import './unit/change-event-buffer.test';
-import './unit/key-compression.test';
-import './unit/event-reduce.test';
-import './unit/cache-replacement-policy.test';
-import './unit/query-builder.test';
-import './unit/idle-queue.test';
-import './unit/conflict-handling.test';
-import './unit/reactive-collection.test';
-import './unit/reactive-query.test';
-import './unit/data-migration.test';
-import './unit/cross-instance.test';
-import './unit/reactive-document.test';
-import './unit/cleanup.test';
-import './unit/hooks.test';
-import './unit/orm.test';
-import './unit/replication-protocol.test';
-import './unit/replication.test';
-import './unit/replication-graphql.test';
-import './unit/replication-couchdb-new.test';
-import './unit/replication-websocket.test';
-import './unit/replication-couchdb.test';
-import './unit/replication-p2p.test';
-import './unit/crdt.test';
-import './unit/server-couchdb.test';
-import './unit/population.test';
-import './unit/leader-election.test';
-import './unit/backup.test';
-import './unit/import-export.test';
-import './unit/plugin.test';
-import './unit/last.test';
+// import './unit/rx-database.test';
+// import './unit/rx-collection.test';
+// import './unit/validate.test';
+// import './unit/attachments.test';
+// import './unit/encryption.test';
+// import './unit/rx-document.test';
+// import './unit/rx-query.test';
+// import './unit/primary.test';
+// import './unit/local-documents.test';
+// import './unit/change-event-buffer.test';
+// import './unit/key-compression.test';
+// import './unit/event-reduce.test';
+// import './unit/cache-replacement-policy.test';
+// import './unit/query-builder.test';
+// import './unit/idle-queue.test';
+// import './unit/conflict-handling.test';
+// import './unit/reactive-collection.test';
+// import './unit/reactive-query.test';
+// import './unit/data-migration.test';
+// import './unit/cross-instance.test';
+// import './unit/reactive-document.test';
+// import './unit/cleanup.test';
+// import './unit/hooks.test';
+// import './unit/orm.test';
+// import './unit/replication-protocol.test';
+// import './unit/replication.test';
+// import './unit/replication-graphql.test';
+// import './unit/replication-couchdb-new.test';
+// import './unit/replication-websocket.test';
+// import './unit/replication-couchdb.test';
+// import './unit/replication-p2p.test';
+// import './unit/crdt.test';
+// import './unit/server-couchdb.test';
+// import './unit/population.test';
+// import './unit/leader-election.test';
+// import './unit/backup.test';
+// import './unit/import-export.test';
+// import './unit/plugin.test';
+// import './unit/last.test';

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,70 +1,70 @@
-// import './unit/init.test';
-// import './unit/util.test';
-// import './unit/pouch-db-integration.test';
-// import './unit/adapter-check.test';
+import './unit/init.test';
+import './unit/util.test';
+import './unit/pouch-db-integration.test';
+import './unit/adapter-check.test';
 
 
-// /**
-//  * Helpers that
-//  * do not fully test RxDB but
-//  * just single methods
-//  */
-// import './unit/custom-index.test';
-// import './unit/query-planner.test';
+/**
+ * Helpers that
+ * do not fully test RxDB but
+ * just single methods
+ */
+import './unit/custom-index.test';
+import './unit/query-planner.test';
 
 
-// /**
-//  * Move these tests around so that
-//  * when you focus on one part of RxDB,
-//  * your relevant tests run first.
-//  * Do not commit this file if you modified the order.
-//  */
-// import './unit/rx-storage-implementations.test';
-// import './unit/rx-storage-query-correctness.test';
+/**
+ * Move these tests around so that
+ * when you focus on one part of RxDB,
+ * your relevant tests run first.
+ * Do not commit this file if you modified the order.
+ */
+import './unit/rx-storage-implementations.test';
+import './unit/rx-storage-query-correctness.test';
 
-// import './unit/rx-storage-pouchdb.test';
-// import './unit/rx-storage-lokijs.test';
-// import './unit/rx-storage-dexie.test';
+import './unit/rx-storage-pouchdb.test';
+import './unit/rx-storage-lokijs.test';
+import './unit/rx-storage-dexie.test';
 
-// import './unit/instance-of-check.test';
-// import './unit/rx-schema.test';
+import './unit/instance-of-check.test';
+import './unit/rx-schema.test';
 import './unit/bug-report.test';
-// import './unit/rx-database.test';
-// import './unit/rx-collection.test';
-// import './unit/validate.test';
-// import './unit/attachments.test';
-// import './unit/encryption.test';
-// import './unit/rx-document.test';
-// import './unit/rx-query.test';
-// import './unit/primary.test';
-// import './unit/local-documents.test';
-// import './unit/change-event-buffer.test';
-// import './unit/key-compression.test';
-// import './unit/event-reduce.test';
-// import './unit/cache-replacement-policy.test';
-// import './unit/query-builder.test';
-// import './unit/idle-queue.test';
-// import './unit/conflict-handling.test';
-// import './unit/reactive-collection.test';
-// import './unit/reactive-query.test';
-// import './unit/data-migration.test';
-// import './unit/cross-instance.test';
-// import './unit/reactive-document.test';
-// import './unit/cleanup.test';
-// import './unit/hooks.test';
-// import './unit/orm.test';
-// import './unit/replication-protocol.test';
-// import './unit/replication.test';
-// import './unit/replication-graphql.test';
-// import './unit/replication-couchdb-new.test';
-// import './unit/replication-websocket.test';
-// import './unit/replication-couchdb.test';
-// import './unit/replication-p2p.test';
-// import './unit/crdt.test';
-// import './unit/server-couchdb.test';
-// import './unit/population.test';
-// import './unit/leader-election.test';
-// import './unit/backup.test';
-// import './unit/import-export.test';
-// import './unit/plugin.test';
-// import './unit/last.test';
+import './unit/rx-database.test';
+import './unit/rx-collection.test';
+import './unit/validate.test';
+import './unit/attachments.test';
+import './unit/encryption.test';
+import './unit/rx-document.test';
+import './unit/rx-query.test';
+import './unit/primary.test';
+import './unit/local-documents.test';
+import './unit/change-event-buffer.test';
+import './unit/key-compression.test';
+import './unit/event-reduce.test';
+import './unit/cache-replacement-policy.test';
+import './unit/query-builder.test';
+import './unit/idle-queue.test';
+import './unit/conflict-handling.test';
+import './unit/reactive-collection.test';
+import './unit/reactive-query.test';
+import './unit/data-migration.test';
+import './unit/cross-instance.test';
+import './unit/reactive-document.test';
+import './unit/cleanup.test';
+import './unit/hooks.test';
+import './unit/orm.test';
+import './unit/replication-protocol.test';
+import './unit/replication.test';
+import './unit/replication-graphql.test';
+import './unit/replication-couchdb-new.test';
+import './unit/replication-websocket.test';
+import './unit/replication-couchdb.test';
+import './unit/replication-p2p.test';
+import './unit/crdt.test';
+import './unit/server-couchdb.test';
+import './unit/population.test';
+import './unit/leader-election.test';
+import './unit/backup.test';
+import './unit/import-export.test';
+import './unit/plugin.test';
+import './unit/last.test';

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -150,7 +150,7 @@ describe('bug-report.test.js', () => {
             replicationIdentifier: 'replicate-' + name,
             collection: db.collections.mycollection,
             pull: {
-                async handler(lastCheckpoint: CheckpointType) {
+                handler(lastCheckpoint: CheckpointType) {
                     const docs = (fetched) ? [] : [{
                         userId: '627b696f-6c1f-4aac-9d60-c876fb0b175c',
                         projectId: 'b1ebbec0-58c4-4364-9b4b-a32665276c0f',


### PR DESCRIPTION
### BUG REPLICATION

## Describe the problem you have without this PR
When documents are added to a collection with a composite primary key through the pull handler of a replication, the resulting composite primary key is accessed before it is generated.
