### PR TITLE
`replicationState.active$` observable does not emit on replication failure

### DIFF
--- a/examples/graphql/client/index.js
+++ b/examples/graphql/client/index.js
@@ -213,6 +213,9 @@ async function run() {
             console.error('replication error:');
             console.dir(err);
         });
+        replicationState.active$.subscribe(active => {
+            console.log(`${db.hero.name} replication active: ${active}`);
+        })
     }
 
 

--- a/examples/graphql/server/index.js
+++ b/examples/graphql/server/index.js
@@ -85,6 +85,8 @@ export async function run() {
     // The root provides a resolver function for each API endpoint
     const root = {
         pullHero: (args, request) => {
+            throw new Error('server failure')
+
             log('## pullHero()');
             log(args);
             authenticateRequest(request);
@@ -138,6 +140,8 @@ export async function run() {
             return ret;
         },
         pushHero: (args, request) => {
+            throw new Error('server failure')
+
             log('## pushHero()');
             log(args);
             authenticateRequest(request);

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -467,51 +467,6 @@ describe('replication.test.js', () => {
             localCollection.database.destroy();
             remoteCollection.database.destroy();
         });
-
-        it('should emit false from active$ when replication is failed', async () => {
-            const { localCollection, remoteCollection } = await getTestCollections({ local: 0, remote: 0 });
-            const replicationState = replicateRxCollection({
-                collection: localCollection,
-                replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
-                live: true,
-                pull: {
-                    handler: async () => {
-                        await wait(0);
-                        throw new Error('must throw on pull');
-                    }
-                },
-                push: {
-                    handler: async () => {
-                        await wait(0);
-                        throw new Error('must throw on push');
-                    }
-                },
-            });
-
-            const values: boolean[] = [];
-            replicationState.active$.subscribe((active) => {
-                values.push(active);
-            });
-
-            // waiting for one second instead of awaitInitialReplication
-            // because it will never resolve when replication is failed
-            await wait(1000);
-            assert.strictEqual(
-                values.length > 0,
-                true
-            );
-            assert.strictEqual(
-                values[0],
-                false,
-            );
-            assert.strictEqual(
-                values[values.length - 1],
-                false
-            );
-
-            localCollection.database.destroy();
-            remoteCollection.database.destroy();
-        });
     });
     config.parallel('other', () => {
         describe('autoStart', () => {

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -467,6 +467,51 @@ describe('replication.test.js', () => {
             localCollection.database.destroy();
             remoteCollection.database.destroy();
         });
+
+        it('should emit false from active$ when replication is failed', async () => {
+            const { localCollection, remoteCollection } = await getTestCollections({ local: 0, remote: 0 });
+            const replicationState = replicateRxCollection({
+                collection: localCollection,
+                replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                live: true,
+                pull: {
+                    handler: async () => {
+                        await wait(0);
+                        throw new Error('must throw on pull');
+                    }
+                },
+                push: {
+                    handler: async () => {
+                        await wait(0);
+                        throw new Error('must throw on push');
+                    }
+                },
+            });
+
+            const values: boolean[] = [];
+            replicationState.active$.subscribe((active) => {
+                values.push(active);
+            });
+
+            // waiting for one second instead of awaitInitialReplication
+            // because it will never resolve when replication is failed
+            await wait(1000);
+            assert.strictEqual(
+                values.length > 0,
+                true
+            );
+            assert.strictEqual(
+                values[0],
+                false,
+            );
+            assert.strictEqual(
+                values[values.length - 1],
+                false
+            );
+
+            localCollection.database.destroy();
+            remoteCollection.database.destroy();
+        });
     });
     config.parallel('other', () => {
         describe('autoStart', () => {


### PR DESCRIPTION
Reproducing a bug where `replicationState.active$` observable does not emit a `false` value on replication failure.

## This PR contains:
- REPRODUCED BUG

## Describe the problem you have without this PR
According to the docs, `replicationState.active$` observable should emit a `false` value when the replication cycle is not running. But when replication is failed (when either pull or push handlers throw an error), it does not emit any value, leaving the observable with the `true` value last emitted.

It might be a change, introduced in the new replication protocol since that issue does not exist in the RxDB@12


