### PR TITLE
test: bulk inserting 2 docs with same primary key

### DIFF
--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -252,6 +252,27 @@ describe('rx-collection.test.ts', () => {
                 });
             });
             describe('negative', () => {
+                it('ensures uniqueness of primary-key', async () => {
+                    const db = await createRxDatabase({
+                        name: randomCouchString(10),
+                        storage: config.storage.getStorage(),
+                    });
+                    const collections = await db.addCollections({
+                        human: { schema: schemas.primaryHuman }
+                    });
+
+                    const human1 = schemaObjects.humanData('same-id');
+                    const human2 = schemaObjects.humanData('same-id');
+
+                    await collections.human.insert(human1);
+
+                    await assertThrows(
+                        () => collections.human.insert(human2),
+                        'RxError'
+                    );
+
+                    db.destroy();
+                });
                 it('should throw a conflict-error', async () => {
                     const db = await createRxDatabase({
                         name: randomCouchString(10),
@@ -367,6 +388,29 @@ describe('rx-collection.test.ts', () => {
                 });
             });
             describe('negative', () => {
+                it('ensures uniqueness of primary-key', async () => {
+                    const db = await createRxDatabase({
+                        name: randomCouchString(10),
+                        storage: config.storage.getStorage(),
+                    });
+                    const collections = await db.addCollections({
+                        human: { schema: schemas.primaryHuman }
+                    });
+
+                    const human1 = schemaObjects.humanData('same-id');
+                    const human2 = schemaObjects.humanData('same-id');
+
+                    /**
+                     * this does not throw, 2 documents are
+                     * inserted with the same primary-key.
+                     */
+                    await assertThrows(
+                        () => collections.human.bulkInsert([human1, human2]),
+                        'RxError'
+                    );
+
+                    db.destroy();
+                });
                 it('should throw if one already exists', async () => {
                     const db = await createRxDatabase({
                         name: randomCouchString(10),


### PR DESCRIPTION
## This PR contains:
a failing test

## Describe the problem you have without this PR
bulk inserting 2 docs with same primary key should throw conflict error
instead, the collection now contains 2 docs with the same primary key

example:
* given a collection: `people` has a primary key: `id`
* when `people.bulkInsert({id: 1, name: bob}, {id: 1, name: jane})` 
* then the bulkInsert is successful and now i have 2 records with the same primary key in the collection
* `people.count().exec()` is 2
