### PR TITLE
Move z-schema to peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,7 +365,13 @@
     "lint"
   ],
   "peerDependencies": {
-    "rxjs": "^7.8.0"
+    "rxjs": "^7.8.0",
+    "z-schema": "5.0.5"
+  },
+  "peerDependenciesMeta": {
+    "z-schema": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "7.21.0",
@@ -402,8 +408,7 @@
     "socket.io-client": "4.6.1",
     "unload": "2.4.1",
     "util": "0.12.5",
-    "ws": "8.13.0",
-    "z-schema": "5.0.5"
+    "ws": "8.13.0"
   },
   "devDependencies": {
     "@babel/cli": "7.21.0",
@@ -509,6 +514,7 @@
     "webpack": "5.76.3",
     "webpack-bundle-analyzer": "4.8.0",
     "webpack-cli": "5.0.1",
-    "webpack-dev-server": "4.13.1"
+    "webpack-dev-server": "4.13.1",
+    "z-schema": "5.0.5"
   }
 }


### PR DESCRIPTION
Listing z-schema as an optional peer dependency has 2 benefits:
1. Users who don't use z-schema validation don't need this dependency.
2. Pnpm won't hoist z-schema to the top level node_modules; pnpm users who wish to register a schema format validation function are now protected from accidentally installing the incorrect version.

## This PR contains
 - SOMETHING ELSE

## Describe the problem you have without this PR
Pnpm won't hoist z-schema to the top level node_modules. As a result, pnpm users who wish to register a schema format validation should explicitly install z-schema. In doing so, they might install the wrong version, and then registering a new validation format will fail.

## Todos
- [ ] Documentation
- [ ] Changelog

We may need to document that if someone wants to use the z-schema wrapper function, they should first install z-schema. The changelog may also need to be updated.

It is not within the scope of this pull request, but a similar change could be made for other plugin dependencies such as AJV.