### PR TITLE
Test and fix for crash with null in selector

### DIFF
--- a/src/plugins/storage-lokijs/lokijs-helper.ts
+++ b/src/plugins/storage-lokijs/lokijs-helper.ts
@@ -478,7 +478,7 @@ export async function mustUseLocalState(
  * @recursive
  */
 export function transformRegexToRegExp(selector: any) {
-    if (typeof selector !== 'object') {
+    if (typeof selector !== 'object' || selector === null) {
         return selector;
     }
 

--- a/src/rx-query-helper.ts
+++ b/src/rx-query-helper.ts
@@ -165,7 +165,7 @@ export function normalizeMangoQuery<RxDocType>(
 export function normalizeQueryRegex(
     selector: any
 ): any {
-    if (typeof selector !== 'object') {
+    if (typeof selector !== 'object' || selector === null) {
         return selector;
     }
 

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -546,4 +546,69 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
             },
         ]
     });
+    testCorrectQueries({
+        testTitle: '$eq null',
+        data: [
+            {
+                foo: '1',
+                bar: 'test'
+            },
+            {
+                foo: '2',
+                bar: null
+            }
+        ],
+        schema: {
+            version: 0,
+            primaryKey: 'foo',
+            type: 'object',
+            properties: {
+                foo: {
+                    type: 'string',
+                    maxLength: 100
+                },
+                bar: {
+                    oneOf: [
+                        {
+                            type: 'string'
+                        },
+                        {
+                            type: 'null'
+                        }
+                    ]
+                },
+            },
+            required: ['foo', 'bar'],
+        },
+        queries: [
+            {
+                info: '$eq string',
+                query: {
+                    selector: {
+                        bar: {
+                            $eq: 'test'
+                        }
+                    },
+                    sort: [{ foo: 'asc' }]
+                },
+                expectedResultDocIds: [
+                    '1'
+                ]
+            },
+            {
+                info: '$eq null',
+                query: {
+                    selector: {
+                        bar: {
+                            $eq: null
+                        }
+                    },
+                    sort: [{ foo: 'asc' }]
+                },
+                expectedResultDocIds: [
+                    '2'
+                ]
+            },
+        ]
+    });
 });


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS
 - A BUGFIX

## Describe the problem you have without this PR
If I use `null` in the selector RxDB crashes in this line:

https://github.com/pubkey/rxdb/blob/b24d101c2a7e4e28da207d6ea0c8d8fb4f317e5e/src/rx-query-helper.ts#L172