### PR TITLE
fix: position of dev-mode iframe

### DIFF
--- a/src/plugins/dev-mode/dev-mode-tracking.ts
+++ b/src/plugins/dev-mode/dev-mode-tracking.ts
@@ -47,6 +47,9 @@ export async function addDevModeTrackingIframe(db: RxDatabase) {
     iframe.style.visibility = 'hidden';
     iframe.width = '1px';
     iframe.height = '1px';
+    iframe.style.position = 'absolute';
+    iframe.style.top = '0';
+    iframe.style.left = '0';
     iframe.style.opacity = '0.1';
     iframe.src = 'https://rxdb.info/html/dev-mode-iframe.html?version=' + RXDB_VERSION;
     document.body.appendChild(iframe);


### PR DESCRIPTION
This patch removes 5 extra pixels in dev-mode
<img width="1113" alt="Screenshot 2024-10-18 at 10 20 22" src="https://github.com/user-attachments/assets/f02ca98b-182f-4255-9bb7-9f600e114c78">

