### PR TITLE
Feature: Ability to use a responseModifier for GraphQL push replication

### DIFF
--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -416,8 +416,7 @@ type PushResponse {
 }
 
 type Mutation {
-    # Returns a list of all conflicts
-    # If no document write caused a conflict, return an empty list.
+    # Returns a PushResponse type that contains the conflicts along with other information
     pushHuman(rows: [HumanInputPushRow!]): PushResponse!
 }
 ```

--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -131,8 +131,8 @@ const pullQueryBuilder = (checkpoint, limit) => {
      */
     if (!checkpoint) {
         checkpoint = {
-            id: "",
-            updatedAt: 0,
+            id: '',
+            updatedAt: 0
         };
     }
     const query = `query PullHuman($checkpoint: CheckpointInput, $limit: Int!) {
@@ -154,8 +154,8 @@ const pullQueryBuilder = (checkpoint, limit) => {
         query,
         variables: {
             checkpoint,
-            limit,
-        },
+            limit
+        }
     };
 };
 ```
@@ -207,7 +207,7 @@ const replicationState = replicateGraphQL(
 For the push-replication, you also need a `queryBuilder`. Here, the builder receives a changed document as input which has to be send to the server. It also returns a GraphQL-Query and its data.
 
 ```js
-const pushQueryBuilder = (rows) => {
+const pushQueryBuilder = rows => {
     const query = `
     mutation PushHuman($writeRows: [HumanInputPushRow!]) {
         pushHuman(writeRows: $writeRows) {
@@ -220,11 +220,11 @@ const pushQueryBuilder = (rows) => {
     }
     `;
     const variables = {
-        writeRows: rows,
+        writeRows: rows
     };
     return {
         query,
-        variables,
+        variables
     };
 };
 ```
@@ -232,36 +232,38 @@ const pushQueryBuilder = (rows) => {
 With the queryBuilder, you can then setup the push-replication.
 
 ```js
-const replicationState = replicateGraphQL({
-    collection: myRxCollection,
-    // urls to the GraphQL endpoints
-    url: {
-        http: "http://example.com/graphql",
-    },
-    push: {
-        queryBuilder: pushQueryBuilder, // the queryBuilder from above
-        /**
-         * batchSize (optional)
-         * Amount of document that will be pushed to the server in a single request.
-         */
-        batchSize: 5,
-        /**
-         * modifier (optional)
-         * Modifies all pushed documents before they are send to the GraphQL endpoint.
-         * Returning null will skip the document.
-         */
-        modifier: (doc) => doc,
-        dataPath: undefined, // (optional) specifies the object path to access the conflicting document(s). Otherwise, the first result of the response data is used.
-    },
-    headers: {
-        Authorization: "Bearer abcde...",
-    },
-    pull: {
+const replicationState = replicateGraphQL(
+    {
+        collection: myRxCollection,
+        // urls to the GraphQL endpoints
+        url: {
+            http: 'http://example.com/graphql'
+        },
+        push: {
+            queryBuilder: pushQueryBuilder, // the queryBuilder from above
+            /**
+             * batchSize (optional)
+             * Amount of document that will be pushed to the server in a single request.
+             */
+            batchSize: 5,
+            /**
+             * modifier (optional)
+             * Modifies all pushed documents before they are send to the GraphQL endpoint.
+             * Returning null will skip the document.
+             */
+            modifier: doc => doc
+        },
+        headers: {
+            Authorization: 'Bearer abcde...'
+        },
+        pull: {
+            /* ... */
+        },
         /* ... */
-    },
-    /* ... */
-});
+    }
+);
 ```
+
 
 #### Pull Stream
 
@@ -288,8 +290,8 @@ const pullStreamQueryBuilder = (headers) => {
     return {
         query,
         variables: {
-            headers,
-        },
+            headers
+        }
     };
 };
 ```
@@ -297,52 +299,48 @@ const pullStreamQueryBuilder = (headers) => {
 With the `pullStreamQueryBuilder` you can then start a realtime replication.
 
 ```js
-const replicationState = replicateGraphQL({
-    collection: myRxCollection,
-    // urls to the GraphQL endpoints
-    url: {
-        http: "http://example.com/graphql",
-        ws: "ws://example.com/subscriptions", // <- The websocket has to use a different url.
-    },
-    push: {
-        batchSize: 100,
-        queryBuilder: pushQueryBuilder,
-    },
-    headers: {
-        Authorization: "Bearer abcde...",
-    },
-    pull: {
-        batchSize: 100,
-        queryBuilder: pullQueryBuilder,
-        streamQueryBuilder: pullStreamQueryBuilder,
-    },
-    deletedField: "deleted",
-});
+const replicationState = replicateGraphQL(
+    {
+        collection: myRxCollection,
+        // urls to the GraphQL endpoints
+        url: {
+            http: 'http://example.com/graphql',
+            ws: 'ws://example.com/subscriptions' // <- The websocket has to use a different url.
+        },
+        push: {
+            batchSize: 100,
+            queryBuilder: pushQueryBuilder
+        },
+        headers: {
+            Authorization: 'Bearer abcde...'
+        },
+        pull: {
+            batchSize: 100,
+            queryBuilder: pullQueryBuilder,
+            streamQueryBuilder: pullStreamQueryBuilder
+        },
+        deletedField: 'deleted'
+    }
+);
 ```
 
 **NOTICE**: If it is not possible to create a websocket server on your backend, you can use any other method of pull out the ongoing events from the backend and then you can send them into `RxReplicationState.emitEvent()`.
+
 
 ### Transforming null to undefined in optional fields
 
 GraphQL fills up non-existent optional values with `null` while RxDB required them to be `undefined`.
 Therefore, if your schema contains optional properties, you have to transform the pulled data to switch out `null` to `undefined`
-
 ```js
 const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
     {
         collection: myRxCollection,
-        url: {
-            /* ... */
-        },
-        headers: {
-            /* ... */
-        },
-        push: {
-            /* ... */
-        },
+        url: {/* ... */},
+        headers: {/* ... */},
+        push: {/* ... */},
         pull: {
             queryBuilder: pullQueryBuilder,
-            modifier: (doc) => {
+            modifier: (doc => {
                 //Wwe have to remove optional non-existend field values
                 // they are set as null by GraphQL but should be undefined
                 Object.entries(doc).forEach(([k, v]) => {
@@ -351,7 +349,7 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
                     }
                 });
                 return doc;
-            },
+            })
         },
         /* ... */
     }
@@ -364,21 +362,17 @@ With the `pull.responseModifier` you can modify the whole response from the Grap
 For example if your endpoint is not capable of returning a valid checkpoint, but instead only returns the plain document array, you can use the `responseModifier` to aggregate the checkpoint from the returned documents.
 
 ```js
-import {} from "rxdb";
+import {
+
+} from 'rxdb';
 const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
     {
         collection: myRxCollection,
-        url: {
-            /* ... */
-        },
-        headers: {
-            /* ... */
-        },
-        push: {
-            /* ... */
-        },
+        url: {/* ... */},
+        headers: {/* ... */},
+        push: {/* ... */},
         pull: {
-            responseModifier: async function (
+            responseModifier: async function(
                 plainResponse, // the exact response that was returned from the server
                 origin, // either 'handler' if plainResponse came from the pull.handler, or 'stream' if it came from the pull.stream
                 requestCheckpoint // if origin==='handler', the requestCheckpoint contains the checkpoint that was send to the backend
@@ -390,15 +384,12 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
                 const docs = plainResponse;
                 return {
                     documents: docs,
-                    checkpoint:
-                        docs.length === 0
-                            ? requestCheckpoint
-                            : {
-                                  name: lastOfArray(docs).name,
-                                  updatedAt: lastOfArray(docs).updatedAt,
-                              },
+                    checkpoint: docs.length === 0 ? requestCheckpoint : {
+                        name: lastOfArray(docs).name,
+                        updatedAt: lastOfArray(docs).updatedAt
+                    }
                 };
-            },
+            }
         },
         /* ... */
     }
@@ -426,12 +417,8 @@ import {} from "rxdb";
 const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
     {
         collection: myRxCollection,
-        url: {
-            /* ... */
-        },
-        headers: {
-            /* ... */
-        },
+        url: {/* ... */},
+        headers: {/* ... */},
         push: {
             responseModifier: async function (plainResponse) {
                 /**
@@ -441,9 +428,7 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
                 return plainResponse.conflicts;
             },
         },
-        pull: {
-            /* ... */
-        },
+        pull: {/* ... */},
         /* ... */
     }
 );
@@ -452,6 +437,7 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
 #### Helper Functions
 
 RxDB provides the helper functions `graphQLSchemaFromRxSchema()`, `pullQueryBuilderFromRxSchema()`, `pullStreamBuilderFromRxSchema()` and `pushQueryBuilderFromRxSchema()` that can be used to generate handlers and schemas from the `RxJsonSchema`. To learn how to use them, please inspect the [GraphQL Example](https://github.com/pubkey/rxdb/tree/master/examples/graphql).
+
 
 ### RxGraphQLReplicationState
 
@@ -463,7 +449,7 @@ Changes the headers for the replication after it has been set up.
 
 ```js
 replicationState.setHeaders({
-    Authorization: `...`,
+    Authorization: `...`
 });
 ```
 
@@ -472,20 +458,23 @@ replicationState.setHeaders({
 The underlying fetch framework uses a `same-origin` policy for credentials per default. That means, cookies and session data is only shared if you backend and frontend run on the same domain and port. Pass the credential parameter to `include` cookies in requests to servers from different origins via:
 
 ```js
-replicationState.setCredentials("include");
+replicationState.setCredentials('include');
 ```
 
 or directly pass it in the the `syncGraphQL`:
 
 ```js
-replicateGraphQL({
-    collection: myRxCollection,
-    /* ... */
-    credentials: "include",
-    /* ... */
-});
+replicateGraphQL(
+    {
+        collection: myRxCollection,
+        /* ... */
+        credentials: 'include',
+        /* ... */
+    }
+);
 ```
 
 See [the fetch spec](https://fetch.spec.whatwg.org/#concept-request-credentials-mode) for more information about available options.
+
 
 **NOTICE:** To play around, check out the full example of the RxDB [GraphQL replication with server and client](https://github.com/pubkey/rxdb/tree/master/examples/graphql)

--- a/docs-src/replication-graphql.md
+++ b/docs-src/replication-graphql.md
@@ -361,7 +361,7 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
 With the `pull.responseModifier` you can modify the whole response from the GraphQL endpoint **before** it is processed by RxDB.
 For example if your endpoint is not capable of returning a valid checkpoint, but instead only returns the plain document array, you can use the `responseModifier` to aggregate the checkpoint from the returned documents.
 
-```js
+```ts
 import {
 
 } from 'rxdb';
@@ -412,7 +412,7 @@ type Mutation {
 }
 ```
 
-```js
+```ts
 import {} from "rxdb";
 const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
     {
@@ -424,7 +424,6 @@ const replicationState: RxGraphQLReplicationState<RxDocType> = replicateGraphQL(
                 /**
                  * In this example we aggregate the conflicting documents from a response object
                  */
-                const pullResponse = plainResponse;
                 return plainResponse.conflicts;
             },
         },

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -161,8 +161,15 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
                 if (result.errors) {
                     throw result.errors;
                 }
-                const dataPath = Object.keys(result.data)[0];
-                const data: any = getProperty(result.data, dataPath);
+                const dataPath = push.dataPath || Object.keys(result.data)[0];
+                let data: any = getProperty(result.data, dataPath);
+
+                if (push.responseModifier) {
+                    data = await push.responseModifier(
+                        data,
+                    );
+                }
+
                 return data;
             },
             batchSize: push.batchSize,

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -1,6 +1,6 @@
 import { RxReplicationWriteToMasterRow } from '../replication-protocol';
 import { ById, MaybePromise } from '../util';
-import { ReplicationOptions, ReplicationPullHandlerResult, ReplicationPullOptions, ReplicationPushOptions } from './replication';
+import { ReplicationOptions, ReplicationPullHandlerResult, ReplicationPullOptions, ReplicationPushHandlerResult, ReplicationPushOptions } from './replication';
 
 export interface RxGraphQLReplicationQueryBuilderResponseObject {
     query: string;
@@ -43,6 +43,11 @@ export type RxGraphQLPullResponseModifier<RxDocType, CheckpointType> = (
     requestCheckpoint?: CheckpointType
 ) => MaybePromise<ReplicationPullHandlerResult<RxDocType, CheckpointType>>;
 
+export type RxGraphQLPushResponseModifier<RxDocType> = (
+    // the exact response that was returned from the server
+    plainResponse: ReplicationPushHandlerResult<RxDocType> | any,
+) => MaybePromise<ReplicationPushHandlerResult<RxDocType>>;
+
 export type RxGraphQLReplicationPullStreamQueryBuilder = (headers: { [k: string]: string; }) => RxGraphQLReplicationQueryBuilderResponse;
 
 export type GraphQLSyncPushOptions<RxDocType> = Omit<
@@ -50,6 +55,8 @@ ReplicationPushOptions<RxDocType>,
 'handler'
 > & {
     queryBuilder: RxGraphQLReplicationPushQueryBuilder;
+    dataPath?: string;
+    responseModifier?: RxGraphQLPushResponseModifier<RxDocType>;
 };
 
 export type GraphQLServerUrl = {

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -22,6 +22,8 @@ export type ReplicationPullHandlerResult<RxDocType, CheckpointType> = {
     documents: WithDeleted<RxDocType>[];
 };
 
+export type ReplicationPushHandlerResult<RxDocType> = RxDocType[];
+
 export type ReplicationPullHandler<RxDocType, CheckpointType> = (
     lastPulledCheckpoint: CheckpointType,
     batchSize: number
@@ -84,6 +86,8 @@ export type ReplicationPushOptions<RxDocType> = {
      * they are send into the push handler.
      */
     modifier?: (docData: WithDeleted<RxDocType>) => MaybePromise<any>;
+
+
 
     /**
      * How many local changes to process at once.

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -87,8 +87,6 @@ export type ReplicationPushOptions<RxDocType> = {
      */
     modifier?: (docData: WithDeleted<RxDocType>) => MaybePromise<any>;
 
-
-
     /**
      * How many local changes to process at once.
      */


### PR DESCRIPTION
## This PR contains:
- New feature that lets you define a responseModifier for GraphQL push replication to be able to covert any response to the format required by RxDB to detect conflicting documents
- New feature that lets you define a dataPath for the conflicting documents in a GraphQL push replication

## Describe the problem you have without this PR
- It's not possible to use RxDB with an advanced GraphQL setup where the server returns more than an array of conflicting documents on push replication

## Todos
- [x] Tests
- [x] Documentation
- [x] Typings
- [ ] Changelog