### PR TITLE
Fix typo in CRDT plugin docs

### DIFF
--- a/docs-src/crdt.md
+++ b/docs-src/crdt.md
@@ -72,8 +72,7 @@ To use CRDTs with RxDB, you need the following:
 // import the relevant parts from the CRDT plugin
 import {
     getCRDTSchemaPart,
-    RxDDcrdtPlugin,
-    getCRDTConflictHandler
+    RxDBcrdtPlugin
 } from 'rxdb/plugins/crdt';
 
 // add the CRDT plugin to RxDB


### PR DESCRIPTION
Typo + removed `getCRDTConflictHandler` import because it's not used in the example

## This PR contains:

 - IMPROVED DOCS
