### PR TITLE
Added initial checkpoint to graphql replication

### DIFF
--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -151,7 +151,8 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
             },
             batchSize: pull.batchSize,
             modifier: pull.modifier,
-            stream$: pullStream$.asObservable()
+            stream$: pullStream$.asObservable(),
+            initialCheckpoint: pull.initialCheckpoint
         };
     }
     let replicationPrimitivesPush: ReplicationPushOptions<RxDocType> | undefined;
@@ -178,7 +179,8 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
                 return data;
             },
             batchSize: push.batchSize,
-            modifier: push.modifier
+            modifier: push.modifier,
+            initialCheckpoint: push.initialCheckpoint
         };
     }
 


### PR DESCRIPTION
<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->


## This PR contains:
1. Initial checkpoint for GraphQL Replication: pull & push.
2. This PR is inspired by couchdb initial replication from another PR: https://github.com/pubkey/rxdb/pull/5461

## Describe the problem you have without this PR
1. Currently only the couchdb supported initial replication. However GraphQL replication does not support this.

<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

