### PR TITLE
Feature request: isMangoQuerySatisfiedByIndex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
  * for when the you call "import from 'rxdb'".
  */
 
+import { MangoQuery, RxDocumentData, RxJsonSchema } from './types';
+
 export { addRxPlugin } from './plugin';
 
 export * from './rx-database';
@@ -28,6 +30,20 @@ export * from './plugin-helpers';
 export * from './plugins/utils';
 export * from './hooks';
 export * from './query-cache';
+
+export function isMangoQuerySatisfiedByIndex<RxDocType>(
+    collectionName: string, // There is probably a better type for this
+    mangoQuery: MangoQuery<RxDocType>
+): boolean {
+
+}
+
+export function isMangoQuerySatisfiedByIndex2<RxDocType>(
+    schema: RxJsonSchema<RxDocumentData<RxDocType>>,
+    mangoQuery: MangoQuery<RxDocType>
+): boolean {
+
+}
 
 /**
  * TODO use export type * from './types';

--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -279,6 +279,10 @@ export class RxCollectionBase<
         return this.getDataMigrator().migratePromise(batchSize);
     }
 
+    isMangoQuerySatisfiedByIndex(mangoQuery: MangoQuery<RxDocumentType>): boolean {
+
+    }
+
     async insert(
         json: RxDocumentType | RxDocument
     ): Promise<RxDocument<RxDocumentType, OrmMethods>> {

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -340,7 +340,9 @@ export class RxQueryBase<
             });
     }
 
+    isSatisfiedByIndex(): boolean {
 
+    }
 
     /**
      * cached call to get the queryMatcher


### PR DESCRIPTION
## This PR contains:

A feature request. The code changes are just to show different options for where the function could live / what the signature could be.

## Describe the problem you have without this PR

From reading the updated [`rxQuery.count` docs](https://rxdb.info/rx-query.html#count), my understanding is that we should ideally only use `.count` if it's satisfied by an index, otherwise we should use `.find` and count the amount of RxDocument results.

In codebases like mine, I can't predict every query. I'd like to be able to do the optimal operation based on what the input is. This is why I'm proposing a function which receives a `MangoQuery` and returns a boolean indicating whether the `MangoQuery` is satisfied by an index or not.

## Ideas

As you can see from the code changes, I think it could be any of the following:

1. `rxCollection.isMangoQuerySatisfiedByIndex(mangoQuery)`
2. `isMangoQuerySatisfiedByIndex(collectionName, mangoQuery)` (standalone util)
3. `isMangoQuerySatisfiedByIndex(rxSchema, mangoQuery)` (standalone util)
4. `rxQuery.isSatisfiedByIndex()`

I don't have a preference except that number 4 is a little cumbersome because if the result is `false`, we would need to create a new `RxQuery`. It's an extra step, plus creating two `RxQuery`s instead of one would involve some unnecessary work under the hood I assume.

### Specific index

Side note: an index could be included in the `MangoQuery`. If given, it would check against that index; if omitted, it would check against all indexes.

## Dev mode

I found that the dev mode plugin exports this:

```
export function areSelectorsSatisfiedByIndex<RxDocType>(
    schema: RxJsonSchema<RxDocumentData<RxDocType>>,
    query: FilledMangoQuery<RxDocType>
): boolean {
    // ...
}
```

This doesn't cover it for two reasons:

1. It requires a `FilledMangoQuery` instead of a `MangoQuery`. I don't know how to fill one; I assume there is an internal function for this.
2. I want to use this in production and I won't be using the dev-mode plugin in production.

## Should users have to worry about this?

I also wonder if this is a problem I should have to worry about at all. Maybe RxDB's `.count` should do this under the hood and return me a number.