### PR TITLE
Keep primary fields with an underscore

### DIFF
--- a/src/plugins/replication-graphql/graphql-schema-from-rx-schema.ts
+++ b/src/plugins/replication-graphql/graphql-schema-from-rx-schema.ts
@@ -260,7 +260,7 @@ export function fillUpOptionals(
     const schema = fillWithDefaultSettings(input.schema);
     // strip internal attributes
     Object.keys(schema.properties).forEach(key => {
-        if (key.startsWith('_')) {
+        if (key.startsWith('_') && schema.primaryKey !== key) {
             delete schema.properties[key];
         }
     });

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1849,6 +1849,29 @@ describe('replication-graphql.test.ts', () => {
                 const build = buildSchema(output.asString);
                 assert.ok(build);
             });
+            it('should create a valid output with the underscore primary key', () => {
+                const { id: _id, ...restProperties } =  schemas.humanWithTimestamp.properties;
+
+                const schema: RxJsonSchema<any> = {
+                    ...schemas.humanWithTimestamp,
+                    primaryKey: '_id',
+                    properties: { _id, ...restProperties }
+                };
+
+                const output = graphQLSchemaFromRxSchema({
+                    human: {
+                        schema,
+                        checkpointFields: [
+                            '_id',
+                            'updatedAt'
+                        ]
+                    }
+                });
+
+                assert.ok(output.asString.includes('_id'));
+                const build = buildSchema(output.asString);
+                assert.ok(build);
+            });
             it('should create a valid output with subscription params', () => {
                 const output = graphQLSchemaFromRxSchema({
                     human: {

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1852,7 +1852,7 @@ describe('replication-graphql.test.ts', () => {
             it('should create a valid output with the underscore primary key', () => {
                 const { id: _id, ...restProperties } =  schemas.humanWithTimestamp.properties;
 
-                const schema: RxJsonSchema<any> = {
+                const schema = {
                     ...schemas.humanWithTimestamp,
                     primaryKey: '_id',
                     properties: { _id, ...restProperties }


### PR DESCRIPTION
For example, if we were to use couchbase entities/structures with _id property