### PR TITLE
Add test to show that you can't get data for object field defined with `additionalProperties: { ... }`

### DIFF
--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -125,9 +125,9 @@ describe('bug-report.test.js', () => {
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.strictEqual(myDocument.toJSON().tags, tags);
-        assert.strictEqual(myDocument.get('tags'), tags);
-        assert.strictEqual(myDocument.tags, tags);
+        assert.deepStrictEqual(myDocument.toJSON().tags, tags);
+        assert.deepStrictEqual(myDocument.get('tags'), tags);
+        assert.deepStrictEqual(myDocument.tags, tags);
 
         // clean up afterwards
         db.destroy();

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -9,13 +9,13 @@
  * - 'npm run test:browser' so it runs in the browser
  */
 import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
 import config from './config.ts';
 
 import {
     createRxDatabase,
     randomCouchString
 } from '../../plugins/core/index.mjs';
+import { RxJsonSchema } from '../../src';
 
 describe('bug-report.test.js', () => {
     it('should fail because it reproduces the bug', async () => {
@@ -36,7 +36,7 @@ describe('bug-report.test.js', () => {
         }
 
         // create a schema
-        const mySchema = {
+        const mySchema: RxJsonSchema<any> = {
             version: 0,
             primaryKey: 'passportId',
             type: 'object',
@@ -55,8 +55,22 @@ describe('bug-report.test.js', () => {
                     type: 'integer',
                     minimum: 0,
                     maximum: 150
-                }
-            }
+                },
+                tags: {
+                    type: 'object',
+                    additionalProperties: {
+                        properties: {
+                            created: {
+                                type: 'integer',
+                            },
+                            name: {
+                                type: 'string',
+                            },
+                        },
+                        required: ['created', 'name'],
+                    },
+                },
+            },
         };
 
         /**
@@ -83,54 +97,39 @@ describe('bug-report.test.js', () => {
             }
         });
 
+        const tags = {
+            hello: {
+                created: 1,
+                name: 'hello',
+            },
+            world: {
+                created: 2,
+                name: 'world',
+            }
+        };
+
         // insert a document
         await collections.mycollection.insert({
             passportId: 'foobar',
             firstName: 'Bob',
             lastName: 'Kelso',
-            age: 56
+            age: 56,
+            tags,
         });
 
-        /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
-         */
-        const dbInOtherTab = await createRxDatabase({
-            name,
-            storage: config.storage.getStorage(),
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collectionInOtherTab = await dbInOtherTab.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
-        });
-
-        // find the document in the other tab
-        const myDocument = await collectionInOtherTab.mycollection
+        const myDocument = await collections.mycollection
             .findOne()
-            .where('firstName')
-            .eq('Bob')
             .exec();
 
         /*
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.strictEqual(myDocument.age, 56);
-
-        // you can also wait for events
-        const emitted = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => emitted.push(doc));
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
+        assert.strictEqual(myDocument.toJSON().tags, tags);
+        assert.strictEqual(myDocument.get('tags'), tags);
+        assert.strictEqual(myDocument.tags, tags);
 
         // clean up afterwards
-        sub.unsubscribe();
         db.destroy();
-        dbInOtherTab.destroy();
     });
 });


### PR DESCRIPTION
This replaces #4950. While I was off work, someone accidentally deleted our fork which closed the old PR.