### PR TITLE
Add test to show that you can't use `patternProperties` in schema

### DIFF
--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -70,7 +70,8 @@ export function validateFieldsDeep(rxJsonSchema: RxJsonSchema<any>): true {
         if (
             typeof fieldName === 'string' &&
             typeof schemaObj === 'object' &&
-            !Array.isArray(schemaObj)
+            !Array.isArray(schemaObj) &&
+            path.split('.').pop() !== 'patternProperties'
         ) checkFieldNameRegex(fieldName);
 
         // 'item' only allowed it type=='array'

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -58,22 +58,20 @@ describe('bug-report.test.js', () => {
                 },
                 tags: {
                     type: 'object',
-                    additionalProperties: {
-                        $ref: '#/definitions/tag',
+                    patternProperties: {
+                        '.*': {
+                            type: 'object',
+                            properties: {
+                                created: {
+                                    type: 'integer',
+                                },
+                                name: {
+                                    type: 'string',
+                                },
+                            },
+                            required: ['created', 'name'],
+                        }
                     },
-                },
-            },
-            definitions: {
-                tag: {
-                    properties: {
-                        created: {
-                            type: 'integer',
-                        },
-                        name: {
-                            type: 'string',
-                        },
-                    },
-                    required: ['created', 'name'],
                 },
             },
         };

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -128,9 +128,17 @@ describe('bug-report.test.js', () => {
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.strictEqual(myDocument.toJSON().tags, tags);
-        assert.strictEqual(myDocument.get('tags'), tags);
-        assert.strictEqual(myDocument.tags, tags);
+        assert.deepStrictEqual(myDocument.toJSON().tags.hello, tags.hello, 'myDocument.toJSON().tags.hello');
+        assert.deepStrictEqual(myDocument.toJSON().tags.world, tags.world, 'myDocument.toJSON().tags.world');
+        assert.deepStrictEqual(Object.keys(myDocument.toJSON().tags), Object.keys(tags), 'Object.keys(myDocument.toJSON().tags)');
+
+        assert.deepStrictEqual(myDocument.get('tags').hello, tags.hello, 'myDocument.get(\'tags\').hello');
+        assert.deepStrictEqual(myDocument.get('tags').world, tags.world, 'myDocument.get(\'tags\').world');
+        assert.deepStrictEqual(Object.keys(myDocument.get('tags')), Object.keys(tags), 'Object.keys(myDocument.get(\'tags\'))');
+
+        assert.deepStrictEqual(myDocument.tags.hello, tags.hello, 'myDocument.tags.hello');
+        assert.deepStrictEqual(myDocument.tags.world, tags.world, 'myDocument.tags.world');
+        assert.deepStrictEqual(Object.keys(myDocument.tags), Object.keys(tags), 'Object.keys(myDocument.tags)');
 
         // clean up afterwards
         db.destroy();

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -1047,6 +1047,102 @@ config.parallel('rx-schema.test.js', () => {
 
             db.destroy();
         });
+        it('#4951 patternProperties are allowed', async () => {
+            /**
+             * Dexie.js does not support boolean indexes,
+             * see docs-src/rx-storage-dexie.md
+             */
+            if (config.storage.name.includes('dexie')) {
+                return;
+            }
+
+            const db = await createRxDatabase({
+                name: randomCouchString(10),
+                storage: config.storage.getStorage()
+            });
+
+            const mySchema = {
+                'keyCompression': false,
+                'version': 0,
+                'primaryKey': 'passportId',
+                'type': 'object',
+                'properties': {
+                    passportId: {
+                        type: 'string',
+                        maxLength: 100
+                    },
+                    firstName: {
+                        type: 'string'
+                    },
+                    lastName: {
+                        type: 'string'
+                    },
+                    age: {
+                        type: 'integer',
+                        minimum: 0,
+                        maximum: 150
+                    },
+                    tags: {
+                        type: 'object',
+                        patternProperties: {
+                            '.*': {
+                                type: 'object',
+                                properties: {
+                                    created: {
+                                        type: 'integer',
+                                    },
+                                    name: {
+                                        type: 'string',
+                                    },
+                                },
+                                required: ['created', 'name'],
+                            }
+                        },
+                    },
+                },
+            };
+            const collections = await db.addCollections({
+                test: {
+                    schema: mySchema
+                }
+            });
+
+            const tags = {
+                hello: {
+                    created: 1,
+                    name: 'hello',
+                },
+                world: {
+                    created: 2,
+                    name: 'world',
+                }
+            };
+
+            // insert a document
+            await collections.test.insert({
+                passportId: 'foobar',
+                firstName: 'Bob',
+                lastName: 'Kelso',
+                age: 56,
+                tags,
+            });
+
+            const myDocument = await collections.test
+                .findOne()
+                .exec();
+
+            assert.deepStrictEqual(myDocument.toJSON().tags.hello, tags.hello, 'myDocument.toJSON().tags.hello');
+            assert.deepStrictEqual(myDocument.toJSON().tags.world, tags.world, 'myDocument.toJSON().tags.world');
+            assert.deepStrictEqual(Object.keys(myDocument.toJSON().tags), Object.keys(tags), 'Object.keys(myDocument.toJSON().tags)');
+
+            assert.deepStrictEqual(myDocument.get('tags').hello, tags.hello, 'myDocument.get(\'tags\').hello');
+            assert.deepStrictEqual(myDocument.get('tags').world, tags.world, 'myDocument.get(\'tags\').world');
+
+            assert.deepStrictEqual(myDocument.tags.hello, tags.hello, 'myDocument.tags.hello');
+            assert.deepStrictEqual(myDocument.tags.world, tags.world, 'myDocument.tags.world');
+
+            db.destroy();
+        });
     });
     describe('wait a bit', () => {
         it('w8 a bit', async () => {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED TESTS

## Describe the problem you have without this PR
This is for #4926. It shows that if you use `patternProperties` to define the value of unknown keys, that it'll error due to schema key validation.