### PR TITLE
test: .count() with key-compression plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "test:local": "npm run transpile && cross-env DEFAULT_STORAGE=dexie NODE_ENV=fast mocha --config ./config/.mocharc.cjs ./test_tmp/unit/key-compression.test.js",
     "postinstall": "node scripts/postinstall.js || echo \"ignore\"",
     "test": "npm run test:node && npm run test:browser",
     "// test:fast": "run tests in the fast-mode. Most of them will run in parrallel, skips tests that are known slow",

--- a/test/unit/key-compression.test.ts
+++ b/test/unit/key-compression.test.ts
@@ -122,6 +122,32 @@ config.parallel('key-compression.test.js', () => {
 
             col.database.destroy();
         });
+        it('should properly run the .count() with key-compression', async () => {
+            const col = await getCollection();
+            
+            assert.ok(col.schema.jsonSchema.keyCompression);
+
+            await col.bulkInsert([
+                {
+                    firstName: 'aaa',
+                    lastName: 'aaa',
+                    passportId: 'aaa',
+                    age: 0
+                },
+                {
+                    firstName: 'bbb',
+                    lastName: 'bbb',
+                    passportId: 'bbb',
+                    age: 0
+                }
+            ]);
+
+           const counts= await col.count({selector:{firstName:'aaa'}}).exec()
+
+           assert.strictEqual(counts, 1);
+
+            col.database.destroy();
+        });
     });
     describe('replication', () => {
         if (!config.storage.hasReplication) {


### PR DESCRIPTION
## This PR contains:
Unit test case for doc.count() with key-compression plugin.

## Describe the problem you have without this PR
Throw store error about indexes when use .count() with key-compression plugin.



