### PR TITLE
fix: typescript schema to allow nullable fields

### DIFF
--- a/src/types/rx-schema.d.ts
+++ b/src/types/rx-schema.d.ts
@@ -5,7 +5,7 @@ import { StringKeys } from './util';
 /**
  * @link https://github.com/types/lib-json-schema/blob/master/v4/index.d.ts
  */
-export type JsonSchemaTypes =  'array' | 'boolean' | 'integer' | 'number' | 'null' | 'object' | 'string' | (string & {}) | ['null', 'array'] | ['null', 'boolean'] | ['null', 'integer'] | ['null', 'number'] | ['null', 'object'] | ['null', 'string'];
+export type JsonSchemaTypes =  'array' | 'boolean' | 'integer' | 'number' | 'null' | 'object' | 'string' | (string & {});
 
 export type CompositePrimaryKey<RxDocType> = {
     /**
@@ -38,7 +38,7 @@ export type JsonSchema<RxDocType = any> = {
     oneOf?: JsonSchema[];
     additionalItems?: boolean | JsonSchema;
     additionalProperties?: boolean | JsonSchema;
-    type?: JsonSchemaTypes | JsonSchemaTypes[];
+    type?: JsonSchemaTypes | JsonSchemaTypes[] | readonly JsonSchemaTypes[];
     description?: string;
     dependencies?: {
         [key: string]: JsonSchema | string[];

--- a/src/types/rx-schema.d.ts
+++ b/src/types/rx-schema.d.ts
@@ -5,7 +5,7 @@ import { StringKeys } from './util';
 /**
  * @link https://github.com/types/lib-json-schema/blob/master/v4/index.d.ts
  */
-export type JsonSchemaTypes = 'array' | 'boolean' | 'integer' | 'number' | 'null' | 'object' | 'string' | (string & {});
+export type JsonSchemaTypes =  'array' | 'boolean' | 'integer' | 'number' | 'null' | 'object' | 'string' | (string & {}) | ['null', 'array'] | ['null', 'boolean'] | ['null', 'integer'] | ['null', 'number'] | ['null', 'object'] | ['null', 'string'];
 
 export type CompositePrimaryKey<RxDocType> = {
     /**


### PR DESCRIPTION
Otherwise any schema with a type like:
```
   myfield: {
      type: ["string", "null"],
    },
```
will produce an error.

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

<!--
READ THIS BEFORE SUBMISSION:

- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
