### PR TITLE
feature request: populate multiple paths like in mongoose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ release-body.md
 /test-db-*
 dist/typings
 *-debug.log
+.vscode

--- a/test/unit/population.test.ts
+++ b/test/unit/population.test.ts
@@ -270,6 +270,19 @@ config.parallel('population.test.js', () => {
             });
         });
     });
+    describe('RxQuery().populate()', () => {
+        describe('positive', () => {
+            it('populates all top-level-field', async () => {
+                const col = await humansCollection.createRelated();
+                const docs = await col.find().populate('bestFriend').exec(true);
+                const doc = docs[0];
+                const friend = doc.bestFriend;
+                assert.ok(isRxDocument(friend));
+                assert.strictEqual(friend.name, doc.bestFriend);
+                col.database.destroy();
+            });
+        });
+    });
     describe('RxDocument populate via pseudo-proxy', () => {
         describe('positive', () => {
             it('populate top-level-field', async () => {


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
**Feature request: populate multiple paths like in mongoose**
https://mongoosejs.com/docs/populate.html#populating-multiple-paths


## Describe the problem you have without this PR
There are cases where you want to easily populate fields for multiple find results. Current option is only to run this as separate async array looping and its not convenient to use.

