### PR TITLE
RxDocument proxy performance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,7 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js || echo \"ignore\"",
     "test": "npm run test:node && npm run test:browser",
+    "test:bugreport": "npm run transpile && cross-env DEFAULT_STORAGE=memory NODE_ENV=fast mocha --config ./config/.mocharc.cjs ./test_tmp/unit/bug-report.test.js",
     "// test:fast": "run tests in the fast-mode. Most of them will run in parrallel, skips tests that are known slow",
     "test:fast": "npm run test:fast:memory && npm run test:fast:lokijs && npm run test:fast:dexie",
     "test:fast:memory": "npm run transpile && cross-env DEFAULT_STORAGE=memory NODE_ENV=fast mocha --config ./config/.mocharc.cjs ./test_tmp/unit.test.js",


### PR DESCRIPTION
## This PR contains:

A failing test to illustrate a performance issue with RxDocument

## Describe the problem you have without this PR

I've noticed a big performance degradation when adding rxdb to my app. A page that use to take a couple dozen ms to render started taking almost 200 ms. I tracked down the issue to the performance of RxDocument.proxy-get.

In my app mapping the list of RxDocuments I'm processing to regular javascript objects using:
```
myDocs.map((doc) => { return {...doc }}); 
```
Brought down rendering time from 200ms back to 30ms

