### PR TITLE
docs: add info about $options to v15 release note

### DIFF
--- a/docs-src/docs/releases/15.0.0.md
+++ b/docs-src/docs/releases/15.0.0.md
@@ -71,7 +71,7 @@ We now use `export type * from './types';` so RxDB will not work on typescript v
 
 ## Require string based `$regex`
 
-Queries with a `$regex` operator must now be defined as strings, not with `RegExp` objects. `RegExp` are mutable objects, which was dangerous and caused hard-to-debug problems.
+Queries with a `$regex` operator must now be defined as strings, not with `RegExp` objects. You can still pass RegExp's flags in `$options` parameter. `RegExp` are mutable objects, which was dangerous and caused hard-to-debug problems.
 Also stringification of the $regex had bad performance but is required to send queries from RxDB to the RxStorage.
 
 ## Refactor dexie.js RxStorage


### PR DESCRIPTION
## This PR contains:
improved docs

## Describe the problem you have without this PR
Currently it's not clear how to convert RegExp into string while keeping the flags.
