### PR TITLE
Fixes firestore replication of multiple document with the same serverTimestamp

### DIFF
--- a/src/plugins/replication-firestore/index.ts
+++ b/src/plugins/replication-firestore/index.ts
@@ -138,8 +138,8 @@ export function replicateFirestore<RxDocType>(
                     );
                     sameTimeQuery = query(pullQuery,
                         where(serverTimestampField, '==', lastServerTimestamp),
-                        where(primaryPath, '>', lastPulledCheckpoint.id),
-                        orderBy(primaryPath, 'asc'),
+                        where(documentId(), '>', lastPulledCheckpoint.id),
+                        orderBy(documentId(), 'asc'),
                         limit(batchSize)
                     );
                 } else {


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
I noticed some documents where missing when replicating from firestore. I traced down the issue to a bug in the `sameTimeQuery` in the firestore plugin where we're querying for a document field instead of querying for a document id.

I'm not sure how to test a change to this library on my project, could you advise on how to do so? I don't think I can use `npm link` because of the build steps required.

