### PR TITLE
CHANGE storage-instance must return deleted docs

### DIFF
--- a/docs-src/docs/migration-storage.md
+++ b/docs-src/docs/migration-storage.md
@@ -10,6 +10,7 @@ The storage migration plugin can be used to migrate all data from one existing R
 - You want to migration from one [RxStorage](./rx-storage.md) to another one.
 - You want to migrate to a new major RxDB version while keeping the previous saved data. This function only works from the previous major version upwards. Do not use it to migrate like rxdb v9 to v14.
 
+<!-- TODO this was inherited from PouchDB, we should remove this in the future and also migrate deleted documents. -->
 The storage migration **drops deleted documents** and filters them out during the migration.
 
 

--- a/docs-src/docs/releases/15.0.0.md
+++ b/docs-src/docs/releases/15.0.0.md
@@ -139,9 +139,12 @@ In the past, the [modifyjs](https://github.com/lgandecki/modifyjs) was used for 
 
 ## Changes to the RxStorage interface
 
-We no longer have `statics.prepareQuery()`. Instead all storages get the same prepared query as input for the `.query()` method. If a storage requires some transformations, it has to do them by itself before running the query. This change simplifies the whole RxDB code base a lot and the previous assumption of having a better performance by pre-running the query preparation, turned out to be not true because the query planning is quite fast.
+We no longer have `RxStorage.statics.prepareQuery()`. Instead all storages get the same prepared query as input for the `.query()` method. If a storage requires some transformations, it has to do them by itself before running the query. This change simplifies the whole RxDB code base a lot and the previous assumption of having a better performance by pre-running the query preparation, turned out to be not true because the query planning is quite fast.
 
 Somewhere in the future it is planned to remove the whole `RxStorage.statics` property to simplify the configuration of storages.
+
+The RxStorage itself will now return `_deleted=true` documents on the `.query()` method. This is required for upcomming plugins like the server plugin where it must be able to run queries on deleted documents.
+Notice that this is only for the RxStorage itself, RxDB queries will run like normal and NOT contain deleted documents in their results.
 
 ## Other changes
 

--- a/docs-src/docs/releases/15.0.0.md
+++ b/docs-src/docs/releases/15.0.0.md
@@ -143,7 +143,7 @@ We no longer have `RxStorage.statics.prepareQuery()`. Instead all storages get t
 
 Somewhere in the future it is planned to remove the whole `RxStorage.statics` property to simplify the configuration of storages.
 
-The RxStorage itself will now return `_deleted=true` documents on the `.query()` method. This is required for upcomming plugins like the server plugin where it must be able to run queries on deleted documents.
+The RxStorage itself will now return `_deleted=true` documents on the `.query()` method. This is required for upcoming plugins like the server plugin where it must be able to run queries on deleted documents.
 Notice that this is only for the RxStorage itself, RxDB queries will run like normal and NOT contain deleted documents in their results.
 
 ## Other changes

--- a/src/custom-index.ts
+++ b/src/custom-index.ts
@@ -268,6 +268,10 @@ export function getStartIndexStringFromLowerBound(
             case 'boolean':
                 if (bound === null) {
                     str += inclusiveStart ? '0' : INDEX_MAX;
+                } else if (bound === INDEX_MIN) {
+                    str += '0';
+                } else if (bound === INDEX_MAX) {
+                    str += '1';
                 } else {
                     const boolToStr = bound ? '1' : '0';
                     str += boolToStr;

--- a/src/plugin-helpers.ts
+++ b/src/plugin-helpers.ts
@@ -19,6 +19,7 @@ import type {
     MaybePromise
 } from './types/index.d.ts';
 import {
+    ensureNotFalsy,
     flatClone,
     getFromMapOrCreate,
     requestIdleCallbackIfAvailable
@@ -272,8 +273,8 @@ export function wrapRxStorageInstance<RxDocType>(
                     return ret;
                 });
         },
-        getChangedDocumentsSince: (limit, checkpoint) => {
-            return instance.getChangedDocumentsSince(limit, checkpoint)
+        getChangedDocumentsSince: !instance.getChangedDocumentsSince ? undefined : (limit, checkpoint) => {
+            return ensureNotFalsy(instance.getChangedDocumentsSince)(limit, checkpoint)
                 .then(async (result) => {
                     return {
                         checkpoint: result.checkpoint,

--- a/src/plugin-helpers.ts
+++ b/src/plugin-helpers.ts
@@ -194,7 +194,6 @@ export function wrapRxStorageInstance<RxDocType>(
         schema: originalSchema,
         collectionName: instance.collectionName,
         count: instance.count.bind(instance),
-        info: instance.info.bind(instance),
         remove: instance.remove.bind(instance),
         originalStorageInstance: instance,
         bulkWrite: async (

--- a/src/plugin-helpers.ts
+++ b/src/plugin-helpers.ts
@@ -19,7 +19,6 @@ import type {
     MaybePromise
 } from './types/index.d.ts';
 import {
-    ensureNotFalsy,
     flatClone,
     getFromMapOrCreate,
     requestIdleCallbackIfAvailable
@@ -274,12 +273,12 @@ export function wrapRxStorageInstance<RxDocType>(
                 });
         },
         getChangedDocumentsSince: !instance.getChangedDocumentsSince ? undefined : (limit, checkpoint) => {
-            return ensureNotFalsy(instance.getChangedDocumentsSince)(limit, checkpoint)
-                .then(async (result) => {
+            return ((instance as any).getChangedDocumentsSince)(limit, checkpoint)
+                .then(async (result: any) => {
                     return {
                         checkpoint: result.checkpoint,
                         documents: await Promise.all(
-                            result.documents.map(d => fromStorage(d))
+                            result.documents.map((d: any) => fromStorage(d))
                         )
                     };
                 });

--- a/src/plugins/backup/index.ts
+++ b/src/plugins/backup/index.ts
@@ -35,6 +35,7 @@ import {
     writeJsonToFile,
     writeToFile
 } from './file-util.ts';
+import { getChangedDocumentsSince } from '../../rx-storage-helper.ts';
 
 
 /**
@@ -143,7 +144,10 @@ export class RxBackupState {
                     let hasMore = true;
                     while (hasMore && !this.isStopped) {
                         await this.database.requestIdlePromise();
-                        const changesResult = await collection.storageInstance.getChangedDocumentsSince(
+                        const changesResult = await getChangedDocumentsSince(
+                            collection.schema.primaryPath,
+                            this.database.storage,
+                            collection.storageInstance,
                             this.options.batchSize ? this.options.batchSize : 0,
                             lastCheckpoint
                         );

--- a/src/plugins/backup/index.ts
+++ b/src/plugins/backup/index.ts
@@ -145,7 +145,6 @@ export class RxBackupState {
                     while (hasMore && !this.isStopped) {
                         await this.database.requestIdlePromise();
                         const changesResult = await getChangedDocumentsSince(
-                            collection.schema.primaryPath,
                             collection.storageInstance,
                             this.options.batchSize ? this.options.batchSize : 0,
                             lastCheckpoint

--- a/src/plugins/backup/index.ts
+++ b/src/plugins/backup/index.ts
@@ -146,7 +146,6 @@ export class RxBackupState {
                         await this.database.requestIdlePromise();
                         const changesResult = await getChangedDocumentsSince(
                             collection.schema.primaryPath,
-                            this.database.storage,
                             collection.storageInstance,
                             this.options.batchSize ? this.options.batchSize : 0,
                             lastCheckpoint

--- a/src/plugins/crdt/index.ts
+++ b/src/plugins/crdt/index.ts
@@ -3,6 +3,7 @@ import type {
     CRDTDocumentField,
     CRDTEntry,
     CRDTOperation,
+    FilledMangoQuery,
     HashFunction,
     JsonSchema,
     RxConflictHandler,
@@ -145,8 +146,8 @@ function runOperationOnDocument<RxDocType>(
     entryParts.forEach(entryPart => {
         let isMatching: boolean;
         if (entryPart.selector) {
-            const query = {
-                selector: ensureNotFalsy(entryPart.selector),
+            const query: FilledMangoQuery<RxDocType> = {
+                selector: ensureNotFalsy(entryPart.selector as any),
                 sort: [],
                 skip: 0
             };

--- a/src/plugins/migration-schema/rx-migration-state.ts
+++ b/src/plugins/migration-schema/rx-migration-state.ts
@@ -66,6 +66,8 @@ import {
     addConnectedStorageToCollection,
     getPrimaryKeyOfInternalDocument
 } from '../../rx-database-internal-store.ts';
+import { prepareQuery } from '../../rx-query.ts';
+import { normalizeMangoQuery } from '../../rx-query-helper.ts';
 
 
 
@@ -451,8 +453,18 @@ export class RxMigrationState {
         let ret = 0;
         await Promise.all(
             storageInstances.map(async (instance) => {
-                const info = await instance.info();
-                ret += info.totalCount;
+
+                const preparedQuery = prepareQuery(
+                    instance.schema,
+                    normalizeMangoQuery(
+                        instance.schema,
+                        {
+                            selector: {}
+                        }
+                    )
+                );
+                const countResult = await instance.count(preparedQuery);
+                ret += countResult.count;
             })
         );
         return ret;

--- a/src/plugins/migration-storage/index.ts
+++ b/src/plugins/migration-storage/index.ts
@@ -111,8 +111,10 @@ export async function migrateCollection<RxDocType>(
 
     const plainQuery: FilledMangoQuery<RxDocType> = {
         selector: {
-            _deleted: false
-        },
+            _deleted: {
+                $eq: false
+            }
+        } as any,
         limit: batchSize,
         sort: [{ [primaryPath]: 'asc' } as any],
         skip: 0

--- a/src/plugins/migration-storage/index.ts
+++ b/src/plugins/migration-storage/index.ts
@@ -146,8 +146,6 @@ export async function migrateCollection<RxDocType>(
          */
         const queryResult = await oldStorageInstance.query(preparedQuery);
         const docs = queryResult.documents;
-        console.log('resuiltös:');
-        console.dir(docs);
         if (docs.length === 0) {
             /**
              * No more documents to migrate

--- a/src/plugins/migration-storage/index.ts
+++ b/src/plugins/migration-storage/index.ts
@@ -10,7 +10,8 @@ import {
     RxStorage,
     blobToBase64String,
     prepareQuery,
-    PreparedQuery
+    PreparedQuery,
+    FilledMangoQuery
 } from '../../index.ts';
 
 export type RxStorageOld<A, B> = RxStorage<A, B> | any;
@@ -108,8 +109,10 @@ export async function migrateCollection<RxDocType>(
     });
 
 
-    const plainQuery = {
-        selector: {},
+    const plainQuery: FilledMangoQuery<RxDocType> = {
+        selector: {
+            _deleted: false
+        },
         limit: batchSize,
         sort: [{ [primaryPath]: 'asc' } as any],
         skip: 0

--- a/src/plugins/migration-storage/index.ts
+++ b/src/plugins/migration-storage/index.ts
@@ -141,6 +141,8 @@ export async function migrateCollection<RxDocType>(
          */
         const queryResult = await oldStorageInstance.query(preparedQuery);
         const docs = queryResult.documents;
+        console.log('resuiltös:');
+        console.dir(docs);
         if (docs.length === 0) {
             /**
              * No more documents to migrate

--- a/src/plugins/migration-storage/index.ts
+++ b/src/plugins/migration-storage/index.ts
@@ -108,7 +108,11 @@ export async function migrateCollection<RxDocType>(
     const preparedQuery = oldStorage.statics.prepareQuery(
         schema as any,
         {
-            selector: {},
+            selector: {
+                _deleted: {
+                    $eq: false
+                }
+            },
             limit: batchSize,
             sort: [{ [primaryPath]: 'asc' } as any],
             skip: 0

--- a/src/plugins/storage-denokv/denokv-query.ts
+++ b/src/plugins/storage-denokv/denokv-query.ts
@@ -37,14 +37,11 @@ export async function queryDenoKV<RxDocType>(
 
     const kv = await instance.kvPromise;
 
-
     const indexForName = queryPlanFields.slice(0);
-    indexForName.unshift('_deleted');
     const indexName = getDenoKVIndexName(indexForName);
     const indexMeta = ensureNotFalsy(instance.internals.indexes[indexName]);
 
     let lowerBound: any[] = queryPlan.startKeys;
-    lowerBound = [false].concat(lowerBound);
     let lowerBoundString = getStartIndexStringFromLowerBound(
         instance.schema,
         indexForName,
@@ -56,15 +53,15 @@ export async function queryDenoKV<RxDocType>(
     }
 
     let upperBound: any[] = queryPlan.endKeys;
-    upperBound = [false].concat(upperBound);
     let upperBoundString = getStartIndexStringFromUpperBound(
         instance.schema,
         indexForName,
         upperBound,
         queryPlan.inclusiveEnd
     );
-    if (!queryPlan.inclusiveEnd) {
-        upperBoundString = changeIndexableStringByOneQuantum(upperBoundString, -1);
+
+    if (queryPlan.inclusiveEnd) {
+        upperBoundString = changeIndexableStringByOneQuantum(upperBoundString, +1);
     }
 
 

--- a/src/plugins/storage-denokv/denokv-query.ts
+++ b/src/plugins/storage-denokv/denokv-query.ts
@@ -24,7 +24,7 @@ export async function queryDenoKV<RxDocType>(
     const limit = query.limit ? query.limit : Infinity;
     const skipPlusLimit = skip + limit;
     const queryPlanFields: string[] = queryPlan.index;
-    const mustManuallyResort = !queryPlan.sortFieldsSameAsIndexFields;
+    const mustManuallyResort = !queryPlan.sortSatisfiedByIndex;
 
 
     let queryMatcher: QueryMatcher<RxDocumentData<RxDocType>> | false = false;

--- a/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
+++ b/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
@@ -387,11 +387,6 @@ export async function createDenoKVStorageInstance<RxDocType>(
         const indexAr = toArray(index);
         return indexAr;
     });
-    // used for `getChangedDocumentsSince()`
-    useIndexesFinal.push([
-        '_meta.lwt',
-        primaryPath
-    ]);
     useIndexesFinal.push(CLEANUP_INDEX);
     useIndexesFinal.forEach((indexAr, indexId) => {
         const indexName = getDenoKVIndexName(indexAr);

--- a/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
+++ b/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
@@ -258,70 +258,6 @@ export class RxStorageInstanceDenoKV<RxDocType> implements RxStorageInstance<
     getAttachmentData(documentId: string, attachmentId: string, digest: string): Promise<string> {
         throw new Error("Method not implemented.");
     }
-    async getChangedDocumentsSince(limit: number, checkpoint?: RxStorageDefaultCheckpoint | undefined): Promise<{ documents: RxDocumentData<RxDocType>[]; checkpoint: RxStorageDefaultCheckpoint; }> {
-        return this.retryUntilNoWriteInBetween(
-            async () => {
-                const kv = await this.kvPromise;
-                const index = [
-                    '_meta.lwt',
-                    this.primaryPath as any
-                ];
-                const indexName = getDenoKVIndexName(index);
-                const indexMeta = this.internals.indexes[indexName];
-                let lowerBoundString = '';
-                if (checkpoint) {
-                    const checkpointPartialDoc: any = {
-                        [this.primaryPath]: checkpoint.id,
-                        _meta: {
-                            lwt: checkpoint.lwt
-                        }
-                    };
-                    lowerBoundString = indexMeta.getIndexableString(checkpointPartialDoc);
-                    lowerBoundString = changeIndexableStringByOneQuantum(lowerBoundString, 1);
-                }
-
-                const range = kv.list({
-                    start: [this.keySpace, indexMeta.indexId, lowerBoundString],
-                    end: [this.keySpace, indexMeta.indexId, INDEX_MAX]
-                }, {
-                    consistency: this.settings.consistencyLevel,
-                    limit,
-                    batchSize: this.settings.batchSize
-                });
-                const docIds: any[] = [];
-                for await (const row of range) {
-                    const docId = row.value;
-                    docIds.push([this.keySpace, DENOKV_DOCUMENT_ROOT_PATH, docId]);
-                }
-
-                /**
-                 * We have to run in batches because without it says
-                 * "TypeError: too many ranges (max 10)"
-                 */
-                const batches = batchArray(docIds, 10);
-                const result: RxDocumentData<RxDocType>[] = [];
-
-                for (const batch of batches) {
-                    const docs = await kv.getMany(batch);
-                    docs.forEach((row: any) => {
-                        const docData = row.value;
-                        result.push(docData as any);
-                    });
-                }
-
-                const lastDoc = lastOfArray(result);
-                return {
-                    documents: result,
-                    checkpoint: lastDoc ? {
-                        id: lastDoc[this.primaryPath] as any,
-                        lwt: lastDoc._meta.lwt
-                    } : checkpoint ? checkpoint : {
-                        id: '',
-                        lwt: 0
-                    }
-                };
-            });
-    }
     changeStream() {
         return this.changes$.asObservable();
     }
@@ -449,7 +385,6 @@ export async function createDenoKVStorageInstance<RxDocType>(
     useIndexes.push([primaryPath]);
     const useIndexesFinal = useIndexes.map(index => {
         const indexAr = toArray(index);
-        indexAr.unshift('_deleted');
         return indexAr;
     });
     // used for `getChangedDocumentsSince()`

--- a/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
+++ b/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
@@ -17,7 +17,6 @@ import type {
     RxConflictResultionTaskSolution,
     RxStorageDefaultCheckpoint,
     RxStorageCountResult,
-    RxStorageInfoResult,
     RxConflictResultionTask,
     PreparedQuery
 } from '../../types/index.d.ts';
@@ -26,7 +25,7 @@ import { addRxStorageMultiInstanceSupport } from '../../rx-storage-multiinstance
 import type { DenoKVIndexMeta, DenoKVSettings, DenoKVStorageInternals } from './denokv-types.ts';
 import { RxStorageDenoKV } from './index.ts';
 import { CLEANUP_INDEX, DENOKV_DOCUMENT_ROOT_PATH, RX_STORAGE_NAME_DENOKV, getDenoGlobal, getDenoKVIndexName } from "./denokv-helper.ts";
-import { getIndexableStringMonad, getStartIndexStringFromLowerBound, changeIndexableStringByOneQuantum } from "../../custom-index.ts";
+import { getIndexableStringMonad, getStartIndexStringFromLowerBound } from "../../custom-index.ts";
 import { appendToArray, batchArray, lastOfArray, toArray } from "../utils/utils-array.ts";
 import { ensureNotFalsy } from "../utils/utils-other.ts";
 import { categorizeBulkWriteRows } from "../../rx-storage-helper.ts";
@@ -236,24 +235,6 @@ export class RxStorageInstanceDenoKV<RxDocType> implements RxStorageInstance<
             count: result.documents.length,
             mode: 'fast'
         };
-    }
-    async info(): Promise<RxStorageInfoResult> {
-        return this.retryUntilNoWriteInBetween(
-            async () => {
-                const kv = await this.kvPromise;
-                const range = kv.list({
-                    start: [this.keySpace, DENOKV_DOCUMENT_ROOT_PATH],
-                    end: [this.keySpace, DENOKV_DOCUMENT_ROOT_PATH, INDEX_MAX]
-                }, this.kvOptions);
-                let totalCount = 0;
-                for await (const res of range) {
-                    totalCount++;
-                }
-                return {
-                    totalCount
-                };
-            }
-        );
     }
     getAttachmentData(documentId: string, attachmentId: string, digest: string): Promise<string> {
         throw new Error("Method not implemented.");

--- a/src/plugins/storage-dexie/dexie-helper.ts
+++ b/src/plugins/storage-dexie/dexie-helper.ts
@@ -53,12 +53,6 @@ export function getDexieDbWithTables(
                 dexieDb.version(1).stores(dexieStoresSettings);
                 await dexieDb.open();
 
-
-                // if (getBooleanIndexes(schema).length === 0) {
-                //     console.dir(schema);
-                //     throw new Error('not a single boolean index');
-                // }
-
                 return {
                     dexieDb,
                     dexieTable: (dexieDb as any)[DEXIE_DOCS_TABLE_NAME],
@@ -259,10 +253,6 @@ export function getDexieStoreSchema(
     dexieSchemaRows = dexieSchemaRows.filter((elem: any, pos: any, arr: any) => arr.indexOf(elem) === pos); // unique;
     const dexieSchema = dexieSchemaRows.join(', ');
 
-
-    console.log('########################## dexie schema:');
-    console.dir(dexieSchema);
-
     return dexieSchema;
 }
 
@@ -286,9 +276,6 @@ export function attachmentObjectId(documentId: string, attachmentId: string): st
 
 
 export function getBooleanIndexes(schema: RxJsonSchema<any>): string[] {
-
-    console.log('::getBooleanIndexes()');
-    console.dir(schema);
     const checkedFields = new Set<string>();
     const ret: string[] = [];
     if (!schema.indexes) {
@@ -308,7 +295,6 @@ export function getBooleanIndexes(schema: RxJsonSchema<any>): string[] {
         });
     });
     ret.push('_deleted');
-    console.dir(ret);
 
     return uniqueArray(ret);
 }

--- a/src/plugins/storage-dexie/dexie-query.ts
+++ b/src/plugins/storage-dexie/dexie-query.ts
@@ -153,7 +153,7 @@ export async function dexieQuery<RxDocType>(
                          * because we already have every relevant document.
                          */
                         if (
-                            queryPlan.sortFieldsSameAsIndexFields &&
+                            queryPlan.sortSatisfiedByIndex &&
                             rows.length === skipPlusLimit
                         ) {
                             res();
@@ -172,7 +172,7 @@ export async function dexieQuery<RxDocType>(
     );
 
 
-    if (!queryPlan.sortFieldsSameAsIndexFields) {
+    if (!queryPlan.sortSatisfiedByIndex) {
         const sortComparator = getSortComparator(instance.schema, preparedQuery.query);
         rows = rows.sort(sortComparator);
     }

--- a/src/plugins/storage-dexie/dexie-query.ts
+++ b/src/plugins/storage-dexie/dexie-query.ts
@@ -27,12 +27,8 @@ function rangeFieldToBooleanSubstitute(
     fieldName: string,
     value: any
 ) {
-    console.log('rangeFieldToBooleanSubstitute: ' + fieldName);
     if (booleanIndexes.includes(fieldName)) {
-        console.log('xxxx yes');
-        console.dir(value);
         const newValue = value === INDEX_MAX || value === true ? '1' : '0';
-        console.dir(newValue);
         return newValue;
     } else {
         return value;
@@ -65,9 +61,6 @@ export function getKeyRangeByQueryPlan(
             return rangeFieldToBooleanSubstitute(booleanIndexes, fieldName, v);
         })
         .map(mapKeyForKeyRange);
-
-    console.log('xxx new keyrange:');
-    console.dir({ queryPlan, startKeys, endKeys, booleanIndexes });
 
     const keyRange = IDBKeyRange.bound(
         startKeys,
@@ -109,14 +102,6 @@ export async function dexieQuery<RxDocType>(
 
     const queryPlanFields: string[] = queryPlan.index;
 
-
-    console.log('query:: ');
-    console.dir({
-        preparedQuery,
-        schema: instance.schema
-    });
-    console.dir(keyRange);
-
     let rows: any[] = [];
     await state.dexieDb.transaction(
         'r',
@@ -141,7 +126,6 @@ export async function dexieQuery<RxDocType>(
                     .map(field => dexieReplaceIfStartsWithPipe(field))
                     .join('+')
                 + ']';
-            console.log('indexName: ' + indexName);
             index = store.index(indexName);
 
 
@@ -152,8 +136,6 @@ export async function dexieQuery<RxDocType>(
                     if (cursor) {
                         // We have a record in cursor.value
                         const docData = fromDexieToStorage<RxDocType>(state.booleanIndexes, cursor.value);
-                        console.log('curseroror');
-                        console.dir(docData);
                         if (!queryMatcher || queryMatcher(docData)) {
                             rows.push(docData);
                         }

--- a/src/plugins/storage-dexie/rx-storage-instance-dexie.ts
+++ b/src/plugins/storage-dexie/rx-storage-instance-dexie.ts
@@ -199,12 +199,7 @@ export class RxStorageInstanceDexie<RxDocType> implements RxStorageInstance<
             'r',
             state.dexieTable,
             async () => {
-
-                console.log('find by id ' + deleted);
-                console.dir(ids);
-
                 const docsInDb = await getDocsInDb<RxDocType>(this.internals, ids);
-                console.dir(docsInDb);
                 docsInDb.forEach(documentInDb => {
                     if (
                         documentInDb &&
@@ -213,8 +208,6 @@ export class RxStorageInstanceDexie<RxDocType> implements RxStorageInstance<
                         ret.push(documentInDb);
                     }
                 });
-
-                console.dir(ret);
             });
         return ret;
     }

--- a/src/plugins/storage-dexie/rx-storage-instance-dexie.ts
+++ b/src/plugins/storage-dexie/rx-storage-instance-dexie.ts
@@ -26,8 +26,7 @@ import type {
     RxStorageDefaultCheckpoint,
     CategorizeBulkWriteRowsOutput,
     RxStorageCountResult,
-    PreparedQuery,
-    RxStorageInfoResult
+    PreparedQuery
 } from '../../types/index.d.ts';
 import type {
     DexieSettings,
@@ -235,22 +234,6 @@ export class RxStorageInstanceDexie<RxDocType> implements RxStorageInstance<
                 mode: 'slow'
             };
         }
-    }
-
-    async info(): Promise<RxStorageInfoResult> {
-        const state = await this.internals;
-        const ret: RxStorageInfoResult = {
-            totalCount: -1
-        };
-        await state.dexieDb.transaction(
-            'r',
-            state.dexieTable,
-            async (_dexieTx) => {
-                ret.totalCount = await state.dexieTable.count();
-            }
-        );
-
-        return ret;
     }
 
     changeStream(): Observable<EventBulk<RxStorageChangeEvent<RxDocumentData<RxDocType>>, RxStorageDefaultCheckpoint>> {

--- a/src/plugins/storage-foundationdb/foundationdb-query.ts
+++ b/src/plugins/storage-foundationdb/foundationdb-query.ts
@@ -23,7 +23,7 @@ export async function queryFoundationDB<RxDocType>(
     const limit = query.limit ? query.limit : Infinity;
     const skipPlusLimit = skip + limit;
     const queryPlanFields: string[] = queryPlan.index;
-    const mustManuallyResort = !queryPlan.sortFieldsSameAsIndexFields;
+    const mustManuallyResort = !queryPlan.sortSatisfiedByIndex;
 
 
     let queryMatcher: QueryMatcher<RxDocumentData<RxDocType>> | false = false;

--- a/src/plugins/storage-foundationdb/foundationdb-query.ts
+++ b/src/plugins/storage-foundationdb/foundationdb-query.ts
@@ -1,4 +1,5 @@
 import {
+    changeIndexableStringByOneQuantum,
     getStartIndexStringFromLowerBound,
     getStartIndexStringFromUpperBound
 } from '../../custom-index.ts';
@@ -42,7 +43,7 @@ export async function queryFoundationDB<RxDocType>(
     const indexDB = ensureNotFalsy(dbs.indexes[indexName]).db;
 
     let lowerBound: any[] = queryPlan.startKeys;
-    const lowerBoundString = getStartIndexStringFromLowerBound(
+    let lowerBoundString = getStartIndexStringFromLowerBound(
         instance.schema,
         indexForName,
         lowerBound,
@@ -50,7 +51,7 @@ export async function queryFoundationDB<RxDocType>(
     );
 
     let upperBound: any[] = queryPlan.endKeys;
-    const upperBoundString = getStartIndexStringFromUpperBound(
+    let upperBoundString = getStartIndexStringFromUpperBound(
         instance.schema,
         indexForName,
         upperBound,
@@ -79,6 +80,13 @@ export async function queryFoundationDB<RxDocType>(
                 }
             }
             return innerResult;
+        }
+
+        if (!queryPlan.inclusiveStart) {
+            lowerBoundString = changeIndexableStringByOneQuantum(lowerBoundString, 1);
+        }
+        if (queryPlan.inclusiveEnd) {
+            upperBoundString = changeIndexableStringByOneQuantum(upperBoundString, +1);
         }
 
         const range = indexTx.getRangeBatch(

--- a/src/plugins/storage-foundationdb/foundationdb-query.ts
+++ b/src/plugins/storage-foundationdb/foundationdb-query.ts
@@ -38,12 +38,10 @@ export async function queryFoundationDB<RxDocType>(
 
 
     const indexForName = queryPlanFields.slice(0);
-    indexForName.unshift('_deleted');
     const indexName = getFoundationDBIndexName(indexForName);
     const indexDB = ensureNotFalsy(dbs.indexes[indexName]).db;
 
     let lowerBound: any[] = queryPlan.startKeys;
-    lowerBound = [false].concat(lowerBound);
     const lowerBoundString = getStartIndexStringFromLowerBound(
         instance.schema,
         indexForName,
@@ -52,7 +50,6 @@ export async function queryFoundationDB<RxDocType>(
     );
 
     let upperBound: any[] = queryPlan.endKeys;
-    upperBound = [false].concat(upperBound);
     const upperBoundString = getStartIndexStringFromUpperBound(
         instance.schema,
         indexForName,

--- a/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
+++ b/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
@@ -464,7 +464,6 @@ export function createFoundationDBStorageInstance<RxDocType>(
         useIndexes.push([primaryPath]);
         const useIndexesFinal = useIndexes.map(index => {
             const indexAr = toArray(index);
-            indexAr.unshift('_deleted');
             return indexAr;
         });
         // used for `getChangedDocumentsSince()`

--- a/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
+++ b/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
@@ -14,7 +14,6 @@ import type {
     RxStorageChangeEvent,
     RxStorageCountResult,
     RxStorageDefaultCheckpoint,
-    RxStorageInfoResult,
     RxStorageInstance,
     RxStorageInstanceCreationParams,
     RxStorageQueryResult,
@@ -242,21 +241,6 @@ export class RxStorageInstanceFoundationDB<RxDocType> implements RxStorageInstan
             count: result.documents.length,
             mode: 'fast'
         };
-    }
-    async info(): Promise<RxStorageInfoResult> {
-        const dbs = await this.internals.dbsPromise;
-        const ret: RxStorageInfoResult = {
-            totalCount: -1
-        };
-        await dbs.root.doTransaction(async (tx: any) => {
-            const mainTx = tx.at(dbs.main.subspace);
-            const range = await mainTx.getRangeAll(
-                '',
-                INDEX_MAX
-            );
-            ret.totalCount = range.length;
-        });
-        return ret;
     }
 
     async getAttachmentData(documentId: string, attachmentId: string, _digest: string): Promise<string> {

--- a/src/plugins/storage-lokijs/lokijs-helper.ts
+++ b/src/plugins/storage-lokijs/lokijs-helper.ts
@@ -270,27 +270,6 @@ export function getLokiSortComparator<RxDocType>(
 }
 
 
-export function patchLokiJSQuery<RxDocType>(
-    mutateableQuery: FilledMangoQuery<RxDocType>
-) {
-    mutateableQuery = flatClone(mutateableQuery);
-    if (Object.keys(ensureNotFalsy(mutateableQuery.selector)).length > 0) {
-        mutateableQuery.selector = {
-            $and: [
-                {
-                    _deleted: false
-                },
-                mutateableQuery.selector
-            ]
-        } as any;
-    } else {
-        mutateableQuery.selector = {
-            _deleted: false
-        } as any;
-    }
-
-    return mutateableQuery;
-}
 
 export function getLokiLeaderElector(
     databaseInstanceToken: string,

--- a/src/plugins/storage-lokijs/lokijs-helper.ts
+++ b/src/plugins/storage-lokijs/lokijs-helper.ts
@@ -227,7 +227,7 @@ export async function closeLokiCollections(
  */
 export function getLokiSortComparator<RxDocType>(
     _schema: RxJsonSchema<RxDocumentData<RxDocType>>,
-    query: MangoQuery<RxDocType>
+    query: FilledMangoQuery<RxDocType>
 ): DeterministicSortComparator<RxDocType> {
     if (!query.sort) {
         throw newRxError('SNH', { query });

--- a/src/plugins/storage-lokijs/rx-storage-instance-loki.ts
+++ b/src/plugins/storage-lokijs/rx-storage-instance-loki.ts
@@ -225,6 +225,9 @@ export class RxStorageInstanceLoki<RxDocType> implements RxStorageInstance<
             return requestRemoteInstance(this, 'query', [preparedQueryOriginal]);
         }
 
+        console.log('loki query:');
+        console.dir(preparedQueryOriginal);
+
         let preparedQuery = patchLokiJSQuery(ensureNotFalsy(preparedQueryOriginal.query));
         if (preparedQuery.selector) {
             preparedQuery = flatClone(preparedQuery);

--- a/src/plugins/storage-lokijs/rx-storage-instance-loki.ts
+++ b/src/plugins/storage-lokijs/rx-storage-instance-loki.ts
@@ -7,10 +7,7 @@ import {
     now,
     ensureNotFalsy,
     isMaybeReadonlyArray,
-    getFromMapOrThrow,
-    getSortDocumentsByLastWriteTimeComparator,
-    RX_META_LWT_MINIMUM,
-    lastOfArray
+    getFromMapOrThrow
 } from '../utils/index.ts';
 import { newRxError } from '../../rx-error.ts';
 import type {
@@ -34,7 +31,6 @@ import type {
     RxConflictResultionTaskSolution,
     RxStorageDefaultCheckpoint,
     RxStorageCountResult,
-    RxStorageInfoResult,
     PreparedQuery
 } from '../../types/index.d.ts';
 import {
@@ -103,7 +99,6 @@ export class RxStorageInstanceLoki<RxDocType> implements RxStorageInstance<
                 close: this.close.bind(this),
                 query: this.query.bind(this),
                 count: this.count.bind(this),
-                info: this.info.bind(this),
                 findDocumentsById: this.findDocumentsById.bind(this),
                 collectionName: this.collectionName,
                 databaseName: this.databaseName,
@@ -282,17 +277,6 @@ export class RxStorageInstanceLoki<RxDocType> implements RxStorageInstance<
     }
     getAttachmentData(_documentId: string, _attachmentId: string, _digest: string): Promise<string> {
         throw new Error('Attachments are not implemented in the lokijs RxStorage. Make a pull request.');
-    }
-
-
-    async info(): Promise<RxStorageInfoResult> {
-        const localState = await mustUseLocalState(this);
-        if (!localState) {
-            return requestRemoteInstance(this, 'info', []);
-        }
-        return {
-            totalCount: localState.collection.count()
-        };
     }
 
     changeStream(): Observable<EventBulk<RxStorageChangeEvent<RxDocumentData<RxDocType>>, RxStorageDefaultCheckpoint>> {

--- a/src/plugins/storage-memory/memory-indexes.ts
+++ b/src/plugins/storage-memory/memory-indexes.ts
@@ -11,12 +11,6 @@ export function addIndexesToInternalsState<RxDocType>(
     const primaryPath = getPrimaryFieldOfPrimaryKey(schema.primaryKey);
     const useIndexes: string[][] = !schema.indexes ? [] : schema.indexes.map(row => toArray(row)) as any;
 
-    // we need this as default index
-    useIndexes.push([
-        '_deleted',
-        primaryPath
-    ]);
-
     // we need this index for running cleanup()
     useIndexes.push([
         '_deleted',
@@ -32,19 +26,6 @@ export function addIndexesToInternalsState<RxDocType>(
             getIndexableString: getIndexableStringMonad(schema, indexAr)
         };
     });
-
-    // we need this index for the changes()
-    const changesIndex = [
-        '_meta.lwt',
-        primaryPath
-    ];
-    const indexName = getMemoryIndexName(changesIndex);
-    state.byIndex[indexName] = {
-        index: changesIndex,
-        docsWithIndex: [],
-        getIndexableString: getIndexableStringMonad(schema, changesIndex)
-    };
-
 }
 
 

--- a/src/plugins/storage-memory/memory-indexes.ts
+++ b/src/plugins/storage-memory/memory-indexes.ts
@@ -13,23 +13,19 @@ export function addIndexesToInternalsState<RxDocType>(
 
     // we need this as default index
     useIndexes.push([
+        '_deleted',
         primaryPath
     ]);
 
     // we need this index for running cleanup()
     useIndexes.push([
+        '_deleted',
         '_meta.lwt',
         primaryPath
     ]);
 
 
     useIndexes.forEach(indexAr => {
-        /**
-         * Running a query will only return non-deleted documents
-         * so all indexes must have the the deleted field as first index field.
-         */
-        indexAr.unshift('_deleted');
-
         state.byIndex[getMemoryIndexName(indexAr)] = {
             index: indexAr,
             docsWithIndex: [],

--- a/src/plugins/storage-memory/rx-storage-instance-memory.ts
+++ b/src/plugins/storage-memory/rx-storage-instance-memory.ts
@@ -23,7 +23,6 @@ import type {
     RxStorageChangeEvent,
     RxStorageCountResult,
     RxStorageDefaultCheckpoint,
-    RxStorageInfoResult,
     RxStorageInstance,
     RxStorageInstanceCreationParams,
     RxStorageQueryResult,
@@ -374,13 +373,6 @@ export class RxStorageInstanceMemory<RxDocType> implements RxStorageInstance<
             count: result.documents.length,
             mode: 'fast'
         };
-    }
-
-    info(): Promise<RxStorageInfoResult> {
-        this.ensurePersistence();
-        return Promise.resolve({
-            totalCount: this.internals.documents.size
-        });
     }
 
     cleanup(minimumDeletedTime: number): Promise<boolean> {

--- a/src/plugins/storage-memory/rx-storage-instance-memory.ts
+++ b/src/plugins/storage-memory/rx-storage-instance-memory.ts
@@ -273,10 +273,6 @@ export class RxStorageInstanceMemory<RxDocType> implements RxStorageInstance<
     ): Promise<RxStorageQueryResult<RxDocType>> {
         this.ensurePersistence();
 
-
-        console.log('query():');
-        console.dir(preparedQuery);
-
         const queryPlan = preparedQuery.queryPlan;
         const query = preparedQuery.query;
 

--- a/src/plugins/storage-mongodb/mongodb-helper.ts
+++ b/src/plugins/storage-mongodb/mongodb-helper.ts
@@ -25,9 +25,6 @@ export function primarySwapMongoDBQuerySelector<RxDocType>(
     selector: MangoQuerySelector<RxDocType>
 ): MongoQuerySelector<RxDocType> {
     selector = flatClone(selector);
-    (selector as any)._deleted = false;
-
-
 
     if (primaryKey !== '_id') {
         return selector as any;

--- a/src/plugins/storage-mongodb/mongodb-types.ts
+++ b/src/plugins/storage-mongodb/mongodb-types.ts
@@ -4,7 +4,7 @@ import type {
     TransactionOptions
 } from 'mongodb';
 import type {
-    MangoQuery
+    FilledMangoQuery
 } from '../../types/index.d.ts';
 export type MongoQuerySelector<RxDocType> = MongoQueryFilter<RxDocType | any>;
 export type MongoDBDatabaseSettings = {
@@ -17,7 +17,7 @@ export type MongoDBDatabaseSettings = {
 };
 
 export type MongoDBPreparedQuery<RxDocType> = {
-    query: MangoQuery<RxDocType>;
+    query: FilledMangoQuery<RxDocType>;
     mongoSelector: MongoQuerySelector<RxDocType>;
     mongoSort: MongoSort;
 };

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -410,54 +410,6 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         };
     }
 
-    async getChangedDocumentsSince(
-        limit: number,
-        checkpoint?: RxStorageDefaultCheckpoint
-    ): Promise<{
-        documents: RxDocumentData<RxDocType>[];
-        checkpoint: RxStorageDefaultCheckpoint;
-    }> {
-        this.runningOperations.next(this.runningOperations.getValue() + 1);
-        const mongoCollection = await this.mongoCollectionPromise;
-        const sinceLwt = checkpoint ? checkpoint.lwt : RX_META_LWT_MINIMUM;
-        const plainQuery = {
-            $or: [
-                {
-                    '_meta.lwt': {
-                        $gt: sinceLwt
-                    }
-                },
-                {
-                    '_meta.lwt': {
-                        $eq: sinceLwt
-                    },
-                    [this.inMongoPrimaryPath]: {
-                        $gt: checkpoint ? checkpoint.id : ''
-                    }
-                }
-            ]
-        };
-        const query = mongoCollection.find(plainQuery)
-            .sort({
-                '_meta.lwt': 1,
-                [this.inMongoPrimaryPath]: 1
-            })
-            .limit(limit);
-        const documents = await query.toArray();
-        const lastDoc = lastOfArray(documents);
-        this.runningOperations.next(this.runningOperations.getValue() - 1);
-        return {
-            documents: documents.map(d => swapMongoToRxDoc(d)),
-            checkpoint: lastDoc ? {
-                id: lastDoc[this.primaryPath],
-                lwt: lastDoc._meta.lwt
-            } : checkpoint ? checkpoint : {
-                id: '',
-                lwt: 0
-            }
-        };
-    }
-
     async cleanup(minimumDeletedTime: number): Promise<boolean> {
         this.runningOperations.next(this.runningOperations.getValue() + 1);
         const mongoCollection = await this.mongoCollectionPromise;

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -18,7 +18,6 @@ import type {
     RxStorageChangeEvent,
     RxStorageCountResult,
     RxStorageDefaultCheckpoint,
-    RxStorageInfoResult,
     RxStorageInstance,
     RxStorageInstanceCreationParams,
     RxStorageQueryResult,
@@ -396,17 +395,6 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         return {
             count,
             mode: 'fast'
-        };
-    }
-
-    async info(): Promise<RxStorageInfoResult> {
-        this.runningOperations.next(this.runningOperations.getValue() + 1);
-        await this.writeQueue;
-        const mongoCollection = await this.mongoCollectionPromise;
-        const totalCount = await mongoCollection.countDocuments();
-        this.runningOperations.next(this.runningOperations.getValue() - 1);
-        return {
-            totalCount
         };
     }
 

--- a/src/plugins/storage-remote/remote.ts
+++ b/src/plugins/storage-remote/remote.ts
@@ -16,6 +16,7 @@ import type {
     RxStorageRemoteExposeSettingsRxStorage,
     RxStorageRemoteExposeType
 } from './storage-remote-types.ts';
+import { getChangedDocumentsSince } from '../../rx-storage-helper.ts';
 
 /**
  * Run this on the 'remote' part,
@@ -230,12 +231,21 @@ export function exposeRxStorageRemote(settings: RxStorageRemoteExposeSettings): 
                         subs.forEach(sub => sub.unsubscribe());
                         return;
                     }
-                    result = await (storageInstance as any)[message.method](
-                        message.params[0],
-                        message.params[1],
-                        message.params[2],
-                        message.params[3]
-                    );
+
+                    if (message.method === 'getChangedDocumentsSince' && !storageInstance.getChangedDocumentsSince) {
+                        result = await getChangedDocumentsSince(
+                            storageInstance,
+                            message.params[0],
+                            message.params[1]
+                        );
+                    } else {
+                        result = await (storageInstance as any)[message.method](
+                            message.params[0],
+                            message.params[1],
+                            message.params[2],
+                            message.params[3]
+                        );
+                    }
                     if (
                         message.method === 'close' ||
                         message.method === 'remove'

--- a/src/plugins/storage-remote/rx-storage-remote.ts
+++ b/src/plugins/storage-remote/rx-storage-remote.ts
@@ -16,7 +16,6 @@ import type {
     RxStorageBulkWriteResponse,
     RxStorageChangeEvent,
     RxStorageCountResult,
-    RxStorageInfoResult,
     RxStorageInstance,
     RxStorageInstanceCreationParams,
     RxStorageQueryResult,
@@ -240,9 +239,6 @@ export class RxStorageInstanceRemote<RxDocType> implements RxStorageInstance<RxD
     }
     count(preparedQuery: any): Promise<RxStorageCountResult> {
         return this.requestRemote('count', [preparedQuery]);
-    }
-    info(): Promise<RxStorageInfoResult> {
-        return this.requestRemote('info', []);
     }
     getAttachmentData(documentId: string, attachmentId: string, digest: string): Promise<string> {
         return this.requestRemote('getAttachmentData', [documentId, attachmentId, digest]);

--- a/src/plugins/utils/utils-array.ts
+++ b/src/plugins/utils/utils-array.ts
@@ -145,4 +145,12 @@ export function appendToArray<T>(ar: T[], add: T[] | readonly T[]): void {
     }
 }
 
+/**
+ * @link https://gist.github.com/telekosmos/3b62a31a5c43f40849bb
+ */
+export function uniqueArray(arrArg: string[]): string[] {
+    return arrArg.filter(function (elem, pos, arr) {
+        return arr.indexOf(elem) === pos;
+    });
+}
 

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -1,6 +1,6 @@
 import { countUntilNotMatching } from './plugins/utils/index.ts';
 import { newRxError } from './rx-error.ts';
-import { getPrimaryFieldOfPrimaryKey, getSchemaByObjectPath } from './rx-schema-helper.ts';
+import { getSchemaByObjectPath } from './rx-schema-helper.ts';
 import type {
     FilledMangoQuery,
     MangoQuerySelector,
@@ -35,15 +35,15 @@ export function getQueryPlan<RxDocType>(
     schema: RxJsonSchema<RxDocumentData<RxDocType>>,
     query: FilledMangoQuery<RxDocType>
 ): RxQueryPlan {
-    const primaryPath = getPrimaryFieldOfPrimaryKey(schema.primaryKey);
     const selector = query.selector;
 
     let indexes: string[][] = schema.indexes ? schema.indexes.slice(0) as any : [];
     if (query.index) {
         indexes = [query.index];
-    } else {
-        indexes.push(['_deleted', primaryPath]);
     }
+
+    console.log('.-....................');
+    console.dir({schema, query});
 
     /**
      * Most storages do not support descending indexes

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -1,5 +1,6 @@
 import { countUntilNotMatching } from './plugins/utils/index.ts';
-import { getPrimaryFieldOfPrimaryKey } from './rx-schema-helper.ts';
+import { newRxError } from './rx-error.ts';
+import { getPrimaryFieldOfPrimaryKey, getSchemaByObjectPath } from './rx-schema-helper.ts';
 import type {
     FilledMangoQuery,
     MangoQuerySelector,
@@ -20,9 +21,8 @@ export const INDEX_MAX = String.fromCharCode(65535);
  * Notice that for IndexedDB IDBKeyRange we have
  * to transform the value back to -Infinity
  * before we can use it in IDBKeyRange.bound.
- *
  */
-export const INDEX_MIN = Number.MIN_VALUE;
+export const INDEX_MIN = Number.MIN_SAFE_INTEGER;
 
 /**
  * Returns the query plan which contains
@@ -42,16 +42,39 @@ export function getQueryPlan<RxDocType>(
     if (query.index) {
         indexes = [query.index];
     } else {
-        indexes.push([primaryPath]);
+        indexes.push(['_deleted', primaryPath]);
     }
 
-    const optimalSortIndex = query.sort.map(sortField => Object.keys(sortField)[0]);
-    const optimalSortIndexCompareString = optimalSortIndex.join(',');
     /**
      * Most storages do not support descending indexes
      * so having a 'desc' in the sorting, means we always have to re-sort the results.
      */
     const hasDescSorting = !!query.sort.find(sortField => Object.values(sortField)[0] === 'desc');
+
+    /**
+     * Some fields can be part of the selector while not being relevant for sorting
+     * because their selector operators specify that in all cases all matching docs
+     * would have the same value.
+     * For example the boolean field _deleted.
+     * TODO similar thing could be done for enums.
+     */
+    const sortIrrelevevantFields = new Set();
+    Object.keys(selector).forEach(fieldName => {
+        const schemaPart = getSchemaByObjectPath(schema, fieldName);
+        if (
+            schemaPart &&
+            schemaPart.type === 'boolean' &&
+            (selector as any)[fieldName].hasOwnProperty('$eq')
+        ) {
+            sortIrrelevevantFields.add(fieldName);
+        }
+    });
+
+
+    const optimalSortIndex = query.sort.map(sortField => Object.keys(sortField)[0]);
+    const optimalSortIndexCompareString = optimalSortIndex
+        .filter(f => !sortIrrelevevantFields.has(f))
+        .join(',');
 
     let currentBestQuality = -1;
     let currentBestQueryPlan: RxQueryPlan | undefined;
@@ -115,7 +138,7 @@ export function getQueryPlan<RxDocType>(
             endKeys: opts.map(opt => opt.endKey),
             inclusiveEnd,
             inclusiveStart,
-            sortFieldsSameAsIndexFields: !hasDescSorting && optimalSortIndexCompareString === index.join(','),
+            sortSatisfiedByIndex: !hasDescSorting && optimalSortIndexCompareString === index.filter(f => !sortIrrelevevantFields.has(f)).join(','),
             selectorSatisfiedByIndex: isSelectorSatisfiedByIndex(index, query.selector)
         };
         const quality = rateQueryPlan(
@@ -125,8 +148,7 @@ export function getQueryPlan<RxDocType>(
         );
         if (
             (
-                quality > 0 &&
-                quality > currentBestQuality
+                quality >= currentBestQuality
             ) ||
             query.index
         ) {
@@ -136,18 +158,12 @@ export function getQueryPlan<RxDocType>(
     });
 
     /**
-     * No index found, use the default index
+     * In all cases and index must be found
      */
     if (!currentBestQueryPlan) {
-        currentBestQueryPlan = {
-            index: [primaryPath],
-            startKeys: [INDEX_MIN],
-            endKeys: [INDEX_MAX],
-            inclusiveEnd: true,
-            inclusiveStart: true,
-            sortFieldsSameAsIndexFields: !hasDescSorting && optimalSortIndexCompareString === primaryPath,
-            selectorSatisfiedByIndex: isSelectorSatisfiedByIndex([primaryPath], query.selector)
-        };
+        throw newRxError('SNH', {
+            query
+        });
     }
 
     return currentBestQueryPlan;
@@ -156,6 +172,7 @@ export function getQueryPlan<RxDocType>(
 export const LOGICAL_OPERATORS = new Set(['$eq', '$gt', '$gte', '$lt', '$lte']);
 export const LOWER_BOUND_LOGICAL_OPERATORS = new Set(['$eq', '$gt', '$gte']);
 export const UPPER_BOUND_LOGICAL_OPERATORS = new Set(['$eq', '$lt', '$lte']);
+
 
 export function isSelectorSatisfiedByIndex(
     index: string[],
@@ -296,7 +313,7 @@ export function rateQueryPlan<RxDocType>(
     });
     addQuality(equalKeyCount * pointsPerMatchingKey * 1.5);
 
-    const pointsIfNoReSortMustBeDone = queryPlan.sortFieldsSameAsIndexFields ? 5 : 0;
+    const pointsIfNoReSortMustBeDone = queryPlan.sortSatisfiedByIndex ? 5 : 0;
     addQuality(pointsIfNoReSortMustBeDone);
 
     // console.log('rateQueryPlan() result:');

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -42,9 +42,6 @@ export function getQueryPlan<RxDocType>(
         indexes = [query.index];
     }
 
-    console.log('.-....................');
-    console.dir({schema, query});
-
     /**
      * Most storages do not support descending indexes
      * so having a 'desc' in the sorting, means we always have to re-sort the results.

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -313,16 +313,5 @@ export function rateQueryPlan<RxDocType>(
     const pointsIfNoReSortMustBeDone = queryPlan.sortSatisfiedByIndex ? 5 : 0;
     addQuality(pointsIfNoReSortMustBeDone);
 
-    // console.log('rateQueryPlan() result:');
-    // console.log({
-    //     query,
-    //     queryPlan,
-    //     nonMinKeyCount,
-    //     nonMaxKeyCount,
-    //     equalKeyCount,
-    //     pointsIfNoReSortMustBeDone,
-    //     quality
-    // });
-
     return quality;
 }

--- a/src/replication-protocol/index.ts
+++ b/src/replication-protocol/index.ts
@@ -24,7 +24,6 @@ import type {
     RxDocumentData,
     RxReplicationHandler,
     RxReplicationWriteToMasterRow,
-    RxStorage,
     RxStorageInstance,
     RxStorageInstanceReplicationInput,
     RxStorageInstanceReplicationState,
@@ -166,7 +165,6 @@ export async function awaitRxStorageReplicationIdle(
 
 
 export function rxStorageInstanceToReplicationHandler<RxDocType, MasterCheckpointType>(
-    storage: RxStorage<any, any>,
     instance: RxStorageInstance<RxDocType, any, any, MasterCheckpointType>,
     conflictHandler: RxConflictHandler<RxDocType>,
     databaseInstanceToken: string,
@@ -216,7 +214,6 @@ export function rxStorageInstanceToReplicationHandler<RxDocType, MasterCheckpoin
         ) {
             return getChangedDocumentsSince(
                 primaryPath,
-                storage,
                 instance,
                 batchSize,
                 checkpoint

--- a/src/replication-protocol/index.ts
+++ b/src/replication-protocol/index.ts
@@ -213,7 +213,6 @@ export function rxStorageInstanceToReplicationHandler<RxDocType, MasterCheckpoin
             batchSize
         ) {
             return getChangedDocumentsSince(
-                primaryPath,
                 instance,
                 batchSize,
                 checkpoint

--- a/src/replication-protocol/upstream.ts
+++ b/src/replication-protocol/upstream.ts
@@ -137,7 +137,6 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
             }
 
             const upResult = await getChangedDocumentsSince(
-                state.primaryPath,
                 state.input.forkInstance,
                 state.input.pushBatchSize,
                 lastCheckpoint

--- a/src/replication-protocol/upstream.ts
+++ b/src/replication-protocol/upstream.ts
@@ -1,5 +1,5 @@
 import { firstValueFrom, filter } from 'rxjs';
-import { stackCheckpoints } from '../rx-storage-helper.ts';
+import { getChangedDocumentsSince, stackCheckpoints } from '../rx-storage-helper.ts';
 import type {
     BulkWriteRow,
     BulkWriteRowById,
@@ -136,7 +136,10 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
                 await Promise.race(Array.from(promises));
             }
 
-            const upResult = await state.input.forkInstance.getChangedDocumentsSince(
+            const upResult = await getChangedDocumentsSince(
+                state.primaryPath,
+                {},
+                state.input.forkInstance,
                 state.input.pushBatchSize,
                 lastCheckpoint
             );

--- a/src/replication-protocol/upstream.ts
+++ b/src/replication-protocol/upstream.ts
@@ -138,7 +138,6 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
 
             const upResult = await getChangedDocumentsSince(
                 state.primaryPath,
-                {},
                 state.input.forkInstance,
                 state.input.pushBatchSize,
                 lastCheckpoint

--- a/src/rx-database-internal-store.ts
+++ b/src/rx-database-internal-store.ts
@@ -122,7 +122,8 @@ export async function getAllCollectionDocuments(
         storageInstance.schema,
         {
             selector: {
-                context: INTERNAL_CONTEXT_COLLECTION
+                context: INTERNAL_CONTEXT_COLLECTION,
+                _deleted: false
             },
             sort: [{ id: 'asc' }],
             skip: 0

--- a/src/rx-database-internal-store.ts
+++ b/src/rx-database-internal-store.ts
@@ -117,12 +117,14 @@ export function getPrimaryKeyOfInternalDocument(
 export async function getAllCollectionDocuments(
     storageInstance: RxStorageInstance<InternalStoreDocType<any>, any, any>
 ): Promise<RxDocumentData<InternalStoreCollectionDocType>[]> {
-    const getAllQueryPrepared = prepareQuery(
+    const getAllQueryPrepared = prepareQuery<InternalStoreDocType<any>>(
         storageInstance.schema,
         {
             selector: {
                 context: INTERNAL_CONTEXT_COLLECTION,
-                _deleted: false
+                _deleted: {
+                    $eq: false
+                }
             },
             sort: [{ id: 'asc' }],
             skip: 0

--- a/src/rx-document-prototype-merge.ts
+++ b/src/rx-document-prototype-merge.ts
@@ -43,7 +43,7 @@ export function getDocumentPrototype(
 
 
             /**
-             * When enumerable is true, it will show on console.dir(instance)
+             * When enumerable is true, it will show on console dir(instance)
              * To not pollute the output, only getters and methods are enumerable
              */
             let enumerable = true;

--- a/src/rx-query-helper.ts
+++ b/src/rx-query-helper.ts
@@ -220,10 +220,6 @@ export function getQueryMatcher<RxDocType>(
 
     const mingoQuery = getMingoQuery(query.selector as any);
     const fun: QueryMatcher<RxDocumentData<RxDocType>> = (doc: RxDocumentData<RxDocType>) => {
-        if (doc._deleted) {
-            return false;
-        }
-
         return mingoQuery.test(doc);
     };
     return fun;

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -358,11 +358,15 @@ export class RxQueryBase<
                 this.mangoQuery
             )
         };
+        (hookInput.mangoQuery.selector as any)._deleted = { $eq: false };
+        if (hookInput.mangoQuery.index) {
+            hookInput.mangoQuery.index.unshift('_deleted');
+        }
         runPluginHooks('prePrepareQuery', hookInput);
 
         const value = this.collection.database.storage.statics.prepareQuery(
             this.collection.schema.jsonSchema,
-            hookInput.mangoQuery
+            hookInput.mangoQuery as any
         );
 
         this.getPreparedQuery = () => value;

--- a/src/rx-schema-helper.ts
+++ b/src/rx-schema-helper.ts
@@ -251,7 +251,6 @@ export function fillWithDefaultSettings<T = any>(
     });
 
     if (useIndexes.length === 0) {
-        console.log('HAS NONE');
         useIndexes.push(getDefaultIndex(primaryPath));
     }
 

--- a/src/rx-schema-helper.ts
+++ b/src/rx-schema-helper.ts
@@ -157,6 +157,15 @@ export function normalizeRxJsonSchema<T>(jsonSchema: RxJsonSchema<T>): RxJsonSch
 }
 
 /**
+ * If the schema does not specify any index,
+ * we add this index so we at least can run RxQuery()
+ * and only select non-deleted fields.
+ */
+export function getDefaultIndex(primaryPath: string) {
+    return ['_deleted', primaryPath];
+}
+
+/**
  * fills the schema-json with default-settings
  * @return cloned schemaObj
  */
@@ -222,26 +231,46 @@ export function fillWithDefaultSettings<T = any>(
     // version is 0 by default
     schemaObj.version = schemaObj.version || 0;
 
-    if (schemaObj.indexes) {
-        schemaObj.indexes = schemaObj.indexes.map(index => {
-            const arIndex = isMaybeReadonlyArray(index) ? index.slice(0) : [index];
-            /**
-             * Append primary key to indexes that do not contain the primaryKey.
-             * All indexes must have the primaryKey to ensure a deterministic sort order.
-             */
-            if (!arIndex.includes(primaryPath)) {
-                arIndex.push(primaryPath);
-            }
+    const useIndexes: string[][] = schemaObj.indexes.map(index => {
+        const arIndex = isMaybeReadonlyArray(index) ? index.slice(0) : [index];
+        /**
+         * Append primary key to indexes that do not contain the primaryKey.
+         * All indexes must have the primaryKey to ensure a deterministic sort order.
+         */
+        if (!arIndex.includes(primaryPath)) {
+            arIndex.push(primaryPath);
+        }
 
-            // add _deleted flag to all indexes so we can query only non-deleted fields
-            // in RxDB itself
-            if (arIndex[0] !== '_deleted') {
-                arIndex.unshift('_deleted');
-            }
+        // add _deleted flag to all indexes so we can query only non-deleted fields
+        // in RxDB itself
+        if (arIndex[0] !== '_deleted') {
+            arIndex.unshift('_deleted');
+        }
 
-            return arIndex;
-        });
+        return arIndex;
+    });
+
+    if (useIndexes.length === 0) {
+        console.log('HAS NONE');
+        useIndexes.push(getDefaultIndex(primaryPath));
     }
+
+    // we need this index for the getChangedDocumentsSince() method
+    useIndexes.push(['_meta.lwt', primaryPath]);
+
+    // make indexes unique
+    const hasIndex = new Set<string>();
+    useIndexes.filter(index => {
+        const indexStr = index.join(',');
+        if (hasIndex.has(indexStr)) {
+            return false;
+        } else {
+            hasIndex.add(indexStr);
+            return true;
+        }
+    });
+
+    schemaObj.indexes = useIndexes;
 
     return schemaObj as any;
 }

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -881,10 +881,6 @@ export async function getChangedDocumentsSince<RxDocType, CheckpointType>(
         return storageInstance.getChangedDocumentsSince(limit, checkpoint);
     }
 
-
-    console.log('getChangedDocumentsSince:()');
-    console.dir(checkpoint);
-
     const primaryPath = getPrimaryFieldOfPrimaryKey(storageInstance.schema.primaryKey);
     const sinceLwt = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).lwt : RX_META_LWT_MINIMUM;
     const sinceId = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).id : '';

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -770,7 +770,7 @@ export function getWrappedStorageInstance<
         },
         getChangedDocumentsSince: !storageInstance.getChangedDocumentsSince ? undefined : (limit: number, checkpoint?: any) => {
             return database.lockedRun(
-                () => ensureNotFalsy(storageInstance.getChangedDocumentsSince)(ensureNotFalsy(limit), checkpoint)
+                () => ((storageInstance as any).getChangedDocumentsSince)(ensureNotFalsy(limit), checkpoint)
             );
         },
         cleanup(minDeletedTime: number) {
@@ -865,7 +865,6 @@ export function hasEncryption(jsonSchema: RxJsonSchema<any>): boolean {
 
 
 export async function getChangedDocumentsSince<RxDocType, CheckpointType>(
-    primaryPath: string,
     storageInstance: RxStorageInstance<RxDocType, any, any, CheckpointType>,
     limit: number,
     checkpoint?: CheckpointType
@@ -882,6 +881,11 @@ export async function getChangedDocumentsSince<RxDocType, CheckpointType>(
         return storageInstance.getChangedDocumentsSince(limit, checkpoint);
     }
 
+
+    console.log('getChangedDocumentsSince:()');
+    console.dir(checkpoint);
+
+    const primaryPath = getPrimaryFieldOfPrimaryKey(storageInstance.schema.primaryKey);
     const sinceLwt = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).lwt : RX_META_LWT_MINIMUM;
     const sinceId = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).id : '';
     const query = prepareQuery<RxDocumentData<any>>(

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -749,11 +749,6 @@ export function getWrappedStorageInstance<
                 () => storageInstance.count(preparedQuery)
             );
         },
-        info() {
-            return database.lockedRun(
-                () => storageInstance.info()
-            );
-        },
         findDocumentsById(ids, deleted) {
             return database.lockedRun(
                 () => storageInstance.findDocumentsById(ids, deleted)
@@ -988,13 +983,6 @@ export function randomDelayStorage<Internals, InstanceCreationOptions>(
                 async count(a) {
                     await promiseWait(input.delayTimeBefore());
                     const ret = await storageInstance.count(a);
-                    await promiseWait(input.delayTimeAfter());
-                    return ret;
-
-                },
-                async info() {
-                    await promiseWait(input.delayTimeBefore());
-                    const ret = await storageInstance.info();
                     await promiseWait(input.delayTimeAfter());
                     return ret;
 

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -46,6 +46,7 @@ import {
     randomCouchString
 } from './plugins/utils/index.ts';
 import { Observable, filter, map, startWith, switchMap } from 'rxjs';
+import { prepareQuery } from './rx-query.ts';
 
 export const INTERNAL_STORAGE_NAME = '_rxdb_internal';
 export const RX_DATABASE_LOCAL_DOCS_STORAGE_NAME = 'rxdatabase_storage_local';
@@ -865,7 +866,6 @@ export function hasEncryption(jsonSchema: RxJsonSchema<any>): boolean {
 
 export async function getChangedDocumentsSince<RxDocType, CheckpointType>(
     primaryPath: string,
-    storage: RxStorage<any, any>,
     storageInstance: RxStorageInstance<RxDocType, any, any, CheckpointType>,
     limit: number,
     checkpoint?: CheckpointType
@@ -884,7 +884,7 @@ export async function getChangedDocumentsSince<RxDocType, CheckpointType>(
 
     const sinceLwt = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).lwt : RX_META_LWT_MINIMUM;
     const sinceId = checkpoint ? (checkpoint as unknown as RxStorageDefaultCheckpoint).id : '';
-    const query = storage.statics.prepareQuery<RxDocumentData<any>>(
+    const query = prepareQuery<RxDocumentData<any>>(
         storageInstance.schema,
         {
             selector: {

--- a/src/types/query-planner.d.ts
+++ b/src/types/query-planner.d.ts
@@ -19,9 +19,10 @@ export type RxQueryPlan = {
     index: string[];
     /**
      * If the index does not match the sort params,
-     * we have to resort the query results.
+     * we have to resort the query results manually
+     * after fetching them from the index.
      */
-    sortFieldsSameAsIndexFields: boolean;
+    sortSatisfiedByIndex: boolean;
 
     /**
      * If the whole selector matching is satisfied

--- a/src/types/rx-storage.d.ts
+++ b/src/types/rx-storage.d.ts
@@ -188,16 +188,6 @@ export type RxStorageCountResult = {
     mode: 'fast' | 'slow';
 };
 
-export type RxStorageInfoResult = {
-    /**
-     * Contains the total amount of stored documents.
-     * This contains the _deleted and non-_deleted documents.
-     * This is used by RxDB to give the option to show
-     * loading percentage in replication and migration.
-     */
-    totalCount: number;
-};
-
 export type RxStorageInstanceCreationParams<RxDocType, InstanceCreationOptions> = {
 
     /**

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -186,7 +186,7 @@ export interface RxStorageInstance<
      * storageInstance by checking the givent context-string. But this would make it impossible
      * to run a replication on the parentStorage itself.
      */
-    readonly underlyingPersistentStorage?: RxStorageInstance<RxDocType, any ,any, any>;
+    readonly underlyingPersistentStorage?: RxStorageInstance<RxDocType, any, any, any>;
 
     /**
      * Writes multiple documents to the storage instance.
@@ -287,8 +287,13 @@ export interface RxStorageInstance<
      * Must never return the same document multiple times in the same call operation.
      * This is used by RxDB to known what has changed since X so these docs can be handled by the backup or the replication
      * plugin.
+     *
+     * Important: This method is optional. If not defined,
+     * RxDB will manually run a query and use the last returned document
+     * for checkpointing. In  the future we might even remove this method completely
+     * and let RxDB do the work instead of the RxStorage.
      */
-    getChangedDocumentsSince(
+    getChangedDocumentsSince?(
         limit: number,
         /**
          * The checkpoint from with to start

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -133,7 +133,7 @@ export type RxStorageStatics = Readonly<{
         /**
          * a query that can be mutated by the function without side effects.
          */
-        mutateableQuery: FilledMangoQuery<RxDocType>
+        mutateableQuery: FilledMangoQuery<RxDocumentData<RxDocType>>
     ): PreparedQuery<RxDocType>;
 
     /**

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -5,7 +5,6 @@ import type {
     RxStorageBulkWriteResponse,
     RxStorageChangeEvent,
     RxStorageCountResult,
-    RxStorageInfoResult,
     RxStorageInstanceCreationParams,
     RxStorageQueryResult
 } from './rx-storage.ts';
@@ -239,16 +238,6 @@ export interface RxStorageInstance<
     count(
         preparedQuery: PreparedQuery<RxDocType>
     ): Promise<RxStorageCountResult>;
-
-
-
-    /**
-     * Returns some info about the storage.
-     * Used in various places. This method is expected to
-     * not really care about performance, so do not
-     * use it in hot paths.
-     */
-    info(): Promise<RxStorageInfoResult>;
 
     /**
      * Returns the plain data of a single attachment.

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -72,12 +72,12 @@ export interface RxStorage<Internals, InstanceCreationOptions> {
  * so we do not have to do many if-field-exist tests in the internals.
  */
 export type FilledMangoQuery<RxDocType> = Override<
-    MangoQuery<RxDocType>,
+    MangoQuery<RxDocumentData<RxDocType>>,
     {
         /**
          * The selector is required here.
          */
-        selector: MangoQuerySelector<RxDocType>;
+        selector: MangoQuerySelector<RxDocumentData<RxDocType>>;
 
         /**
          * In contrast to the user-provided MangoQuery,
@@ -85,7 +85,7 @@ export type FilledMangoQuery<RxDocType> = Override<
          * RxDB has to ensure that the primary key is always
          * part of the sort params.
          */
-        sort: MangoQuerySortPart<RxDocType>[];
+        sort: MangoQuerySortPart<RxDocumentData<RxDocType>>[];
 
         /**
          * In the normalized mango query,

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -21,7 +21,6 @@ import './unit/rx-storage-implementations.test.ts';
 import './unit/rx-storage-query-correctness.test.ts';
 import './unit/rx-storage-helper.test.ts';
 
-import './unit/migration-storage.test.ts';
 
 import './unit/rx-storage-lokijs.test.ts';
 import './unit/rx-storage-dexie.test.ts';
@@ -60,6 +59,7 @@ import './unit/replication-webrtc.test.ts';
 import './unit/migration-schema.test.ts';
 import './unit/attachments.test.ts';
 import './unit/attachments-compression.test.ts';
+import './unit/migration-storage.test.ts';
 import './unit/crdt.test.ts';
 import './unit/population.test.ts';
 import './unit/leader-election.test.ts';

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -21,6 +21,7 @@ import './unit/rx-storage-implementations.test.ts';
 import './unit/rx-storage-query-correctness.test.ts';
 import './unit/rx-storage-helper.test.ts';
 
+import './unit/migration-storage.test.ts';
 
 import './unit/rx-storage-lokijs.test.ts';
 import './unit/rx-storage-dexie.test.ts';
@@ -59,7 +60,6 @@ import './unit/replication-webrtc.test.ts';
 import './unit/migration-schema.test.ts';
 import './unit/attachments.test.ts';
 import './unit/attachments-compression.test.ts';
-import './unit/migration-storage.test.ts';
 import './unit/crdt.test.ts';
 import './unit/population.test.ts';
 import './unit/leader-election.test.ts';

--- a/test/unit/migration-storage.test.ts
+++ b/test/unit/migration-storage.test.ts
@@ -376,6 +376,7 @@ testStorages.forEach(storages => {
                 // check new database
                 const newDocs = await col.find().exec();
                 assert.strictEqual(newDocs.length, docsAmount);
+
                 assert.strictEqual(handlerEmitted.length, batchesAmount);
                 const firstDoc = newDocs[0];
                 const newDocPlain = firstDoc.toJSON(true);

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -354,7 +354,6 @@ config.parallel('query-planner.test.js', () => {
             assert.deepStrictEqual(queryPlan.index, ['_deleted', 'firstName', 'age', 'passportId']);
         });
         it('should have set sortSatisfiedByIndex=false when order is desc', () => {
-            console.log(',,,,,,,,,,,,,,,,,,,,,,,,');
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
@@ -375,9 +374,6 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-
-            console.dir(queryPlan);
-
             assert.strictEqual(queryPlan.sortSatisfiedByIndex, false);
         });
     });

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -56,7 +56,7 @@ config.parallel('query-planner.test.js', () => {
                     ['age', 'firstName'],
                     ['lastName', 'firstName']
                 ]);
-                const query = normalizeMangoQuery<HumanDocumentType>(
+                const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                     schema,
                     {
                         selector: {
@@ -65,13 +65,16 @@ config.parallel('query-planner.test.js', () => {
                             },
                             firstName: {
                                 $gt: ''
-                            }
+                            },
+                            _deleted: false
                         }
                     }
                 );
+
                 assert.deepStrictEqual(
                     query.sort,
                     [
+                        { _deleted: 'asc' },
                         { age: 'asc' },
                         { firstName: 'asc' },
                         { passportId: 'asc' }
@@ -91,7 +94,7 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
         });
         it('should respect the given index', () => {
             const customSetIndex = ['firstName'];
@@ -110,13 +113,14 @@ config.parallel('query-planner.test.js', () => {
         });
         it('should have the correct start- and end keys', () => {
             const schema = getHumanSchemaWithIndexes([['age']]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
                     selector: {
                         age: {
                             $gte: 20
-                        }
+                        },
+                        _deleted: false
                     }
                 }
             );
@@ -124,9 +128,10 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['age', 'passportId']);
-            assert.strictEqual(queryPlan.startKeys[0], 20);
-            assert.strictEqual(queryPlan.endKeys[0], INDEX_MAX);
+
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'age', 'passportId']);
+            assert.strictEqual(queryPlan.startKeys[1], 20);
+            assert.strictEqual(queryPlan.endKeys[1], INDEX_MAX);
             assert.ok(queryPlan.inclusiveStart);
         });
         it('should have the correct start- and end keys when inclusiveStart and inclusiveEnd are false', () => {
@@ -163,7 +168,8 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 {
                     selector: {
-                        passportId: 'asdf'
+                        passportId: 'asdf',
+                        _deleted: false
                     }
                 }
             );
@@ -171,22 +177,23 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['passportId']);
-            assert.deepStrictEqual(queryPlan.startKeys[0], 'asdf');
-            assert.deepStrictEqual(queryPlan.endKeys[0], 'asdf');
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
+            assert.deepStrictEqual(queryPlan.startKeys[1], 'asdf');
+            assert.deepStrictEqual(queryPlan.endKeys[1], 'asdf');
         });
     });
     describe('.isSelectorSatisfiedByIndex()', () => {
         const schema = getHumanSchemaWithIndexes([['age']]);
         it('should be true if satisfied', () => {
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
                     selector: {
                         age: {
                             $gt: 10,
                             $lt: 100
-                        }
+                        },
+                        _deleted: false
                     }
                 }
             );
@@ -255,20 +262,21 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
         });
         it('should prefer the index that reduces the read-count by having a non-minimal startKey', () => {
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
             ]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
                     selector: {
                         age: {
                             $eq: 10
-                        }
+                        },
+                        _deleted: false
                     }
                 }
             );
@@ -276,16 +284,19 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['age', 'firstName', 'passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'age', 'firstName', 'passportId']);
         });
         it('should prefer the index that matches the sort order, if no selector given', () => {
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
             ]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
+                    selector: {
+                        _deleted: false
+                    },
                     sort: [
                         { age: 'asc' },
                         { firstName: 'asc' }
@@ -296,14 +307,16 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['age', 'firstName', 'passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'age', 'firstName', 'passportId']);
+            assert.ok(queryPlan.selectorSatisfiedByIndex);
+            assert.ok(queryPlan.sortSatisfiedByIndex);
         });
         it('should prefer the index that matches the sort order, if selector for both fields is used', () => {
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
             ]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
                     selector: {
@@ -312,7 +325,8 @@ config.parallel('query-planner.test.js', () => {
                         },
                         firstName: {
                             $gt: 'aaa'
-                        }
+                        },
+                        _deleted: false
                     },
                     sort: [
                         { age: 'asc' },
@@ -320,18 +334,21 @@ config.parallel('query-planner.test.js', () => {
                     ]
                 }
             );
+            console.dir(query);
             const queryPlan = getQueryPlan(
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['age', 'firstName', 'passportId']);
+            console.dir(queryPlan);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'age', 'firstName', 'passportId']);
+            assert.ok(queryPlan.sortSatisfiedByIndex);
         });
         it('should prefer indexing over the $eq operator over the $gt operator', () => {
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
             ]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
                     selector: {
@@ -340,7 +357,8 @@ config.parallel('query-planner.test.js', () => {
                         },
                         firstName: {
                             $eq: 'aaa'
-                        }
+                        },
+                        _deleted: false
                     },
                     sort: [
                         { age: 'asc' },
@@ -352,17 +370,19 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['firstName', 'age', 'passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'firstName', 'age', 'passportId']);
         });
-        it('should have set sortFieldsSameAsIndexFields: false when order is desc', () => {
+        it('should have set sortSatisfiedByIndex=false when order is desc', () => {
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
             ]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
                 schema,
                 {
-                    selector: {},
+                    selector: {
+                        _deleted: false
+                    },
                     sort: [
                         { age: 'desc' },
                         { firstName: 'asc' }
@@ -374,12 +394,14 @@ config.parallel('query-planner.test.js', () => {
                 query
             );
 
+            console.dir(queryPlan);
+
             /**
              * Because on a 'desc'-sorting no index can be used,
              * it should use the default index.
              */
-            assert.deepStrictEqual(queryPlan.index, ['passportId']);
-            assert.strictEqual(queryPlan.sortFieldsSameAsIndexFields, false);
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
+            assert.strictEqual(queryPlan.sortSatisfiedByIndex, false);
         });
     });
 });

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -13,8 +13,7 @@ import {
     normalizeMangoQuery,
     INDEX_MAX,
     lastOfArray,
-    INDEX_MIN,
-    getDefaultIndex
+    INDEX_MIN
 } from '../../plugins/core/index.mjs';
 
 

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -13,7 +13,8 @@ import {
     normalizeMangoQuery,
     INDEX_MAX,
     lastOfArray,
-    INDEX_MIN
+    INDEX_MIN,
+    getDefaultIndex
 } from '../../plugins/core/index.mjs';
 
 
@@ -94,7 +95,7 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_meta.lwt', 'passportId']);
         });
         it('should respect the given index', () => {
             const customSetIndex = ['firstName'];
@@ -161,25 +162,6 @@ config.parallel('query-planner.test.js', () => {
 
             assert.strictEqual(lastOfArray(queryPlan.startKeys), INDEX_MAX);
             assert.strictEqual(lastOfArray(queryPlan.endKeys), INDEX_MIN);
-        });
-        it('should use the best plan for an equals comparison', () => {
-            const schema = getHumanSchemaWithIndexes([]);
-            const query = normalizeMangoQuery<HumanDocumentType>(
-                schema,
-                {
-                    selector: {
-                        passportId: 'asdf',
-                        _deleted: false
-                    }
-                }
-            );
-            const queryPlan = getQueryPlan(
-                schema,
-                query
-            );
-            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
-            assert.deepStrictEqual(queryPlan.startKeys[1], 'asdf');
-            assert.deepStrictEqual(queryPlan.endKeys[1], 'asdf');
         });
     });
     describe('.isSelectorSatisfiedByIndex()', () => {
@@ -262,7 +244,7 @@ config.parallel('query-planner.test.js', () => {
                 schema,
                 query
             );
-            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
+            assert.deepStrictEqual(queryPlan.index, ['_meta.lwt', 'passportId']);
         });
         it('should prefer the index that reduces the read-count by having a non-minimal startKey', () => {
             const schema = getHumanSchemaWithIndexes([
@@ -373,6 +355,7 @@ config.parallel('query-planner.test.js', () => {
             assert.deepStrictEqual(queryPlan.index, ['_deleted', 'firstName', 'age', 'passportId']);
         });
         it('should have set sortSatisfiedByIndex=false when order is desc', () => {
+            console.log(',,,,,,,,,,,,,,,,,,,,,,,,');
             const schema = getHumanSchemaWithIndexes([
                 ['firstName', 'age'],
                 ['age', 'firstName']
@@ -396,11 +379,6 @@ config.parallel('query-planner.test.js', () => {
 
             console.dir(queryPlan);
 
-            /**
-             * Because on a 'desc'-sorting no index can be used,
-             * it should use the default index.
-             */
-            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'passportId']);
             assert.strictEqual(queryPlan.sortSatisfiedByIndex, false);
         });
     });

--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -33,7 +33,8 @@ import {
     now,
     getFromMapOrThrow,
     RxCollectionCreator,
-    parseRevision
+    parseRevision,
+    getChangedDocumentsSince
 } from '../../plugins/core/index.mjs';
 
 import { RxDBUpdatePlugin } from '../../plugins/update/index.mjs';
@@ -1085,7 +1086,7 @@ describe('rx-collection.test.ts', () => {
                     /**
                      * Getting the changes in the other database should have an empty result.
                      */
-                    const changesResult = await db2['human-2'].storageInstance.getChangedDocumentsSince(10);
+                    const changesResult = await getChangedDocumentsSince(db2['human-2'].storageInstance, 10);
                     assert.strictEqual(changesResult.documents.length, 0);
 
                     db2.destroy();

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -25,7 +25,8 @@ import {
     fillWithDefaultSettings,
     fillObjectWithDefaults,
     defaultHashSha256,
-    lastOfArray
+    lastOfArray,
+    ensureNotFalsy
 } from '../../plugins/core/index.mjs';
 
 config.parallel('rx-schema.test.ts', () => {
@@ -573,7 +574,7 @@ config.parallel('rx-schema.test.ts', () => {
 
                 console.dir(normalizedSchema);
 
-                normalizedSchema.indexes.forEach(index => {
+                ensureNotFalsy(normalizedSchema.indexes).forEach(index => {
                     assert.ok(index.includes('id'));
                 });
             });
@@ -1001,7 +1002,8 @@ config.parallel('rx-schema.test.ts', () => {
             assert.deepStrictEqual(
                 [
                     ['_deleted', 'properties.name', 'id'],
-                    ['_deleted', 'properties.properties', 'id']
+                    ['_deleted', 'properties.properties', 'id'],
+                    ['_meta.lwt', 'id']
                 ],
                 collections.test.schema.indexes
             );

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -25,7 +25,6 @@ import {
     fillWithDefaultSettings,
     fillObjectWithDefaults,
     defaultHashSha256,
-    lastOfArray,
     ensureNotFalsy
 } from '../../plugins/core/index.mjs';
 

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -570,9 +570,6 @@ config.parallel('rx-schema.test.ts', () => {
                     ]
                 });
                 const normalizedSchema = normalizeRxJsonSchema(schema);
-
-                console.dir(normalizedSchema);
-
                 ensureNotFalsy(normalizedSchema.indexes).forEach(index => {
                     assert.ok(index.includes('id'));
                 });

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -24,7 +24,8 @@ import {
     getSchemaByObjectPath,
     fillWithDefaultSettings,
     fillObjectWithDefaults,
-    defaultHashSha256
+    defaultHashSha256,
+    lastOfArray
 } from '../../plugins/core/index.mjs';
 
 config.parallel('rx-schema.test.ts', () => {
@@ -346,7 +347,7 @@ config.parallel('rx-schema.test.ts', () => {
                         }
                     }));
                 });
-                it('should not allow ending lodash _ in fieldnames (reserved for populate)', async() => {
+                it('should not allow ending lodash _ in fieldnames (reserved for populate)', async () => {
                     await assertThrows(() => checkSchema({
                         title: 'schema',
                         version: 0,
@@ -569,14 +570,12 @@ config.parallel('rx-schema.test.ts', () => {
                     ]
                 });
                 const normalizedSchema = normalizeRxJsonSchema(schema);
-                assert.deepStrictEqual(
-                    normalizedSchema.indexes,
-                    [
-                        ['age', 'id'],
-                        ['foo', 'bar', 'id'],
-                        ['bar', 'id', 'foo']
-                    ]
-                );
+
+                console.dir(normalizedSchema);
+
+                normalizedSchema.indexes.forEach(index => {
+                    assert.ok(index.includes('id'));
+                });
             });
         });
         describe('.create()', () => {
@@ -595,7 +594,8 @@ config.parallel('rx-schema.test.ts', () => {
                 });
                 it('should have indexes human', () => {
                     const schema = createRxSchema(schemas.human, defaultHashSha256);
-                    assert.strictEqual(schema.indexes[0][0], 'firstName');
+                    assert.strictEqual(schema.indexes[0][0], '_deleted');
+                    assert.strictEqual(schema.indexes[0][1], 'firstName');
                 });
             });
             describe('negative', () => {
@@ -1000,8 +1000,8 @@ config.parallel('rx-schema.test.ts', () => {
 
             assert.deepStrictEqual(
                 [
-                    ['properties.name', 'id'],
-                    ['properties.properties', 'id']
+                    ['_deleted', 'properties.name', 'id'],
+                    ['_deleted', 'properties.properties', 'id']
                 ],
                 collections.test.schema.indexes
             );

--- a/test/unit/rx-storage-dexie.test.ts
+++ b/test/unit/rx-storage-dexie.test.ts
@@ -52,7 +52,7 @@ config.parallel('rx-storage-dexie.test.js', () => {
         describe('.fromStorageToDexie()', () => {
             it('should convert unsupported IndexedDB key', () => {
                 const result = fromStorageToDexie<any>(
-                    [],
+                    ['_deleted'],
                     {
                         '|key': 'value',
                         '|objectArray': [{ ['|id']: '1' }],
@@ -82,7 +82,7 @@ config.parallel('rx-storage-dexie.test.js', () => {
         });
         describe('.fromDexieToStorage()', () => {
             it('should revert escaped unsupported IndexedDB key', () => {
-                const result = fromDexieToStorage([], {
+                const result = fromDexieToStorage(['_deleted'], {
                     '__key': 'value',
                     '__objectArray': [{ ['__id']: '1' }],
                     '__nestedObject': {
@@ -166,6 +166,8 @@ config.parallel('rx-storage-dexie.test.js', () => {
                     schema,
                     normalizeMangoQuery(schema, query)
                 );
+
+                console.dir(preparedQuery);
                 const queryPlan = preparedQuery.queryPlan;
                 const result = await storageInstance.query(preparedQuery);
                 return {
@@ -188,13 +190,13 @@ config.parallel('rx-storage-dexie.test.js', () => {
                 sort: [
                     { passportId: 'asc' }
                 ],
-                index: ['passportId', 'age']
+                index: ['_deleted', 'passportId', 'age']
             });
 
             // default should use default index
             assert.deepStrictEqual(
                 defaultAnalyzed.queryPlan.index,
-                ['passportId']
+                ['_meta.lwt', 'passportId']
             );
 
             // custom should use the custom index

--- a/test/unit/rx-storage-implementations.test.ts
+++ b/test/unit/rx-storage-implementations.test.ts
@@ -1554,7 +1554,7 @@ config.parallel('rx-storage-implementations.test.ts (implementation: ' + config.
                     testContext
                 );
 
-                const preparedQuery = config.storage.getStorage().statics.prepareQuery(
+                const preparedQuery = prepareQuery(
                     storageInstance.schema,
                     {
                         selector: {},

--- a/test/unit/rx-storage-implementations.test.ts
+++ b/test/unit/rx-storage-implementations.test.ts
@@ -1881,59 +1881,6 @@ config.parallel('rx-storage-implementations.test.ts (implementation: ' + config.
                 storageInstance.close();
             });
         });
-        describe('.info()', () => {
-            it('should have the correct total count', async () => {
-                const schema = getTestDataSchema();
-                const storageInstance = await config.storage
-                    .getStorage()
-                    .createStorageInstance<TestDocType>({
-                        databaseInstanceToken: randomCouchString(10),
-                        databaseName: randomCouchString(12),
-                        collectionName: randomCouchString(12),
-                        schema,
-                        options: {},
-                        multiInstance: false,
-                        devMode: true
-                    });
-                async function ensureCountIs(nr: number) {
-                    const result = await storageInstance.info();
-                    assert.strictEqual(result.totalCount, nr);
-                }
-
-                await ensureCountIs(0);
-                await storageInstance.bulkWrite([{ document: getWriteData() }], testContext);
-                await ensureCountIs(1);
-
-                const writeData = getWriteData();
-                const insertResult = await storageInstance.bulkWrite([{ document: writeData }], testContext);
-                await ensureCountIs(2);
-
-                // DELETE
-                const previous = insertResult.success[0];
-                await storageInstance.bulkWrite(
-                    [{
-                        previous,
-                        document: Object.assign({}, writeData, {
-                            _rev: EXAMPLE_REVISION_2,
-                            _deleted: true,
-                            _meta: {
-                                lwt: now()
-                            }
-                        })
-                    }],
-                    testContext
-                );
-
-                /**
-                 * Must still count 2 because totalCount includes _deleted documents
-                 * as long as they did not have been purged by the .cleanup()
-                 */
-                await ensureCountIs(2);
-
-                storageInstance.close();
-            });
-
-        });
         describe('.findDocumentsById()', () => {
             it('should find the documents', async () => {
                 const storageInstance = await config.storage.getStorage().createStorageInstance<TestDocType>({

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -144,7 +144,11 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
                     assert.deepStrictEqual(resultStaticsIds, queryData.expectedResultDocIds);
                 } catch (err) {
                     console.log('WRONG QUERY RESULTS FROM STATICS: ' + queryData.info);
-                    console.dir(queryData);
+                    console.dir({
+                        queryData,
+                        resultStaticsIds
+                    });
+
                     throw err;
                 }
 
@@ -172,7 +176,10 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
                     assert.deepStrictEqual(resultIds, queryData.expectedResultDocIds);
                 } catch (err) {
                     console.log('WRONG QUERY RESULTS FROM RxStorageInstance.query(): ' + queryData.info);
-                    console.dir(queryData);
+                    console.dir({
+                        resultIds,
+                        queryData
+                    });
                     throw err;
                 }
 
@@ -966,7 +973,7 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
         },
         queries: [
             {
-                info: '$eq primary key',
+                info: '$eq primary key 2',
                 query: {
                     selector: {
                         id: {

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -231,7 +231,8 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
         schema: withIndexes(schemas.human, [
             ['age'],
             ['age', 'firstName'],
-            ['firstName']
+            ['firstName'],
+            ['passportId']
         ]),
         queries: [
             {
@@ -355,7 +356,8 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
         schema: withIndexes(schemas.human, [
             ['age'],
             ['age', 'firstName'],
-            ['firstName']
+            ['firstName'],
+            ['passportId']
         ]),
         queries: [
             {

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -118,7 +118,9 @@ config.parallel('rx-storage-query-correctness.test.ts', () => {
                     continue;
                 }
 
-                const normalizedQuery = deepFreeze(normalizeMangoQuery(schema, queryData.query));
+                const queryForStorage = clone(queryData.query) as any;
+                queryForStorage.selector._deleted = false;
+                const normalizedQuery = deepFreeze(normalizeMangoQuery(schema, queryForStorage));
                 const skip = normalizedQuery.skip ? normalizedQuery.skip : 0;
                 const limit = normalizedQuery.limit ? normalizedQuery.limit : Infinity;
                 const skipPlusLimit = skip + limit;


### PR DESCRIPTION
This is required for the upcoming server plugin.
The RxStorage itself must be queryable for docs with `_deleted:false`