### PR TITLE
fix: update `firebase` for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
     "custom-idle-queue": "3.0.1",
     "dexie": "4.0.4",
     "event-reduce-js": "5.2.7",
-    "firebase": "10.10.0",
+    "firebase": "10.10.1",
     "get-graphql-from-jsonschema": "8.1.0",
     "graphql": "15.8.0",
     "graphql-ws": "5.16.0",

--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
     "custom-idle-queue": "3.0.1",
     "dexie": "4.0.4",
     "event-reduce-js": "5.2.7",
-    "firebase": "10.10.1",
+    "firebase": "10.11.1",
     "get-graphql-from-jsonschema": "8.1.0",
     "graphql": "15.8.0",
     "graphql-ws": "5.16.0",


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  - DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
    THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
  - EACH CHANGE TO THE SOURCE CODE, REQUIRES AT LEAST ONE TEST
    THAT COVERS THE CHANGE IN BEHAVIOR.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

An update to `firebase` to a version that pulls in a patched version of `undici`

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

The current version of `firebase` pulls in a vulnerable version of `undici`:

```
❯ osv-detector .
Loaded the following OSV databases:
  npm (14444 vulnerabilities, including withdrawn - last updated Fri, 26 Apr 2024 18:50:43 GMT)

yarn.lock: found 1482 packages
  Using db npm (14444 vulnerabilities, including withdrawn - last updated Fri, 26 Apr 2024 18:50:43 GMT)

  undici@5.28.3 is affected by the following vulnerabilities:
    GHSA-9qxr-qj54-h672: Undici's fetch with integrity option is too lax when algorithm is specified but hash value is in incorrect (https://github.com/advisories/GHSA-9qxr-qj54-h672)
    GHSA-m4v8-wqvr-p9f7: Undici's Proxy-Authorization header not cleared on cross-origin redirect for dispatch, request, stream, pipeline (https://github.com/advisories/GHSA-m4v8-wqvr-p9f7)

  2 known vulnerabilities found in yarn.lock

❯ yarn why undici
yarn why v1.22.21
[1/4] Why do we have the module "undici"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "undici@5.28.3"
info Reasons this module exists
   - "rxdb#firebase#@firebase#auth-compat" depends on it
   - Hoisted from "rxdb#firebase#@firebase#auth-compat#undici"
   - Hoisted from "rxdb#firebase#@firebase#auth#undici"
   - Hoisted from "rxdb#firebase#@firebase#firestore#undici"
   - Hoisted from "rxdb#firebase#@firebase#functions#undici"
   - Hoisted from "rxdb#firebase#@firebase#storage#undici"
info Disk size without dependencies: "1.57MB"
info Disk size with unique dependencies: "1.71MB"
info Disk size with transitive dependencies: "1.71MB"
info Number of shared dependencies: 1
Done in 0.26s.
```

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [x] Tests
- [x] ~Documentation~
- [x] ~Typings~
- [x] ~Changelog~

