### PR TITLE
fix(Angular): add process.nextTick() polyfill

### DIFF
--- a/docs-src/docs/install.md
+++ b/docs-src/docs/install.md
@@ -40,6 +40,7 @@ You have to add them by your own, like we do [here](https://github.com/pubkey/rx
 (window as any).global = window;
 (window as any).process = {
     env: { DEBUG: undefined },
+    nextTick: () => {},
 };
 ```
 

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -14,12 +14,13 @@ Also it uses **angular-universal** to enable server side rendering.
 7. Open [http://127.0.0.1:4200/](http://127.0.0.1:4200/) **IMPORTANT: do not use localhost**
 
 ## Important parts when using RxDB with angular:
-- Make sure you have the `window` polyfills added that are needed for pouchdb
+- Make sure you have the `window` polyfills added that are needed for some plugins
 ```ts
 // in polyfills.ts
 (window as any).global = window;
 (window as any).process = {
     env: { DEBUG: undefined },
+    nextTick: () => {},
 };
 ```
 

--- a/examples/angular/src/polyfills.ts
+++ b/examples/angular/src/polyfills.ts
@@ -1,6 +1,7 @@
 (window as any).global = window;
 (window as any).process = {
     env: { DEBUG: undefined },
+    nextTick: () => {},
 };
 
 /*


### PR DESCRIPTION
## This PR contains: a bugfix

## Describe the problem you have without this PR
Without it when using `replicateWebRTC` we'll see console error when peer becomes visible:
 
> ERROR TypeError: process.nextTick is not a function
    at resume (_stream_readable.js:832:13)
    at Readable.resume (_stream_readable.js:824:5)
    at Readable.on (_stream_readable.js:753:39)
    at createPeerConnection (connection-handler-simple-peer.js:101:31)
    at connection-handler-simple-peer.js:140:19
    at Array.forEach (<anonymous>)
    at ensureNotFalsy.onmessage [as __zone_symbol__ON_PROPERTYmessage] (connection-handler-simple-peer.js:136:32)
    at WebSocket.wrapFn (zone.js:755:39)
    at _ZoneDelegate.invokeTask (zone.js:402:31)
    at core.mjs:14369:55

<img width="734" alt="image" src="https://github.com/pubkey/rxdb/assets/8938562/dfdb212b-9118-43e4-ad91-ac13d7cfd303">