### PR TITLE
fix: query-builder copies RxQuery's other param #4586

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ release-body.md
 /test-db-*
 dist/typings
 *-debug.log
+.vscode

--- a/src/plugins/query-builder/index.ts
+++ b/src/plugins/query-builder/index.ts
@@ -4,9 +4,8 @@ import {
     OTHER_MANGO_OPERATORS
 } from './mquery/nosql-query-builder';
 import type { RxPlugin, RxQuery } from '../../types';
-import { RxQueryBase, tunnelQueryCache } from '../../rx-query';
+import { createRxQuery } from '../../rx-query';
 import { clone } from '../../plugins/utils';
-import { runPluginHooks } from '../../hooks';
 
 // if the query-builder plugin is used, we have to save its last path
 const RXQUERY_OTHER_FLAG = 'queryBuilderPath';
@@ -16,37 +15,21 @@ export function runBuildingStep<RxDocumentType, RxQueryResult>(
     functionName: string,
     value: any
 ): RxQuery<RxDocumentType, RxQueryResult> {
-    const queryBuilder = createQueryBuilder(clone(rxQuery.mangoQuery));
-    if (rxQuery.other[RXQUERY_OTHER_FLAG]) {
-        queryBuilder._path = rxQuery.other[RXQUERY_OTHER_FLAG];
-    }
+    const queryBuilder = createQueryBuilder(clone(rxQuery.mangoQuery), rxQuery.other[RXQUERY_OTHER_FLAG]);
 
     (queryBuilder as any)[functionName](value); // run
 
     const queryBuilderJson = queryBuilder.toJSON();
 
-
-    runPluginHooks('preCreateRxQuery', {
-        op: rxQuery.op,
-        queryObj: queryBuilderJson.query,
-        collection: rxQuery.collection
-    });
-
-
-    const newQuery = new RxQueryBase(
+    return createRxQuery(
         rxQuery.op,
         queryBuilderJson.query,
-        rxQuery.collection
+        rxQuery.collection,
+        {
+            ...rxQuery.other,
+            [RXQUERY_OTHER_FLAG]: queryBuilderJson.path
+        }
     ) as RxQuery;
-
-
-
-    if (queryBuilderJson.path) {
-        newQuery.other[RXQUERY_OTHER_FLAG] = queryBuilderJson.path;
-    }
-
-    const tunneled = tunnelQueryCache(newQuery);
-    return tunneled;
 }
 
 export function applyBuildingStep(

--- a/src/plugins/query-builder/mquery/nosql-query-builder.ts
+++ b/src/plugins/query-builder/mquery/nosql-query-builder.ts
@@ -29,7 +29,6 @@ export class NoSqlQueryBuilderClass<DocType> {
     public options: MQueryOptions = {};
     public _conditions: MangoQuerySelector<DocType> = {};
     public _fields: any = {};
-    public _path?: any;
     private _distinct: any;
 
     /**
@@ -41,7 +40,8 @@ export class NoSqlQueryBuilderClass<DocType> {
      *
      */
     constructor(
-        mangoQuery?: MangoQuery<DocType>
+        mangoQuery?: MangoQuery<DocType>,
+        public _path?: any
     ) {
         if (mangoQuery) {
             const queryBuilder: NoSqlQueryBuilder<DocType> = this as any;
@@ -551,6 +551,6 @@ export function canMerge(conds: any): boolean {
 }
 
 
-export function createQueryBuilder<DocType>(query?: MangoQuery<DocType>): NoSqlQueryBuilder<DocType> {
-    return new NoSqlQueryBuilderClass(query) as NoSqlQueryBuilder<DocType>;
+export function createQueryBuilder<DocType>(query?: MangoQuery<DocType>, path?: any): NoSqlQueryBuilder<DocType> {
+    return new NoSqlQueryBuilderClass(query, path) as NoSqlQueryBuilder<DocType>;
 }

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -69,9 +69,6 @@ export class RxQueryBase<
     // used in the query-cache to determine if the RxQuery can be cleaned up.
     public _lastEnsureEqual = 0;
 
-    // used by some plugins
-    public other: any = {};
-
     public uncached = false;
 
     // used to count the subscribers to the query
@@ -103,7 +100,9 @@ export class RxQueryBase<
     constructor(
         public op: RxQueryOP,
         public mangoQuery: Readonly<MangoQuery<RxDocType>>,
-        public collection: RxCollection<RxDocType>
+        public collection: RxCollection<RxDocType>,
+        // used by some plugins
+        public other: any = {}
     ) {
         if (!mangoQuery) {
             this.mangoQuery = _getDefaultQuery();
@@ -484,15 +483,17 @@ export function tunnelQueryCache<RxDocumentType, RxQueryResult>(
 export function createRxQuery<RxDocType>(
     op: RxQueryOP,
     queryObj: MangoQuery<RxDocType>,
-    collection: RxCollection<RxDocType>
+    collection: RxCollection<RxDocType>,
+    other?: any
 ) {
     runPluginHooks('preCreateRxQuery', {
         op,
         queryObj,
-        collection
+        collection,
+        other
     });
 
-    let ret = new RxQueryBase<RxDocType>(op, queryObj, collection);
+    let ret = new RxQueryBase<RxDocType>(op, queryObj, collection, other);
 
     // ensure when created with same params, only one is created
     ret = tunnelQueryCache(ret);

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -1345,5 +1345,18 @@ describe('rx-query.test.ts', () => {
             assert.strictEqual(result.length, 0);
             c.database.remove();
         });
+        it('#4586 query-builder copies other param', async () => {
+            const col = await humansCollection.create(0);
+            const q = col.find();
+            const key = 'some-plugin-key';
+            const data = 'some-plugin-data';
+            q.other[key] = data;
+
+            const newQ = q.where('name').ne('Alice');
+
+            assert.strictEqual(newQ.other[key], data);
+
+            col.database.destroy();
+        });
     });
 });


### PR DESCRIPTION


## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->
Fixes #4586 

Decided to not create the helper because it would still require manual copying of `other`. I realized that `other` is actually quite important for caching, as it is used in `toString` method which is used in `tunnelQueryCache`.
<!--
READ THIS BEFORE SUBMISSION:

- PULL-REQUESTS THAT CONTAIN A BUGFIX, NEED AT LEAST ONE TEST TO REPRODUCE THE BUG

-->
