### PR TITLE
feature(replication-firestore): add filtered replication

### DIFF
--- a/docs-src/replication-firestore.md
+++ b/docs-src/replication-firestore.md
@@ -106,3 +106,30 @@ allDocsResult.forEach(doc => {
 ```
 
 Also notice that if you do writes from non-RxDB applications, you have to keep these fields in sync. It is recommended to use the [Firestore triggers](https://firebase.google.com/docs/functions/firestore-events) to ensure that.
+
+## Filtered Replication
+
+You might need to replicate only a subset of your collection, either to or from Firestore. You can achieve this using `push.filter` and `pull.filter` options.
+
+```ts
+const replicationState = replicateFirestore(
+    {
+        collection: myRxCollection,
+        firestore: {
+            projectId,
+            database: firestoreDatabase,
+            collection: firestoreCollection
+        },
+        pull: {
+            filter: [
+                where('ownerId', '==', userId)
+            ]
+        },
+        push: {
+            filter: (item) => item.syncEnabled === true
+        }
+    }
+);
+```
+
+Keep in mind that you can not use inequality operators (<, <=, !=, not-in, >, or >=) in `pull.filter` since that would cause a conflict with ordering by `serverTimestamp`.

--- a/src/plugins/replication-firestore/firestore-types.ts
+++ b/src/plugins/replication-firestore/firestore-types.ts
@@ -1,12 +1,15 @@
 import type {
+    MaybePromise,
     ReplicationOptions,
     ReplicationPullOptions,
-    ReplicationPushOptions
+    ReplicationPushOptions,
+    WithDeleted
 } from '../../types';
 
 import type {
     CollectionReference,
     Firestore,
+    QueryFieldFilterConstraint,
     QuerySnapshot
 } from 'firebase/firestore';
 
@@ -32,6 +35,17 @@ export type FirestoreOptions<RxDocType> = {
     database: Firestore;
 };
 
+export type FirestoreSyncPullOptions<RxDocType> =
+    Omit<ReplicationPullOptions<RxDocType, FirestoreCheckpointType>, 'handler' | 'stream$'>
+    & {
+        filter?: QueryFieldFilterConstraint | QueryFieldFilterConstraint[];
+    };
+
+export type FirestoreSyncPushOptions<RxDocType> = Omit<ReplicationPushOptions<RxDocType>, 'handler'>
+    & {
+        filter?(item: WithDeleted<RxDocType>): MaybePromise<boolean>;
+    };
+
 export type SyncOptionsFirestore<RxDocType> = Omit<
     ReplicationOptions<RxDocType, any>,
     'pull' | 'push' | 'replicationIdentifier'
@@ -49,8 +63,8 @@ export type SyncOptionsFirestore<RxDocType> = Omit<
      * @link https://groups.google.com/g/firebase-talk/c/tAmPzPei-mE
      */
     serverTimestampField?: string;
-    pull?: Omit<ReplicationPullOptions<RxDocType, FirestoreCheckpointType>, 'handler' | 'stream$'>;
-    push?: Omit<ReplicationPushOptions<RxDocType>, 'handler'>;
+    pull?: FirestoreSyncPullOptions<RxDocType>;
+    push?: FirestoreSyncPushOptions<RxDocType>;
 };
 
 export type GetQuery<RxDocType> = (ids: string[]) => Promise<QuerySnapshot<RxDocType>>;

--- a/src/plugins/utils/utils-array.ts
+++ b/src/plugins/utils/utils-array.ts
@@ -1,4 +1,5 @@
 import type {
+    MaybePromise,
     MaybeReadonly
 } from '../../types';
 
@@ -93,4 +94,12 @@ export function countUntilNotMatching<T>(
         }
     }
     return count;
+}
+
+export async function asyncFilter<T>(array: T[], predicate: (item: T, index: number, a: T[]) => MaybePromise<boolean>): Promise<T[]> {
+    const filters = await Promise.all(
+        array.map(predicate)
+    );
+
+    return array.filter((...[, index]) => filters[index]);
 }


### PR DESCRIPTION
## This PR contains:
 - A NEW FEATURE


## Describe the problem you have without this PR
1. We only want to sync a subset of our Firestore database with each client.
2. We only want to sync a subset of client's database with Firestore.

As an example for case 1, we have a user system and want to add ownership concept to documents. In that case we would need to apply a filter/query when fetching data from Firestore.
For case 2, we want our users to be able to choose which documents are synced with the cloud. So we need to filter the local documents and only replicate a subset of them to Firestore.

Here's my proposal for these problems:

```ts
const replicationState = replicateFirestore(
    {
        collection: myRxCollection,
        firestore: {
            projectId,
            database: firestoreDatabase,
            collection: firestoreCollection
        },
        pull: {
            filter: [
                where('ownerId', '==', userId)
            ]
        },
        push: {
            filter: (item) => item.syncEnabled === true
        }
    }
);
```

You can use `pull.filter` and `push.filter` options to limit the data fetched from Firestore and sent to it.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests
- [x] Documentation
- [x] Typings
- [ ] Changelog