### PR TITLE
Implement an IdleQueue that executes the tasks during the idleness of the main thread (see requestIdleCallback)

### DIFF
--- a/src/plugins/storage-lokijs/loki-save-queue.ts
+++ b/src/plugins/storage-lokijs/loki-save-queue.ts
@@ -1,7 +1,7 @@
 import type { LokiDatabaseSettings } from '../../types';
 import {
     PROMISE_RESOLVE_VOID,
-    requestIdlePromise
+    IdleQueue
 } from '../utils';
 
 /**
@@ -53,7 +53,7 @@ export class LokiSaveQueue {
                  * This ensures that CPU blocking writes are finished
                  * before we proceed.
                  */
-                await requestIdlePromise();
+                await IdleQueue.requestIdlePromise();
 
                 // no write happened since the last save call
                 if (this.writesSinceLastRun === 0) {
@@ -63,10 +63,10 @@ export class LokiSaveQueue {
                 /**
                  * Because LokiJS is a in-memory database,
                  * we can just wait until the JavaScript process is idle
-                 * via requestIdlePromise(). Then we know that nothing important
+                 * via IdleQueue.requestIdlePromise(). Then we know that nothing important
                  * is running at the moment.
                  */
-                await requestIdlePromise().then(() => requestIdlePromise());
+                await IdleQueue.requestIdlePromise().then(() => IdleQueue.requestIdlePromise());
 
                 if (this.writesSinceLastRun === 0) {
                     return;

--- a/src/plugins/utils/index.ts
+++ b/src/plugins/utils/index.ts
@@ -5,6 +5,7 @@ export * from './utils-revision';
 export * from './utils-document';
 export * from './utils-hash';
 export * from './utils-promise';
+export * from './utils-idle-queue';
 export * from './utils-string';
 export * from './utils-object-deep-equal';
 export * from './utils-object-dot-prop';

--- a/src/plugins/utils/utils-idle-queue.ts
+++ b/src/plugins/utils/utils-idle-queue.ts
@@ -1,0 +1,149 @@
+// types
+type PromiseExecutor = (value?: (PromiseLike<void> | void)) => void;
+type IdleDeadline  = {didTimeout: boolean; timeRemaining: () => number;};
+type IdleCallback = (deadline: IdleDeadline) => void;
+type IdleOptions  = {timeout: number;};
+
+type TimeoutHandle = NodeJS.Timeout | number;
+
+type RequestIdleCallback = (callback: IdleCallback, options?: IdleOptions) => TimeoutHandle;
+type CancelIdleCallback = (handle: TimeoutHandle) => void;
+
+type IdleCall = Promise<void> & {_manualResolve: () => void; _timeoutHandle: TimeoutHandle;};
+
+// variables
+const _iC: Set<IdleCall> = new Set();
+let _iCHandle: TimeoutHandle | undefined;
+
+// requestIdleCallback/cancelIdleCallback polyfill
+const _requestIdleCallback: RequestIdleCallback = typeof requestIdleCallback === 'function'
+    ? requestIdleCallback
+    : function(callback: IdleCallback) {
+        const startTime = Date.now();
+        const deadline: IdleDeadline = {
+            didTimeout: false,
+            timeRemaining() {
+                return Math.max(0, 50 - (Date.now() - startTime));
+            }
+        };
+
+        return setTimeout(function () {
+            callback(deadline);
+        }, 1);
+    };
+
+const _cancelIdleCallback: CancelIdleCallback = typeof cancelIdleCallback === 'function'
+    ? cancelIdleCallback as CancelIdleCallback
+    : function(handle: TimeoutHandle) {
+        clearTimeout(handle as number);
+    };
+
+/**
+ *
+ */
+function requestIdlePromise(options?: IdleOptions): Promise<void> {
+    let resolve: PromiseExecutor;
+
+    const prom = new Promise(res => resolve = res) as IdleCall;
+
+    prom._manualResolve = () => {
+        _removeIdleCall(prom);
+        resolve();
+    };
+
+    if (options && options.timeout) {
+        // if timeout has passed, resolve promise even if not idle
+        prom._timeoutHandle = setTimeout(() => {
+            prom._manualResolve();
+        }, options.timeout as number);
+    }
+
+    _iC.add(prom);
+
+    _tryIdleCall();
+
+    return prom;
+}
+
+/**
+ * Removes the promise so it will never be resolved.
+ */
+function cancelIdlePromise(promise: IdleCall): void {
+    _removeIdleCall(promise);
+}
+
+/**
+ * Clears and resets everything
+ */
+function clear(): void {
+    // remove all non-cleared
+    _iC.forEach(promise => cancelIdlePromise(promise));
+
+    _iC.clear();
+
+    // cancels a callback previously scheduled
+    if(_iCHandle) {
+        _cancelIdleCallback(_iCHandle);
+        _iCHandle = undefined;
+    }
+}
+
+/**
+ * Removes the promise from the queue.
+ */
+function _removeIdleCall(promise: IdleCall): void {
+    if (!promise) return;
+
+    // remove timeout if exists
+    if (promise._timeoutHandle)
+        clearTimeout(promise._timeoutHandle);
+
+    // remove from queue
+    _iC.delete(promise);
+}
+
+/**
+ * Tries to run idle calls from idleCalls-queue.
+ */
+function _tryIdleCall(): void {
+    // request an idle callback if not already flushing queue
+    if (_iCHandle) return;
+
+    _iCHandle = _requestIdleCallback(_runIdleCallQueue);
+}
+
+/**
+ * Resolve the enqueued idle calls when the browser determines there's enough idle time available to let us do some work.
+ */
+function _runIdleCallQueue(deadline: IdleDeadline): void {
+    const iterator = _iC.values();
+
+    // Run idle calls from idleCalls-queue until running out of time (i.e. the idle period ended) or finished
+    while (
+        (deadline.timeRemaining() > 0 || deadline.didTimeout) && _iC.size) {
+        // processes the oldest call of the idleCalls-queue
+        const oldestPromise = iterator.next().value;
+
+        oldestPromise._manualResolve();
+    }
+
+    // null out callback id
+    _iCHandle = undefined;
+
+    // If out of time before idle calls are finished, request more time.
+    // This way, the idle calls are processed only during the idle period (i.e. they are processed as background tasks).
+    if (_iC.size) {
+        _tryIdleCall();
+    }
+}
+
+// NOTE: for now wrap these functions in a object to avoid the collisions (see the requestIdlePromise from utils-promise)
+const IdleQueue = {
+    requestIdlePromise,
+    cancelIdlePromise,
+    clear
+};
+
+export {
+    IdleQueue
+};

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -11,7 +11,7 @@ import {
     getFromMapOrCreate,
     nextTick,
     now,
-    requestIdlePromise
+    IdleQueue
 } from './plugins/utils';
 
 export class QueryCache {
@@ -128,7 +128,7 @@ export function triggerCacheReplacement(
      * Do not run directly to not reduce result latency of a new query
      */
     nextTick() // wait at least one tick
-        .then(() => requestIdlePromise(200)) // and then wait for the CPU to be idle
+        .then(() => IdleQueue.requestIdlePromise({timeout: 200})) // and then wait for the CPU to be idle
         .then(() => {
             if (!rxCollection.destroyed) {
                 rxCollection.cacheReplacementPolicy(rxCollection, rxCollection._queryCache);

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -2,7 +2,7 @@ import {
     createRxDatabase,
     randomCouchString,
     overwritable,
-    requestIdlePromise
+    IdleQueue
 } from '../';
 import * as assert from 'assert';
 import * as schemas from './helper/schemas';
@@ -219,7 +219,7 @@ export function averageOfTimeValues(
 
 
 async function awaitBetweenTest() {
-    await requestIdlePromise();
+    await IdleQueue.requestIdlePromise();
     await wait(100);
-    await requestIdlePromise();
+    await IdleQueue.requestIdlePromise();
 }


### PR DESCRIPTION
1. Implement an `IdleQueue` similar to the one exposed from the `custom-idle-queue` package. 
The difference is that all the queued items are executed as background tasks (i.e. when the main thread is idle) due to the usage of the `requestIdleCallback` function. I want to highlight that more than one background task may be executed during the idleness of the main thread (a.k.a the idle period); the remaining tasks are executed on the next idle period (so, when the main thread is idle again) and so on.
2. Replace the usages of the `requestIdlePromise` from `utils/utils-promise` with `IdleQueue.requestIdlePromise`; the replacements were done especially in the files related to the  lokijs rx storage.
3. For the moment, I wrap the functions (`requestIdlePromise`, `cancelIdlePromise`, `clear`) in a object (namely, the `IdleQueue`) to avoid the collisions with the current code (see the `requestIdlePromise` from `utils/utils-promise`). This may change if you consider this pull requests is useful.

## This PR contains:
 - A NEW FEATURE

## Describe the problem you have without this PR
#4877 



