### PR TITLE
feat(websocket-replication): pass all websocket options to constructor

### DIFF
--- a/src/plugins/replication-websocket/websocket-server.ts
+++ b/src/plugins/replication-websocket/websocket-server.ts
@@ -21,10 +21,7 @@ import { Subject } from 'rxjs';
 
 export function startSocketServer(options: ServerOptions): WebsocketServerState {
     const { WebSocketServer } = require('isomorphic-ws' + '');
-    const wss = new WebSocketServer({
-        port: options.port,
-        path: options.path
-    });
+    const wss = new WebSocketServer(options);
     let closed = false;
     function closeServer() {
         if (closed) {
@@ -62,9 +59,8 @@ export function startSocketServer(options: ServerOptions): WebsocketServerState 
 }
 
 export function startWebsocketServer(options: WebsocketServerOptions): WebsocketServerState {
-    const serverState = startSocketServer(options);
-
-    const database = options.database;
+    const { database, ...wsOptions } = options;
+    const serverState = startSocketServer(wsOptions);
 
     // auto close when the database gets destroyed
     database.onDestroy.push(() => serverState.close());


### PR DESCRIPTION
## This PR contains:
 - Ability to pass all websocket options to constructor. E.g. the custom http server.

Example usage:
```
import http from 'http'

  const port = 3030
  const server = http.createServer()

  const serverState = startWebsocketServer({
    database: db,
    server: server,
  })

  server.listen(port, () => {
    console.info(`Data stream server started on port ${port}`)
  })

```