### PR TITLE
Fix returning deleted items in find queries

### DIFF
--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -676,7 +676,7 @@ export async function queryCollection<RxDocType>(
             docIds = docIds.filter(docId => {
                 // first try to fill from docCache
                 const docData = rxQuery.collection._docCache.getLatestDocumentDataIfExists(docId);
-                if (docData) {
+                if (docData && !docData._deleted) {
                     docs.push(docData);
                     return false;
                 } else {
@@ -693,7 +693,7 @@ export async function queryCollection<RxDocType>(
 
             // first try to fill from docCache
             let docData = rxQuery.collection._docCache.getLatestDocumentDataIfExists(docId);
-            if (!docData) {
+            if (!docData || docData._deleted) {
                 // otherwise get from storage
                 const docsMap = await collection.storageInstance.findDocumentsById([docId], false);
                 docData = docsMap[docId];

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -696,6 +696,21 @@ describe('rx-query.test.ts', () => {
             assert.strictEqual(queryCalls, 0);
             c.database.destroy();
         });
+        it('should not return deleted documents when queried by a primary key', async () => {
+            const c = await humansCollection.create();
+            const docData = schemaObjects.human();
+            await c.insert(docData);
+            const doc = await c.findOne(docData.passportId).exec();
+            assert.ok(doc);
+            await c.findOne(docData.passportId).remove();
+            const doc2 = await c.findOne(docData.passportId).exec();
+            assert.strictEqual(doc2, null);
+            const doc3 = await c.findOne({ selector: { passportId: { $eq: [docData.passportId] } } }).exec();
+            assert.strictEqual(doc3, null);
+            const docs = await c.find({ selector: { passportId: docData.passportId }}).exec();
+            assert.strictEqual(docs.length, 0);
+            c.database.destroy();
+        });
     });
     config.parallel('update', () => {
         describe('positive', () => {


### PR DESCRIPTION
## This PR contains:
Bug fix for checking the `_deleted` property when returning cached documents in queries.

## Describe the problem you have without this PR
The bug results in the `collection.find` and `collection.findOne` methods returning deleted documents from the cache when queried by the primary key.


