### PR TITLE
Fix checkSchema for anyOf and items array

### DIFF
--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -175,7 +175,7 @@ export function validateFieldsDeep(rxJsonSchema: RxJsonSchema<any>): true {
                 !currentObj.properties &&
                 schemaObj &&
                 typeof schemaObj === 'object' &&
-                !currentPath.endsWith('oneOf')
+                !Array.isArray(currentObj)
             ) {
                 checkField(
                     attributeName,

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -117,6 +117,56 @@ config.parallel('rx-schema.test.js', () => {
                 it('validates deep nested indexes', () => {
                     checkSchema(schemas.humanWithDeepNestedIndexes);
                 });
+                it('validate anyOf', () => {
+                    checkSchema({
+                        title: 'anyOf schema',
+                        version: 0,
+                        description: 'uses anyOf',
+                        primaryKey: 'id',
+                        type: 'object',
+                        properties: {
+                            id: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            foo: {
+                                anyOf: [
+                                    {
+                                        type: 'string'
+                                    },
+                                    {
+                                        type: 'number'
+                                    }
+                                ]
+                            },
+                        },
+                        required: ['id', 'foo']
+                    });
+                });
+                it('validate items array', () => {
+                    checkSchema({
+                        title: 'items array schema',
+                        version: 0,
+                        description: 'uses items array',
+                        primaryKey: 'id',
+                        type: 'object',
+                        properties: {
+                            id: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            foo: {
+                                type: 'array',
+                                items: [
+                                    {
+                                        type: 'number'
+                                    }
+                                ]
+                            },
+                        },
+                        required: ['id', 'foo']
+                    });
+                });
             });
             describe('negative', () => {
                 it('break when index defined at object property level', () => {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS
 - A BUGFIX

## Describe the problem you have without this PR
The dev mode plugin throws `"fieldnames do not match the regex"` for `fieldName:"0"` if the schema contains `anyOf` or an `items` array.

My patch seems to break the (negative) test for this schema. I'm not sure how this test was supposed to work. It seems like it only worked before because `checkSchema` had bugs with arrays.

https://github.com/pubkey/rxdb/blob/397ecf2a30fb8b58c705bd963d16aac6db0a1aff/test/helper/schemas.ts#L625-L650