### PR TITLE
PurgeDocumentsById on internalStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,6 +359,7 @@
     "// test:node:loop": "runs tests in node in a loop. Use this to debug tests that only fail sometimes",
     "test:node:loop": "npm run test:node && npm run test:node:loop",
     "test:node:loop:memory-random-delay": "npm run test:node:memory-random-delay && npm run test:node:loop:memory-random-delay",
+    "test:browser": "npm run test:browser:lokijs && npm run test:browser:dexie && npm run test:browser:memory && npm run test:browser:remote",
     "test:browser:loop": "npm run test:browser && npm run test:browser:loop",
     "test:browser:lokijs": " npm run transpile && cross-env CI=true DEFAULT_STORAGE=lokijs  karma start ./config/karma.conf.cjs --single-run",
     "test:browser:memory": " npm run transpile && cross-env CI=true DEFAULT_STORAGE=memory  karma start ./config/karma.conf.cjs --single-run",

--- a/package.json
+++ b/package.json
@@ -359,7 +359,6 @@
     "// test:node:loop": "runs tests in node in a loop. Use this to debug tests that only fail sometimes",
     "test:node:loop": "npm run test:node && npm run test:node:loop",
     "test:node:loop:memory-random-delay": "npm run test:node:memory-random-delay && npm run test:node:loop:memory-random-delay",
-    "test:browser": "npm run test:browser:lokijs && npm run test:browser:dexie && npm run test:browser:memory && npm run test:browser:remote",
     "test:browser:loop": "npm run test:browser && npm run test:browser:loop",
     "test:browser:lokijs": " npm run transpile && cross-env CI=true DEFAULT_STORAGE=lokijs  karma start ./config/karma.conf.cjs --single-run",
     "test:browser:memory": " npm run transpile && cross-env CI=true DEFAULT_STORAGE=memory  karma start ./config/karma.conf.cjs --single-run",

--- a/src/plugin-helpers.ts
+++ b/src/plugin-helpers.ts
@@ -188,6 +188,7 @@ export function wrapRxStorageInstance<RxDocType>(
     const wrappedInstance: WrappedRxStorageInstance<RxDocType, any, any> = {
         databaseName: instance.databaseName,
         internals: instance.internals,
+        purgeDocumentsById: instance.purgeDocumentsById.bind(instance),
         cleanup: instance.cleanup.bind(instance),
         options: instance.options,
         close: instance.close.bind(instance),

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -122,6 +122,7 @@ export const ERROR_MESSAGES = {
     DOC23: 'PrimaryKey must not contain a double-quote ["]',
     DOC24: 'Given document data could not be structured cloned. This happens if you pass non-plain-json data into it, like a Date() or a Function. ' +
         'In vue.js this happens if you use ref() on the document data which transforms it into a Proxy object.',
+    DOC25: 'RxDocument.purge(): Document is not marked as deleted and cannot be purged',
 
     // data-migrator.js
     DM1: 'migrate() Migration has already run',

--- a/src/plugins/storage-memory/rx-storage-instance-memory.ts
+++ b/src/plugins/storage-memory/rx-storage-instance-memory.ts
@@ -387,6 +387,32 @@ export class RxStorageInstanceMemory<RxDocType> implements RxStorageInstance<
         };
     }
 
+    async purgeDocumentsById(docIds: string[], forcePurge: boolean = false): Promise<void> {
+        this.ensurePersistence();
+        const documentsById = this.internals.documents;
+        if (documentsById.size === 0) {
+            return;
+        }
+        for (let i = 0; i < docIds.length; ++i) {
+            const docId = docIds[i];
+            const docInDb = documentsById.get(docId);
+            if (
+                docInDb &&
+                (
+                    docInDb._deleted ||
+                    forcePurge
+                )
+            ) {
+                removeDocFromState(
+                    this.primaryPath as any,
+                    this.schema,
+                    this.internals,
+                    docInDb
+                );
+            }
+        }
+    }
+
     cleanup(minimumDeletedTime: number): Promise<boolean> {
         this.ensurePersistence();
         const maxDeletionTime = now() - minimumDeletedTime;

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -396,6 +396,16 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         };
     }
 
+    async purgeDocumentsById(docIds: string[], forcePurge: boolean = false): Promise<void> {
+        this.runningOperations.next(this.runningOperations.getValue() + 1);
+        const mongoCollection = await this.mongoCollectionPromise;
+        await mongoCollection.deleteMany({
+            ...forcePurge ? {} : { _deleted: true }, // if forcePurge=true, we also purge non-deleted documents
+            [this.inMongoPrimaryPath]: docIds
+        });
+        this.runningOperations.next(this.runningOperations.getValue() - 1);
+    }
+
     async cleanup(minimumDeletedTime: number): Promise<boolean> {
         this.runningOperations.next(this.runningOperations.getValue() + 1);
         const mongoCollection = await this.mongoCollectionPromise;

--- a/src/plugins/storage-remote/rx-storage-remote.ts
+++ b/src/plugins/storage-remote/rx-storage-remote.ts
@@ -253,6 +253,9 @@ export class RxStorageInstanceRemote<RxDocType> implements RxStorageInstance<RxD
     changeStream(): Observable<EventBulk<RxStorageChangeEvent<RxDocumentData<RxDocType>>, any>> {
         return this.changes$.asObservable();
     }
+    purgeDocumentsById(docIds: string[], forcePurge: boolean = false): Promise<void> {
+        return this.requestRemote('purgeDocumentsById', [docIds, forcePurge]);
+    }
     cleanup(minDeletedTime: number): Promise<boolean> {
         return this.requestRemote('cleanup', [minDeletedTime]);
     }

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -408,7 +408,7 @@ export const basePrototype = {
      * Purge the removed document from the database.
      *
      * This will not wait for the document to be synced with the server,
-     * use remove() if you need to be sure it is deleted and cleanup() to clean up afterwards
+     * use the cleanup plugin to purge all removed documents properly
     */
     purge(this: RxDocument): Promise<void> {
         if (!this.deleted ) {

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -410,14 +410,14 @@ export const basePrototype = {
      * This will not wait for the document to be synced with the server,
      * use remove() if you need to be sure it is deleted and cleanup() to clean up afterwards
     */
-    purge(this: RxDocument, forcePurge: boolean = false): Promise<void> {
-        if (!forcePurge && !this.deleted ) {
+    purge(this: RxDocument): Promise<void> {
+        if (!this.deleted ) {
             return Promise.reject(newRxError('DOC25', {
                 document: this,
                 id: this.primary
             }));
         }
-        return this.collection.storageInstance.purgeDocumentsById([this.primary], forcePurge);
+        return this.collection.storageInstance.purgeDocumentsById([this.primary], false);
     },
     incrementalRemove(this: RxDocument): Promise<RxDocument> {
         return this.incrementalModify(async (docData) => {

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -768,6 +768,11 @@ export function getWrappedStorageInstance<
                 () => ((storageInstance as any).getChangedDocumentsSince)(ensureNotFalsy(limit), checkpoint)
             );
         },
+        purgeDocumentsById(docIds: string[], forcePurge: boolean = false) {
+            return database.lockedRun(
+                () => storageInstance.purgeDocumentsById(docIds, forcePurge)
+            );
+        },
         cleanup(minDeletedTime: number) {
             return database.lockedRun(
                 () => storageInstance.cleanup(minDeletedTime)
@@ -1008,6 +1013,12 @@ export function randomDelayStorage<Internals, InstanceCreationOptions>(
                 },
                 resolveConflictResultionTask(a) {
                     return storageInstance.resolveConflictResultionTask(a);
+                },
+                async purgeDocumentsById(a, b) {
+                    await promiseWait(input.delayTimeBefore());
+                    const ret = await storageInstance.purgeDocumentsById(a, b);
+                    await promiseWait(input.delayTimeAfter());
+                    return ret;
                 },
                 async cleanup(a) {
                     await promiseWait(input.delayTimeBefore());

--- a/src/types/rx-storage.interface.d.ts
+++ b/src/types/rx-storage.interface.d.ts
@@ -266,8 +266,25 @@ export interface RxStorageInstance<
      */
     changeStream(): Observable<EventBulk<RxStorageChangeEvent<RxDocType>, CheckpointType>>;
 
+     /**
+     * Purge matching documents from the storage.
+     * Only if they have _deleted set to true
+     */
+     purgeDocumentsById(
+       /**
+         * List of primary values
+         * of the documents to purge.
+         */
+       docIds: string[],
+       /**
+        * If set to true, it will force the purge and not check the _deleted flag
+        * @default false
+        */
+       forcePurge: boolean
+    ): Promise<void>;
+
     /**
-     * Runs a cleanup that removes all tompstones
+     * Runs a cleanup that removes all tombstones
      * of documents that have _deleted set to true
      * to free up disc space.
      *


### PR DESCRIPTION
## This PR contains:
 - A new feature for the internalStorage and the document

## Describe the problem you have without this PR
I added a way to purge a document from the storage, to be able to resolve the replication when one document is bloqued by the server.

- I added the function to RxDocument, but I won't mind if you remove it from there, to prevent users from using it by default. By default it will only purge _deleted=true documents, unless the user forcePurge it.
- I added the function on many storage, but it misses the premium storages
- I did not add it to the cleanup plugin and did not attach it to the collection (...yet?)

Like said in another PR, sometimes not everything is perfect, the server might return a GraphQL Error that will prevent the replication to finish and will always return the same error for the same `newDocumentState` in error. Since the cleanup policy or manual cleanup() is configured to `awaitReplicationsInSync` for all others documents, it will never be able to get rid of this "corrupted" document. Unless we have a function to purge it by id (soft deleted or not).

If the replication only allows update and no insert, we can then `doc.remove()` and then `doc.purge()` or calling directly `collection.internalStorage.purgeDocumentsById([id], true)` if `RxDocument` does not have the function

This is still in draft and has no tests because I was unsure if I was on the right path and that's something you will be interested to merge.

## Todos
- [ ] Tests
- [ ] Missing premiums storage
- [ ] Documentation
- [ ] Changelog

