### PR TITLE
Adds missing replicationIdentifier to firestore docs

### DIFF
--- a/docs-src/docs/replication-firestore.md
+++ b/docs-src/docs/replication-firestore.md
@@ -50,6 +50,7 @@ Then you can start the replication by calling `replicateFirestore()` on your [Rx
 ```ts
 const replicationState = replicateFirestore(
     {
+        replicationIdentifier: `https://firestore.googleapis.com/${projectId}`,
         collection: myRxCollection,
         firestore: {
             projectId,


### PR DESCRIPTION

## This PR contains:
 - IMPROVED DOCS
