### PR TITLE
fix: lost RxDocument in preSave from v14.0.0

### DIFF
--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -339,7 +339,7 @@ export const basePrototype = {
                 document: this
             });
         }
-        await beforeDocumentUpdateWrite(this.collection, newData, oldData);
+        await beforeDocumentUpdateWrite(this.collection, newData, oldData, this);
         const writeResult = await this.collection.storageInstance.bulkWrite([{
             previous: oldData,
             document: newData
@@ -513,7 +513,8 @@ export function isRxDocument(obj: any): boolean {
 export function beforeDocumentUpdateWrite<RxDocType>(
     collection: RxCollection<RxDocType>,
     newData: RxDocumentWriteData<RxDocType>,
-    oldData: RxDocumentData<RxDocType>
+    oldData: RxDocumentData<RxDocType>,
+    oldDocument?: RxDocument<RxDocType>
 ): Promise<any> {
     /**
      * Meta values must always be merged
@@ -531,5 +532,5 @@ export function beforeDocumentUpdateWrite<RxDocType>(
     if (overwritable.isDevMode()) {
         collection.schema.validateChange(oldData, newData);
     }
-    return collection._runHooks('pre', 'save', newData);
+    return collection._runHooks('pre', 'save', newData, oldDocument);
 }

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -339,7 +339,7 @@ export const basePrototype = {
                 document: this
             });
         }
-        await beforeDocumentUpdateWrite(this.collection, newData, oldData, this);
+        await beforeDocumentUpdateWrite(this.collection, newData, oldData);
         const writeResult = await this.collection.storageInstance.bulkWrite([{
             previous: oldData,
             document: newData
@@ -513,8 +513,7 @@ export function isRxDocument(obj: any): boolean {
 export function beforeDocumentUpdateWrite<RxDocType>(
     collection: RxCollection<RxDocType>,
     newData: RxDocumentWriteData<RxDocType>,
-    oldData: RxDocumentData<RxDocType>,
-    oldDocument?: RxDocument<RxDocType>
+    oldData: RxDocumentData<RxDocType>
 ): Promise<any> {
     /**
      * Meta values must always be merged
@@ -532,5 +531,5 @@ export function beforeDocumentUpdateWrite<RxDocType>(
     if (overwritable.isDevMode()) {
         collection.schema.validateChange(oldData, newData);
     }
-    return collection._runHooks('pre', 'save', newData, oldDocument);
+    return collection._runHooks('pre', 'save', newData, oldData);
 }

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -189,12 +189,18 @@ config.parallel('hooks.test.js', () => {
                     await c.insert(human);
                     const doc = await c.findOne(human.passportId).exec(true);
                     let count = 0;
-                    c.preSave(function (data) {
+                    c.preSave(function (data, oldData) {
                         assert.ok(data);
+                        assert.ok(oldData);
+                        if (count === 1) {
+                            assert.equal(oldData.firstName, 'foobar');
+                        }
                         count++;
                     }, false);
                     await doc.incrementalPatch({ firstName: 'foobar' });
                     assert.strictEqual(count, 1);
+                    await c.upsert(human);
+                    assert.strictEqual(count, 2);
                     c.database.destroy();
                 });
                 it('parallel', async () => {
@@ -203,8 +209,9 @@ config.parallel('hooks.test.js', () => {
                     await c.insert(human);
                     const doc = await c.findOne(human.passportId).exec(true);
                     let count = 0;
-                    c.preSave(function (data) {
+                    c.preSave(function (data, oldData) {
                         assert.ok(data);
+                        assert.ok(oldData);
                         count++;
                     }, true);
                     await doc.incrementalPatch({ firstName: 'foobar' });


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
  THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
``` js
// series
myCollection.preSave(function(plainData, rxDocument){
    // rxDocument is always undefined in the latest version
    console.log(rxDocument)
    // modify anyField before saving
    plainData.anyField = 'anyValue';
}, false);
```
https://rxdb.info/middleware.html

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests

<!--
READ THIS BEFORE SUBMISSION:

- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
