### PR TITLE
fix(datapath) must be equivalent for pull and push

### DIFF
--- a/src/plugins/replication-graphql/helper.ts
+++ b/src/plugins/replication-graphql/helper.ts
@@ -1,5 +1,5 @@
 import type { RxGraphQLReplicationClientState, RxGraphQLReplicationQueryBuilderResponseObject } from '../../types/index.d.ts';
-import { ensureNotFalsy } from '../../plugins/utils/index.ts';
+import { ensureNotFalsy, getProperty } from '../../plugins/utils/index.ts';
 
 export const GRAPHQL_REPLICATION_PLUGIN_IDENTITY_PREFIX = 'graphql';
 
@@ -40,4 +40,13 @@ export function graphQLRequest(
         .then((body) => {
             return body;
         });
+}
+
+export function getDataFromResult(
+    result: { data: object },
+    userDefinedDataPath: string | string[] | undefined
+): any {
+    const dataPath = userDefinedDataPath || ['data', Object.keys(result.data)[0]];
+    const data: any = getProperty(result, dataPath);
+    return data;
 }

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../../plugins/utils/index.ts';
 
 import {
+    getDataFromResult,
     graphQLRequest
 } from './helper.ts';
 
@@ -131,8 +132,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
                 if (result.errors) {
                     throw result.errors;
                 }
-                const dataPath = pull.dataPath || ['data', Object.keys(result.data)[0]];
-                let data: any = getProperty(result, dataPath);
+                let data: any = getDataFromResult(result, pull.dataPath);
                 if (pull.responseModifier) {
                     data = await pull.responseModifier(
                         data,
@@ -166,9 +166,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
                 if (result.errors) {
                     throw result.errors;
                 }
-                const dataPath = push.dataPath || Object.keys(result.data)[0];
-                let data: any = getProperty(result.data, dataPath);
-
+                let data: any = getDataFromResult(result, push.dataPath);
                 if (push.responseModifier) {
                     data = await push.responseModifier(
                         data,
@@ -176,7 +174,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
                 }
 
                 return data;
-            },
+            }, 
             batchSize: push.batchSize,
             modifier: push.modifier
         };

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -38,7 +38,12 @@ export type GraphQLSyncPullOptions<RxDocType, CheckpointType> = Omit<
 > & {
     queryBuilder: RxGraphQLReplicationPullQueryBuilder<CheckpointType>;
     streamQueryBuilder?: RxGraphQLReplicationPullStreamQueryBuilder;
-    dataPath?: string;
+    /**
+     * The path to the data in the GraphQL response.
+     * If set, the data will be taken from the response at this path.
+     * @example ['data', 'foo', 'bar'] or 'data.foo.bar'
+     */
+    dataPath?: string | string[];
     responseModifier?: RxGraphQLPullResponseModifier<RxDocType, CheckpointType>;
     includeWsHeaders?: boolean;
 };
@@ -63,7 +68,12 @@ export type GraphQLSyncPushOptions<RxDocType> = Omit<
     'handler'
 > & {
     queryBuilder: RxGraphQLReplicationPushQueryBuilder;
-    dataPath?: string;
+    /**
+     * The path to the data in the GraphQL response.
+     * If set, the data will be taken from the response at this path.
+     * @example ['data', 'foo', 'bar'] or 'data.foo.bar'
+     */
+    dataPath?: string | string[];
     responseModifier?: RxGraphQLPushResponseModifier<RxDocType>;
 };
 


### PR DESCRIPTION
## This PR contains:
 - IMPROVED DOCS
 - IMPROVED TESTS
 - A BUGFIX
 - BREAKING


## Describe the problem you have without this PR
If we define a custom `dataPath` for the `graphQL` replication, we end up setting a different datapath for the pull and push rep. Pull rep does not handle the `data.` prefix while push already handles it with `result.data` 

I changed this to make both (pull and push) use the same function helper to extract the proper datapath if defined or not by the user.

Based on the unit tests, I found some that were testing only the pull replication and needed `data` as a prefix so I made the helper function the same as the current `pull.dataPath`, so it will request the user to add `data.` as a prefix, if you prefer the other way around, let me know. However, it makes sense if for any reason the default selector `['data', Object.keys(result.data)[0])]` doesn't work because there is no `data` key returned from the server (exceptional edge case, maybe they used the `customFetch` property) and it breaks the default selector on `Object.keys(result.data)`

I also changed the typing of `dataPath` to accept `string[]` since `getProperty` also accepts it.

```ts
{
  dataPath: ['data', 'foo', 'bar']
}
  // or
{
  dataPath: 'data.foo.bar'
}
```
