### PR TITLE
Migrate assumed masters II.

### DIFF
--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -51,7 +51,8 @@ import {
     awaitRetry,
     DEFAULT_MODIFIER,
     swapDefaultDeletedTodeletedField,
-    handlePulledDocuments
+    handlePulledDocuments,
+    RX_REPLICATION_COLLECTION_FLAG
 } from './replication-helper';
 import {
     addConnectedStorageToCollection
@@ -137,7 +138,8 @@ export class RxReplicationState<RxDocType, CheckpointType> {
         const pushModifier = this.push && this.push.modifier ? this.push.modifier : DEFAULT_MODIFIER;
 
         const database = this.collection.database;
-        const metaInstanceCollectionName = this.collection.name + '-rx-replication-' + this.replicationIdentifierHash;
+        const metaInstanceCollectionName =
+            [this.collection.name, RX_REPLICATION_COLLECTION_FLAG, this.replicationIdentifierHash].join('-');
         const metaInstanceSchema = getRxReplicationMetaInstanceSchema(
             this.collection.schema.jsonSchema,
             hasEncryption(this.collection.schema.jsonSchema)

--- a/src/plugins/replication/replication-helper.ts
+++ b/src/plugins/replication/replication-helper.ts
@@ -8,6 +8,7 @@ import { getComposedPrimaryKeyOfDocumentData } from '../../rx-schema-helper';
 // does nothing
 export const DEFAULT_MODIFIER = (d: any) => Promise.resolve(d);
 
+export const RX_REPLICATION_COLLECTION_FLAG = 'rx-replication';
 
 export function swapDefaultDeletedTodeletedField<RxDocType>(
     deletedField: string,

--- a/test/helper/humans-collection.ts
+++ b/test/helper/humans-collection.ts
@@ -15,6 +15,7 @@ import {
 } from '../../';
 
 import { HumanDocumentType } from './schemas';
+import { replicateRxCollection } from '../../plugins/replication';
 
 export async function create(
     size: number = 20,
@@ -371,7 +372,8 @@ export async function createMigrationCollection(
     addMigrationStrategies: MigrationStrategies = {},
     name = randomCouchString(10),
     autoMigrate = false,
-    attachment?: RxAttachmentCreator
+    attachment?: RxAttachmentCreator,
+    replicate?: boolean
 ): Promise<RxCollection<schemaObjects.SimpleHumanV3DocumentType>> {
 
     const migrationStrategies: any = {
@@ -398,6 +400,16 @@ export async function createMigrationCollection(
             autoMigrate: false
         }
     });
+
+    if (replicate) {
+        const collection = cols[colName];
+        const replicationState = replicateRxCollection({
+            replicationIdentifier: colName,
+            collection,
+            autoStart: true,
+        });
+        await replicationState.awaitInitialReplication();
+    }
 
     await Promise.all(
         new Array(amount)

--- a/test/unit/data-migration.test.ts
+++ b/test/unit/data-migration.test.ts
@@ -438,7 +438,7 @@ config.parallel('data-migration.test.ts', () => {
                     await replicationState.awaitInitialReplication();
 
                     pushed.forEach(({ assumedMasterState, newDocumentState }) => {
-                        assert.deepStrictEqual(assumedMasterState, newDocumentState);
+                        assert.deepEqual(assumedMasterState?.age, newDocumentState.age);
                     });
 
                     await Promise.all(

--- a/test/unit/data-migration.test.ts
+++ b/test/unit/data-migration.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import config from './config';
-import AsyncTestUtil, {wait, waitUntil} from 'async-test-util';
+import AsyncTestUtil, { waitUntil } from 'async-test-util';
 
 import * as schemas from '../helper/schemas';
 import * as humansCollection from '../helper/humans-collection';
@@ -438,7 +438,7 @@ config.parallel('data-migration.test.ts', () => {
                     await replicationState.awaitInitialReplication();
 
                     pushed.forEach(({ assumedMasterState, newDocumentState }) => {
-                        assert.deepEqual(assumedMasterState?.age, newDocumentState.age);
+                        assert.equal(assumedMasterState?.age, newDocumentState.age);
                     });
 
                     await Promise.all(


### PR DESCRIPTION
This is a continuation of #4899 (I’m taking over the PR, no new changes yet). 

Status: 

- Most recent feedback from Daniel incorporated
- Tests fail for some storages like Dexie due to `assumedMasterState` being `undefined` in the push handler — why?
- Waiting for additional feedback regarding failing tests from @pubkey
