### PR TITLE
Add better support for `as const` schemas

### DIFF
--- a/src/types/rx-schema.d.ts
+++ b/src/types/rx-schema.d.ts
@@ -19,7 +19,7 @@ export type CompositePrimaryKey<RxDocType> = {
      * the fields must be required and final
      * and have the type number, int, or string.
      */
-    fields: (StringKeys<RxDocType> | string)[];
+    fields: (StringKeys<RxDocType> | string)[] | readonly (StringKeys<RxDocType> | string)[];
     /**
      * The separator which is used to concat the
      * primary fields values.
@@ -33,19 +33,19 @@ export type CompositePrimaryKey<RxDocType> = {
 export type PrimaryKey<RxDocType> = StringKeys<RxDocType> | CompositePrimaryKey<RxDocType>;
 
 export type JsonSchema<RxDocType = any> = {
-    allOf?: JsonSchema[];
-    anyOf?: JsonSchema[];
-    oneOf?: JsonSchema[];
+    allOf?: JsonSchema[] | readonly JsonSchema[];
+    anyOf?: JsonSchema[] | readonly JsonSchema[];
+    oneOf?: JsonSchema[] | readonly JsonSchema[];
     additionalItems?: boolean | JsonSchema;
     additionalProperties?: boolean | JsonSchema;
     type?: JsonSchemaTypes | JsonSchemaTypes[] | readonly JsonSchemaTypes[];
     description?: string;
     dependencies?: {
-        [key: string]: JsonSchema | string[];
+        [key: string]: JsonSchema | string[] | readonly string[];
     };
     exclusiveMinimum?: boolean;
     exclusiveMaximum?: boolean;
-    items?: JsonSchema | JsonSchema[];
+    items?: JsonSchema | JsonSchema[] | readonly JsonSchema[];
     multipleOf?: number;
     maxProperties?: number;
     maximum?: number;
@@ -62,9 +62,9 @@ export type JsonSchema<RxDocType = any> = {
     properties?: {
         [key in StringKeys<RxDocType>]: JsonSchema;
     };
-    required?: string[];
+    required?: string[] | readonly string[];
     uniqueItems?: boolean;
-    enum?: any[];
+    enum?: any[] | readonly any[];
     not?: JsonSchema;
     definitions?: {
         [key: string]: JsonSchema;
@@ -125,7 +125,7 @@ export type RxJsonSchema<
 
 
     indexes?: (string | string[])[] | (string | readonly string[])[] | readonly (string | string[])[] | readonly (string | readonly string[])[];
-    encrypted?: string[];
+    encrypted?: string[] | readonly string[];
     keyCompression?: boolean;
     /**
      * if not set, rxdb will set 'false' as default

--- a/test/helper/schemas.ts
+++ b/test/helper/schemas.ts
@@ -877,6 +877,70 @@ export const humanCompositePrimary: RxJsonSchema<HumanWithCompositePrimary> = {
     indexes: ['firstName']
 };
 
+export const humanCompositePrimarySchemaLiteral = overwritable.deepFreezeWhenDevMode({
+    title: 'human schema',
+    description: 'describes a human being',
+    version: 0,
+    keyCompression: false,
+    primaryKey: {
+        key: 'id',
+        fields: [
+            'firstName',
+            'info.age'
+        ],
+        separator: '|'
+    },
+    encrypted: [],
+    type: 'object',
+    properties: {
+        id: {
+            type: 'string',
+            maxLength: 100
+        },
+        firstName: {
+            type: 'string',
+            maxLength: 100
+        },
+        lastName: {
+            type: 'string'
+        },
+        info: {
+            type: 'object',
+            properties: {
+                age: {
+                    description: 'age in years',
+                    type: 'integer',
+                    minimum: 0,
+                    maximum: 150
+                }
+            },
+            required: ['age']
+        },
+        readonlyProps: {
+            allOf: [],
+            anyOf: [],
+            oneOf: [],
+            type: [],
+            dependencies: {
+                someDep: ['asd'],
+            },
+            items: [],
+            required: [],
+            enum: [],
+        }
+    },
+    required: [
+        'id',
+        'firstName',
+        'lastName',
+        'info'
+    ],
+    indexes: ['firstName']
+} as const);
+
+const humanCompositePrimarySchemaTyped = toTypedRxJsonSchema(humanCompositePrimarySchemaLiteral);
+export type HumanCompositePrimaryDocType = ExtractDocumentTypeFromTypedRxJsonSchema<typeof humanCompositePrimarySchemaTyped>;
+
 export const refHumanNested: RxJsonSchema<RefHumanNestedDocumentType> = overwritable.deepFreezeWhenDevMode({
     title: 'human related to other human',
     version: 0,

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -131,6 +131,9 @@ describe('typings.test.js', function () {
                 });
                 await myDb.destroy();
             });
+            it('should allow \'as const\' composite primary schemas to work', () => {
+                const humanCompositePrimaryTyped: RxJsonSchema<schemas.HumanCompositePrimaryDocType> = schemas.humanCompositePrimarySchemaLiteral;
+            });
         });
         describe('negative', () => {
             it('should not allow wrong properties when passing a model', async () => {


### PR DESCRIPTION
## This PR contains:
IMPROVED typings

## Describe the problem you have without this PR
From combining the "typescript" and "composite primary key" sections, I got this error:
```
        Types of property 'fields' are incompatible.
          The type 'readonly ["app_id", "budget_id"]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
```

This error happens because adding the const modifier makes arrays be readonly, which have a more restrictive typechecking than readonly props.
I was looking to push a pull request, but I wasn't sure if this was a proper solution (it did fix the issue for me and I imagine it is backwards compat, although I'm not a typescript expert)
```
export type CompositePrimaryKey<RxDocType> = {
    ...
    fields: readonly (StringKeys<RxDocType> | string)[] | (StringKeys<RxDocType> | string);
    ...
};
I also added `readonly` modifier to other props inside the RxJsonSchema. 