### PR TITLE
test: unhandled promise rejections in tests do not fail the test

### DIFF
--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -252,6 +252,30 @@ describe('rx-collection.test.ts', () => {
                 });
             });
             describe('negative', () => {
+                it('example unhandled promise rejection', async () => {
+                    process.on('unhandledRejection', (reason, p) => {
+                        console.error('Unhandled Rejection at:', p, 'reason:', reason);
+                        process.exit(1);
+                    });
+
+                    const db = await createRxDatabase({
+                        name: randomCouchString(10),
+                        storage: config.storage.getStorage(),
+                    });
+                    const collections = await db.addCollections({
+                        human: {
+                            schema: schemas.human
+                        }
+                    });
+                    const doc = schemaObjects.humanData();
+                    /**
+                     * we don't catch the promise or wrap in a try-catch,
+                     * so this will result in an unhandled promise rejection
+                     */
+                    collections.human.insert(doc);
+                    collections.human.insert(doc);
+                    db.destroy();
+                });
                 it('should throw a conflict-error', async () => {
                     const db = await createRxDatabase({
                         name: randomCouchString(10),


### PR DESCRIPTION
## This PR contains:
an example showing how a test can throw an unhandled promise rejection but still pass

this can lead to false test positives, where the test is green but an error was thrown

for a better developer experience, perhaps its possible to fail tests that have unhandled promies rejections

i unfortunately don't have a solution to improve this at this point, but maybe someone else does

## Describe the problem you have without this PR
i was writing a unit test to check that collection insert does throw a conflict error with duplicate primary keys:
```
await people.insert(person1withId1)
await people.insert(person2withId1) <-- can assert that this throws - OK
```

then i thought: is there perhaps a race condition when i don't await the inserts, does it save both?
```
people.insert(person1withId1)
people.insert(person2withId1)
```
this test passes, no error is thrown because we don't catch the promise nor do we have a try/catch block. The second insert still fails, but it doesn't cause the test to go red

what is happening is the conflict error from the second insert results in an unhandled promise rejection.

mocha seems to have limited support for failing tests that contain an unhandled promise rejection, perhaps there is a way to do it in mocha by upgrading promise rejections to exceptions. Alternative could be to use a different test runner which better supports failing tests with unhandled promise rejections.

