### PR TITLE
Docs: remove findByIds$

### DIFF
--- a/docs-src/SUMMARY.md
+++ b/docs-src/SUMMARY.md
@@ -56,7 +56,6 @@
         * [find()](./rx-collection.md#find)
         * [findOne()](./rx-collection.md#findone)
         * [findByIds()](./rx-collection.md#findbyids)
-        * [findByIds$()](./rx-collection.md#findbyids$)
         * [exportJSON()](./rx-collection.md#dump)
         * [importJSON()](./rx-collection.md#importdump)
         * [remove()](./rx-collection.md#remove)

--- a/docs-src/rx-collection.md
+++ b/docs-src/rx-collection.md
@@ -221,10 +221,6 @@ console.dir(docsMap); // Map(2)
 
 NOTICE: The `Map` returned by `findByIds` is not guaranteed to return elements in the same order as the list of ids passed to it.
 
-### findByIds$()
-
-Same as `findByIds()` but returns an `Observable` that emits the `Map` each time a value of it has changed because of a database write.
-
 
 ### exportJSON()
 Use this function to create a json export from every document in the collection.

--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -1876,7 +1876,7 @@ describe('rx-collection.test.ts', () => {
             });
         });
     });
-    config.parallel('.findByIds$()', () => {
+    config.parallel('.findByIds.$()', () => {
         it('should not crash and emit a map', async () => {
             const c = await humansCollection.create(5);
             const docs = await c.find().exec();
@@ -2078,7 +2078,7 @@ describe('rx-collection.test.ts', () => {
 
             db2.destroy();
         });
-        it('#3661 .findByIds$() fires too often', async () => {
+        it('#3661 .findByIds.$() fires too often', async () => {
             const collection = await humansCollection.create(0);
 
             //  Record subscription
@@ -2153,7 +2153,7 @@ describe('rx-collection.test.ts', () => {
 
             /**
              * Each emitted result must have a different result set
-             * because findByIds$ must only emit when data has actually changed.
+             * because findByIds.$ must only emit when data has actually changed.
              * We cannot just count the updates.length here because some RxStorage implementations
              * might return multiple RxChangeEventBulks for a single bulkWrite() operation
              * or do additional writes. So we have to check for the revisions+docId strings.


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  - DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
    THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
  - EACH CHANGE TO THE SOURCE CODE, REQUIRES AT LEAST ONE TEST
    THAT COVERS THE CHANGE IN BEHAVIOR.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:

 - IMPROVED DOCS
 - IMPROVED TESTS

## Describe the problem you have without this PR
`rxCollection.findByIds$` was removed in 14.0.0 ([changelog entry](https://github.com/pubkey/rxdb/blob/master/CHANGELOG.md#1400-8-february-2023-breaking-read-the-announcement)) but it's still mentioned in the docs, which is confusing.

NOTE: I also changed mentions of `findByIds$` to `findByIds.$` in test names (they actually use `findByIds.$` now)