### PR TITLE
Add a feature request to control replication start on offline → online change

### DIFF
--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -134,11 +134,15 @@ export type ReplicationOptions<RxDocType, CheckpointType> = {
     /**
      * Time in milliseconds after when a failed backend request
      * has to be retried.
-     * This time will be skipped if a offline->online switch is detected
-     * via `navigator.onLine`
      * @default 5000
      */
     retryTime?: number;
+    /**
+     * When this is set to true, the retryTime setting will be skipped if offline->online
+     * switch is detected via `navigator.onLine` and replication cycle will be started immediately.
+     * @default true
+     */
+    retryOnOnline?: boolean;
     /**
      * When multiInstance is `true`, like when you use RxDB in multiple browser tabs,
      * the replication should always run in only one of the open browser tabs.


### PR DESCRIPTION
This is a feature request to prevent automatic re-sync when detecting a switch from offline to online mode via the `navigator.onLine`.

It would be helpful for applications that require full control over when the synchronization should be triggered in such cases.

## This PR contains:
- A FEATURE REQUEST

## Describe the problem you have without this PR
In RxDB@12, our application had full control over the replication cycle during the offline → online switch.

But, during the migration to RxDB@14, we encountered a breaking change where replication started automatically when the user went online, which affected our logic.

