### PR TITLE
fix: Add missing extensions error field to errorToPlainJson

### DIFF
--- a/src/plugins/utils/utils-error.ts
+++ b/src/plugins/utils/utils-error.ts
@@ -38,6 +38,7 @@ export function errorToPlainJson(err: Error | TypeError | RxError | RxTypeError)
         message: err.message,
         rxdb: (err as any).rxdb,
         parameters: (err as RxError).parameters,
+        extensions: (err as any).extensions,
         code: (err as RxError).code,
         /**
          * stack must be last to make it easier to read the json in a console.

--- a/src/types/rx-error.d.ts
+++ b/src/types/rx-error.d.ts
@@ -125,6 +125,7 @@ export type PlainJsonError = {
     message: string;
     rxdb?: true;
     code?: RxErrorKey;
+    extensions?: Record<string, any>;
     parameters?: RxErrorParameters;
     stack?: string;
 };

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -24,7 +24,8 @@ import {
     toWithDeleted,
     stringToArrayBuffer,
     arrayBufferToString,
-    clone
+    clone,
+    errorToPlainJson
 } from '../../plugins/core/index.mjs';
 import config from './config.ts';
 
@@ -502,6 +503,29 @@ describe('util.test.js', () => {
             const buffer = stringToArrayBuffer(str);
             const back = arrayBufferToString(buffer);
             assert.strictEqual(str, back);
+        });
+    });
+    describe('.errorToPlainJson()', () => {
+        it('should return the correct result for an error containing all possible fields', () => {
+            const customError = {
+                name: 'CustomError',
+                message: 'This is a custom error',
+                rxdb: false,
+                extensions: { code: 'CUSTOM_ERR_CODE' },
+                parameters: { value: 'value' },
+                code: 'CUSTOM_ERR_CODE',
+                stack: 'CustomError: This is a custom error\n at someFile.js'
+            };
+
+            const result = errorToPlainJson(customError);
+
+            assert.strictEqual(result.name, customError.name);
+            assert.strictEqual(result.message, customError.message);
+            assert.strictEqual(result.rxdb, customError.rxdb);
+            assert.deepStrictEqual(result.extensions, customError.extensions);
+            assert.deepStrictEqual(result.parameters, customError.parameters);
+            assert.strictEqual(result.code, customError.code);
+            assert.strictEqual(result.stack, 'CustomError: This is a custom error \n  at someFile.js');
         });
     });
 });


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  - DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
    THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
  - EACH CHANGE TO THE SOURCE CODE, REQUIRES AT LEAST ONE TEST
    THAT COVERS THE CHANGE IN BEHAVIOR.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
A BUGFIX

## Describe the problem you have without this PR
missing `extensions` field to the error object (v14 regression).

**Related discussion:** https://github.com/pubkey/rxdb/issues/5952 


