### PR TITLE
test: bad rx-state after cleanup

### DIFF
--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -488,6 +488,31 @@ addRxPlugin(RxDBJsonDumpPlugin);
             });
         });
         describe('issues', () => {
+            it('createRxState with cleaned up operations', async () => {
+                const databaseName = randomCouchString(10);
+                const prefix = randomCouchString(10);
+
+                const state = await getState(databaseName, prefix);
+                await state.collection.storageInstance.bulkWrite(
+                    [{
+                        document: {
+                            /**
+                             * this is the operation inserted by _cleanup, see:
+                             * // @see src/plugins/state/rx-state.ts#L255
+                             */
+                            ops: [{ k: '', v: { foo: 'bar' }}]
+                        },
+                    }],
+                    'rxdb-state-test'
+                );
+
+                assert.strictEqual(state.get(), {
+                    foo: 'bar'
+                });
+                // this assertion fails, the actual state returned is:
+                // { '': { foo: 'bar' } }
+            });
+
             /**
              * @link https://github.com/pubkey/rxdb/issues/6459
              */


### PR DESCRIPTION
## This PR contains:
a failing test

## Describe the problem you have without this PR
to reproduce the issue:
- have an rx-state
- make more than 5 writes to ensure _cleanup does its thing
- the state has an additional "" property which causes problems further down the line

