### PR TITLE
fix(rx-query) findByIds not working with modify and patch

### DIFF
--- a/src/rx-query-helper.ts
+++ b/src/rx-query-helper.ts
@@ -242,6 +242,10 @@ export async function runQueryUpdateFunction<RxDocType, RxQueryResult>(
         return Promise.all(
             docs.map(doc => fn(doc))
         ) as any;
+    }else if(docs instanceof Map){
+        return Promise.all(
+            [...docs.values()].map((doc) => fn(doc))
+        ) as any;
     } else {
         // via findOne()
         const result = await fn(docs as any);

--- a/test/unit/rx-collection.test.ts
+++ b/test/unit/rx-collection.test.ts
@@ -2046,6 +2046,35 @@ describe('rx-collection.test.ts', () => {
                 assert.strictEqual(res.size, 5);
                 c.database.destroy();
             });
+            it('we should be able to modify the documents', async () => {
+                const c = await humansCollection.create(5);
+                const docs = await c.find().exec();
+                const ids = docs.map((d) => d.primary);
+
+                await c.findByIds(ids).modify((doc) => {
+                    doc.firstName = 'abcdefghi';
+                    return doc;
+                });
+
+                const res = await c
+                    .count({ selector: { firstName: 'abcdefghi' } })
+                    .exec();
+                assert.strictEqual(res, 5);
+                c.database.destroy();
+            });
+            it('we should be able to patch the documents', async () => {
+                const c = await humansCollection.create(5);
+                const docs = await c.find().exec();
+                const ids = docs.map((d) => d.primary);
+
+                await c.findByIds(ids).patch({ firstName: 'abcdefghi' });
+
+                const res = await c
+                    .count({ selector: { firstName: 'abcdefghi' } })
+                    .exec();
+                assert.strictEqual(res, 5);
+                c.database.destroy();
+            });
             /**
              * @link https://github.com/pubkey/rxdb/issues/6148
              */


### PR DESCRIPTION
## Content
* Unit tests that shows the bug
* Fix for the bug
## Description
When you chain "findByIds" with "patch" or "modify" it throws an error like "there is not method named modify on doc". The issue is caused by "findByIds" returning a result in the form of a map witch is not handled in "runQueryUpdateFunction".


