### PR TITLE
CHANGE `RxDocument.$` now emits `RxDocument` instances instead of the plain document data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - ADD non-incremental `RxDocument` methods `patch()` and `modify()`
 - ADD typings to the query selector
 - CHANGE start replication via pure functions instead of RxCollection methods.
+- CHANGE `RxDocument.$` emits `RxDocument` instances instead of the plain document data.
 
 #
 - CHANGE Do not use hash for revisions but use database instance token instead.

--- a/docs-src/releases/14.0.0.md
+++ b/docs-src/releases/14.0.0.md
@@ -23,6 +23,8 @@ However this behavior is also confusing many times. When the state in the databa
 
 In RxDB v14, all RxDocuments are immutable. When you subscribe to a query and the same document is returned in the results, this will always be a new JavaScript object.
 
+Also `RxDocument.$` now emits `RxDocument` instances instead of the plain document data.
+
 ### Refactor `findByIds()`
 
 In the past, the functions `findByIds` and `findByIds$` directly returned the result set. This was confusing, instead they now return a `RxQuery` object that works exactly like any other database query.

--- a/src/plugins/attachments/index.ts
+++ b/src/plugins/attachments/index.ts
@@ -245,8 +245,8 @@ export const RxDBAttachmentsPlugin: RxPlugin = {
                 get: function allAttachments$(this: RxDocument) {
                     return this.$
                         .pipe(
-                            map(data => Object.entries(
-                                data._attachments
+                            map(rxDocument => Object.entries(
+                                rxDocument.toJSON(true)._attachments
                             )),
                             map(entries => {
                                 return (entries as any)

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -95,6 +95,7 @@ export const basePrototype = {
             map(changeEvent => getDocumentDataOfRxChangeEvent(changeEvent)),
             startWith(_this.collection._docCache.getLatestDocumentData(this.primary)),
             distinctUntilChanged((prev, curr) => prev._rev === curr._rev),
+            map(docData => (this as RxDocument<any>).collection._docCache.getCachedRxDocument(docData)),
             shareReplay(RXJS_SHARE_REPLAY_DEFAULTS)
         );
     },

--- a/src/types/rx-document.d.ts
+++ b/src/types/rx-document.d.ts
@@ -49,7 +49,7 @@ export declare interface RxDocumentBase<RxDocType, OrmMethods = {}> {
     collection: RxCollection<RxDocType, OrmMethods>;
     readonly deleted: boolean;
 
-    readonly $: Observable<DeepReadonly<RxDocumentData<RxDocType>>>;
+    readonly $: Observable<RxDocument<RxDocType, OrmMethods>>;
     readonly deleted$: Observable<boolean>;
 
     readonly primary: string;

--- a/test/unit/reactive-document.test.ts
+++ b/test/unit/reactive-document.test.ts
@@ -23,6 +23,7 @@ import type {
     RxChangeEvent
 } from '../../src/types';
 import { HumanDocumentType } from '../helper/schemas';
+import { firstValueFrom } from 'rxjs';
 
 config.parallel('reactive-document.test.js', () => {
     describe('.save()', () => {
@@ -141,6 +142,19 @@ config.parallel('reactive-document.test.js', () => {
             });
         });
         describe('negative', () => { });
+    });
+    describe('.$', () => {
+        it('should emit a RxDocument, not only the document data', async () => {
+            const c = await humansCollection.create(1);
+            const doc = await c.findOne().exec(true);
+
+            const firstEmitPromise = firstValueFrom(doc.$);
+            doc.incrementalPatch({ age: 100 });
+
+            const emitted = await firstEmitPromise;
+            assert.ok(emitted.$);
+            c.database.destroy();
+        });
     });
     describe('.get$()', () => {
         describe('positive', () => {

--- a/test/unit/reactive-document.test.ts
+++ b/test/unit/reactive-document.test.ts
@@ -20,8 +20,7 @@ import {
     first
 } from 'rxjs/operators';
 import type {
-    RxChangeEvent,
-    RxDocument
+    RxChangeEvent
 } from '../../src/types';
 import { HumanDocumentType } from '../helper/schemas';
 
@@ -182,47 +181,5 @@ config.parallel('reactive-document.test.js', () => {
         });
     });
     describe('issues', () => {
-        it('#3434 event data must not be mutateable', async () => {
-            const db = await createRxDatabase({
-                name: randomCouchString(10),
-                storage: config.storage.getStorage(),
-                eventReduce: true,
-                ignoreDuplicate: true
-            });
-            const collections = await db.addCollections({
-                mycollection: {
-                    schema: schemas.humanDefault
-                }
-            });
-            await collections.mycollection.insert({
-                passportId: 'foobar',
-                firstName: 'Bob',
-                lastName: 'Kelso',
-                age: 56
-            });
-
-            const person: RxDocument<HumanDocumentType> = await db.mycollection.findOne().exec();
-
-
-            let hasThrown = false;
-            person.$.subscribe(data => {
-                try {
-                    // mutating the document data is not allowed and should throw
-                    delete (data as any)['_rev'];
-                } catch (err) {
-                    hasThrown = true;
-                }
-            });
-
-            await person.incrementalModify(state => {
-                state.age = 50;
-                return state;
-            });
-
-            assert.strictEqual(person.getLatest().age, 50);
-            assert.ok(hasThrown);
-
-            db.destroy();
-        });
     });
 });


### PR DESCRIPTION
WIP