### PR TITLE
Correct way to import socket.io-client in P2P Simple Peer Replication

### DIFF
--- a/src/plugins/replication-p2p/connection-handler-simple-peer.ts
+++ b/src/plugins/replication-p2p/connection-handler-simple-peer.ts
@@ -23,7 +23,7 @@ export function getConnectionHandlerSimplePeer(
     serverUrl: string,
     wrtc?: any
 ): P2PConnectionHandlerCreator {
-    const io = require('socket.io-client');
+    const { io } = require('socket.io-client');
 
 
     const creator: P2PConnectionHandlerCreator = (options) => {


### PR DESCRIPTION
Importing `io` was not correct, and it caused the issue for my builds. 

The correct way to import `io` would be:

```
const { io } = require("socket.io-client");
```

and not

```
const io = require("socket.io-client");
```

According to the doc:

https://socket.io/docs/v4/client-initialization/

And this worked just fine at my side.