### PR TITLE
Add missing mingo array operators

### DIFF
--- a/src/rx-query-mingo.ts
+++ b/src/rx-query-mingo.ts
@@ -6,6 +6,7 @@ import { $sort, $project } from 'mingo/operators/pipeline';
 import {
     $and,
     $eq,
+    $elemMatch,
     $exists,
     $gt,
     $gte,
@@ -19,6 +20,7 @@ import {
     $not,
     $or,
     $regex,
+    $size,
     $type,
 } from 'mingo/operators/query';
 
@@ -44,6 +46,7 @@ export function getMingoQuery<RxDocType>(
         useOperators(OperatorType.QUERY, {
             $and,
             $eq,
+            $elemMatch,
             $exists,
             $gt,
             $gte,
@@ -57,6 +60,7 @@ export function getMingoQuery<RxDocType>(
             $not,
             $or,
             $regex,
+            $size,
             $type,
         } as any);
         mingoInitDone = true;

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../plugins/dev-mode';
 import { EXAMPLE_REVISION_1 } from '../helper/revisions';
 import * as schemas from '../helper/schemas';
-import { human, nestedHuman, NestedHumanDocumentType } from '../helper/schema-objects';
+import { HeroArrayDocumentType, human, nestedHuman, NestedHumanDocumentType } from '../helper/schema-objects';
 
 const TEST_CONTEXT = 'rx-storage-query-correctness.test.ts';
 config.parallel('rx-storage-query-correctness.test.ts', () => {
@@ -413,6 +413,82 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
                     'aaa'
                 ]
             }
+        ]
+    });
+    testCorrectQueries<HeroArrayDocumentType>({
+        testTitle: '$elemMatch/$size',
+        data: [
+            {
+                name: 'foo1',
+                skills: [
+                    {
+                        name: 'bar1',
+                        damage: 10
+                    },
+                    {
+                        name: 'bar2',
+                        damage: 5
+                    },
+                ],
+            },
+            {
+                name: 'foo2',
+                skills: [
+                    {
+                        name: 'bar3',
+                        damage: 10
+                    },
+                    {
+                        name: 'bar4',
+                        damage: 10
+                    },
+                ],
+            },
+            {
+                name: 'foo3',
+                skills: [
+                    {
+                        name: 'bar5',
+                        damage: 5
+                    },
+                ],
+            }
+        ],
+        schema: schemas.heroArray,
+        queries: [
+            {
+                info: '$elemMatch',
+                query: {
+                    selector: {
+                        skills: {
+                            $elemMatch: {
+                                damage: 5
+                            }
+                        },
+                    },
+                    sort: [{ name: 'asc' }]
+                },
+                selectorSatisfiedByIndex: false,
+                expectedResultDocIds: [
+                    'foo1',
+                    'foo3'
+                ]
+            },
+            {
+                info: '$size',
+                query: {
+                    selector: {
+                        skills: {
+                            $size: 1
+                        },
+                    },
+                    sort: [{ name: 'asc' }]
+                },
+                selectorSatisfiedByIndex: false,
+                expectedResultDocIds: [
+                    'foo3'
+                ]
+            },
         ]
     });
 });


### PR DESCRIPTION
## This PR contains:

 - IMPROVED TESTS
 - A BUGFIX

## Describe the problem you have without this PR

The `$elemMatch` operator did not work for me after upgrading to 13.17.0. It seems like the array operators `$elemMatch`, `$all` and `$size` are not enabled in mingo anymore. But they are part of the RxQuery type definition:

https://github.com/pubkey/rxdb/blob/d828b8181e5c24c08d32429923508fa8d2e1a5ac/src/types/rx-query.d.ts#L20-L22

This PR enables them and adds a corresponding test.