### PR TITLE
Fix replication primitive pull checkpoint type

### DIFF
--- a/src/plugins/replication-firestore/index.ts
+++ b/src/plugins/replication-firestore/index.ts
@@ -123,7 +123,7 @@ export function replicateFirestore<RxDocType>(
     if (options.pull) {
         replicationPrimitivesPull = {
             async handler(
-                lastPulledCheckpoint: FirestoreCheckpointType,
+                lastPulledCheckpoint: FirestoreCheckpointType | undefined,
                 batchSize: number
             ) {
                 let newerQuery: ReturnType<typeof query>;
@@ -191,7 +191,7 @@ export function replicateFirestore<RxDocType>(
 
                 if (useDocs.length === 0) {
                     return {
-                        checkpoint: lastPulledCheckpoint,
+                        checkpoint: lastPulledCheckpoint ?? null,
                         documents: []
                     };
                 }

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -119,7 +119,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
         const pullBatchSize = pull.batchSize ? pull.batchSize : 20;
         replicationPrimitivesPull = {
             async handler(
-                lastPulledCheckpoint: CheckpointType
+                lastPulledCheckpoint: CheckpointType | undefined
             ) {
                 const pullGraphQL = await pull.queryBuilder(lastPulledCheckpoint, pullBatchSize);
                 const result = await graphqlReplicationState.graphQLRequest(pullGraphQL);

--- a/src/plugins/replication-nats/index.ts
+++ b/src/plugins/replication-nats/index.ts
@@ -96,7 +96,7 @@ export function replicateNats<RxDocType>(
     if (options.pull) {
         replicationPrimitivesPull = {
             async handler(
-                lastPulledCheckpoint: NatsCheckpointType,
+                lastPulledCheckpoint: NatsCheckpointType | undefined,
                 batchSize: number
             ) {
                 const cn = await connectionStatePromise;

--- a/src/plugins/replication-webrtc/index.ts
+++ b/src/plugins/replication-webrtc/index.ts
@@ -163,7 +163,7 @@ export async function replicateWebRTC<RxDocType>(
                     retryTime: options.retryTime,
                     waitForLeadership: false,
                     pull: options.pull ? Object.assign({}, options.pull, {
-                        async handler(lastPulledCheckpoint: WebRTCReplicationCheckpoint) {
+                        async handler(lastPulledCheckpoint: WebRTCReplicationCheckpoint | undefined) {
                             const answer = await sendMessageAndAwaitAnswer(
                                 pool.connectionHandler,
                                 peer,

--- a/src/plugins/replication-websocket/websocket-client.ts
+++ b/src/plugins/replication-websocket/websocket-client.ts
@@ -122,7 +122,7 @@ export async function replicateWithWebsocketServer<RxDocType, CheckpointType>(
                 filter(msg => msg.id === 'stream' && msg.collection === options.collection.name),
                 map(msg => msg.result)
             ),
-            async handler(lastPulledCheckpoint: CheckpointType, batchSize: number) {
+            async handler(lastPulledCheckpoint: CheckpointType | undefined, batchSize: number) {
                 const requestId = getRequestId();
                 const request: WebsocketMessageType = {
                     id: requestId,

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -194,7 +194,7 @@ export class RxReplicationState<RxDocType, CheckpointType> {
                     })
                 ),
                 masterChangesSince: async (
-                    checkpoint: CheckpointType,
+                    checkpoint: CheckpointType | undefined,
                     batchSize: number
                 ) => {
                     if (!this.pull) {

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -25,7 +25,7 @@ export type RxGraphQLReplicationPushQueryBuilder = (
 
 
 export type RxGraphQLReplicationPullQueryBuilder<CheckpointType> = (
-    latestPulledCheckpoint: CheckpointType | null,
+    latestPulledCheckpoint: CheckpointType | undefined,
     limit: number
 ) => RxGraphQLReplicationQueryBuilderResponse;
 export type GraphQLSyncPullOptions<RxDocType, CheckpointType> = Omit<

--- a/src/types/plugins/replication.d.ts
+++ b/src/types/plugins/replication.d.ts
@@ -18,14 +18,14 @@ export type InternalStoreReplicationPullDocType<RxDocType> = InternalStoreDocTyp
 }>;
 
 export type ReplicationPullHandlerResult<RxDocType, CheckpointType> = {
-    checkpoint: CheckpointType;
+    checkpoint: CheckpointType | null;
     documents: WithDeleted<RxDocType>[];
 };
 
 export type ReplicationPushHandlerResult<RxDocType> = RxDocType[];
 
 export type ReplicationPullHandler<RxDocType, CheckpointType> = (
-    lastPulledCheckpoint: CheckpointType,
+    lastPulledCheckpoint: CheckpointType | undefined,
     batchSize: number
 ) => Promise<ReplicationPullHandlerResult<RxDocType, CheckpointType>>;
 export type ReplicationPullOptions<RxDocType, CheckpointType> = {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR

- If there is no checkpoint yet, the pull handler's checkpoint is always `undefined`. According to the type definitions, the checkpoint is always a `CheckpointType`. I've updated the parameter types to be `CheckpointType | undefined`.
- It seems like the pull handler can also return no checkpoint if it did not pull anything and the replication just started. In the replication. In the replication plugin [code](https://github.com/pubkey/rxdb/blob/8b7e6c9197830bb1bcea5e9b2a412e9c5e6db401/src/plugins/replication/index.ts#L201-L204) it seems like the returned checkpoint should be `null` in this case. I've added `null` the the pull handler's return type, but I'm not sure if this is correct.