### PR TITLE
replaceAll is not a function

### DIFF
--- a/src/plugins/utils/utils-error.ts
+++ b/src/plugins/utils/utils-error.ts
@@ -45,7 +45,7 @@ export function errorToPlainJson(err: Error | TypeError | RxError | RxTypeError)
          * shows urls to the source code that can be clicked to inspect
          * the correct place in the code.
          */
-        stack: !err.stack ? undefined : err.stack.replaceAll('\n', ' \n ')
+        stack: !err.stack ? undefined : err.stack.replace(/\n/g, ' \n ')
     };
     return ret;
 }


### PR DESCRIPTION
## This PR contains:
- a bug fix

## Describe the problem you have without this PR
issue with string replaceAll on react-native with expo (targets: "ESNext") not supported.
replace with a regex produces the same result.

https://stackoverflow.com/questions/13340131/string-prototype-replaceall-not-working

