### PR TITLE
Custom fetch to support axios for the graphQL replication

### DIFF
--- a/src/plugins/replication-graphql/helper.ts
+++ b/src/plugins/replication-graphql/helper.ts
@@ -16,6 +16,7 @@ export type GraphQLErrors = Array<GraphQLError>;
 
 
 export function graphQLRequest(
+    fetchRequest: WindowOrWorkerGlobalScope['fetch'],
     httpUrl: string,
     clientState: RxGraphQLReplicationClientState,
     queryParams: RxGraphQLReplicationQueryBuilderResponseObject
@@ -33,7 +34,8 @@ export function graphQLRequest(
             credentials: clientState.credentials,
         }
     );
-    return fetch(req)
+    
+    return fetchRequest(req)
         .then((res) => res.json())
         .then((body) => {
             return body;

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -52,7 +52,8 @@ export class RxGraphQLReplicationState<RxDocType, CheckpointType> extends RxRepl
         public readonly push?: ReplicationPushOptions<RxDocType>,
         public readonly live?: boolean,
         public retryTime?: number,
-        public autoStart?: boolean
+        public autoStart?: boolean,
+        public readonly customFetch?: WindowOrWorkerGlobalScope['fetch']
     ) {
         super(
             replicationIdentifier,
@@ -78,6 +79,7 @@ export class RxGraphQLReplicationState<RxDocType, CheckpointType> extends RxRepl
         queryParams: RxGraphQLReplicationQueryBuilderResponseObject
     ) {
         return graphQLRequest(
+            this.customFetch ?? fetch,
             ensureNotFalsy(this.url.http),
             this.clientState,
             queryParams
@@ -96,6 +98,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
         pull,
         push,
         live = true,
+        fetch: customFetch,
         retryTime = 1000 * 5, // in ms
         autoStart = true,
         replicationIdentifier
@@ -187,7 +190,8 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
         replicationPrimitivesPush,
         live,
         retryTime,
-        autoStart
+        autoStart,
+        customFetch
     );
 
     const mustUseSocket = url.ws &&

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -73,6 +73,7 @@ export type SyncOptionsGraphQL<RxDocType, CheckpointType> = Omit<
     'pull' | 'push'
 > & {
     url: GraphQLServerUrl;
+    fetch?: WindowOrWorkerGlobalScope['fetch'];
     headers?: { [k: string]: string; }; // send with all requests to the endpoint
     credentials?: RequestCredentials;
     pull?: GraphQLSyncPullOptions<RxDocType, CheckpointType>;

--- a/test/helper/graphql-server.ts
+++ b/test/helper/graphql-server.ts
@@ -347,6 +347,7 @@ export async function spawn(
 
 
                         const result = await graphQLRequest(
+                            fetch,
                             httpUrl,
                             clientState,
                             {


### PR DESCRIPTION
## This PR contains:
- A non-breaking new feature to the graphql-replication plugin to make it possible to support a custom fetch that fits the `typeof fetch`
- it always default to `window.fetch` otherwise it will be the responsibility of the lib user to make sure its custom fetch fits the fetch API even for the `then()` and the `catch()`

## Describe the problem you have without this PR
We imported the graphql-replication plugin and customized it to make the helper `graphQLRequest` support `axios` which is a must-to-have lib for our project, since we use it everywhere to auto manages the bearer refresh token (renewal) and makes sure all requests get the updated access token before making a new request with the `axios.interceptors.request.use` and we added custom logic to the `axios.interceptors.response.use` to handle graphql [`extensions.code`](https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes)  that rxdb doesn't handle.

### example with `axios` as a custom fetch
```ts
// options...
fetch: async (request: Request) => axios({
    method: request.method || 'POST',
    url: request.url,
        data: await request.json(),
        // axios.interceptors.request.use can reinject all headers as well as the Authorization Bearer token
        headers: request.headers,
    })
    .then(res => async () => Promise.resolve(res.data))
    .catch(err => {
        throw err.response.data;
    })
// other options...
```
