### PR TITLE
Fix pushing null document with custom deleted field

### DIFF
--- a/src/plugins/replication/replication-helper.ts
+++ b/src/plugins/replication/replication-helper.ts
@@ -13,7 +13,7 @@ export function swapDefaultDeletedTodeletedField<RxDocType>(
     deletedField: string,
     doc: WithDeleted<RxDocType>
 ): RxDocType {
-    if (deletedField === '_deleted') {
+    if (deletedField === '_deleted' || doc === null) {
         return doc;
     } else {
         doc = flatClone(doc);


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
As per documentation, with a push modifier: "Returning null will skip the document."

However, if the deleted field is not the default one, it will call this method and return "newDocumentState: { CUSTOM_FIELD_FOR_DELETED: false/true }" instead of "newDocumentState: null". This cause a failure for the push afterwards.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog