### PR TITLE
Update before-next-major.md

### DIFF
--- a/orga/before-next-major.md
+++ b/orga/before-next-major.md
@@ -50,3 +50,8 @@ Proposed solution:
 
 This was changed in v14 for a normal RxDocument.$ which emits RxDocument instances. Same must be done for local documents.
  
+## Rename send$ to sent$
+
+`myRxReplicationState.send$.subscribe` works only if the sending is successful. Therefore, it should be named `sent$`, not `send$`.
+
+Interestingly, `received$` has been named correctly


### PR DESCRIPTION
## This PR contains:
 - SOMETHING ELSE

## Describe the problem you have without this PR
Incorrect / confused naming 

`myRxReplicationState.send$.subscribe` works only if the sending is successful. Therefore, it should be named `sent$`, not `send$`.

Interestingly, `received$` has been named correctly


