### PR TITLE
added possibility to pass graphql-ws options into the replication options

### DIFF
--- a/docs-src/docs/replication-graphql.md
+++ b/docs-src/docs/replication-graphql.md
@@ -330,6 +330,13 @@ const replicationState = replicateGraphQL(
             queryBuilder: pullQueryBuilder,
             streamQueryBuilder: pullStreamQueryBuilder,
             includeWsHeaders: false, // Includes headers as connection parameter to Websocket.
+            
+            // Websocket options that can be passed as a parameter to initialize the subscription
+            // Can be applied anything from the graphql-ws ClientOptions - https://the-guild.dev/graphql/ws/docs/interfaces/client.ClientOptions
+            // Excepting parameters: 'url', 'shouldRetry', 'webSocketImpl', 'connectionParams' - locked for the internal usage
+            wsOptions: { 
+                retryAttempts: 10,
+            }
         },
         deletedField: 'deleted'
     }

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -17,7 +17,7 @@
     "expo-cli": "6.3.10",
     "jest": "29.7.0",
     "jest-expo": "49.0.0",
-    "react-native-gesture-handler": "2.21.0",
+    "react-native-gesture-handler": "2.21.1",
     "react-test-renderer": "18.3.1",
     "rimraf": "5.0.10",
     "schedule": "0.5.0"

--- a/src/plugins/replication-graphql/graphql-websocket.ts
+++ b/src/plugins/replication-graphql/graphql-websocket.ts
@@ -1,6 +1,7 @@
 import { Client, createClient } from 'graphql-ws';
 import { getFromMapOrCreate, getFromMapOrThrow } from '../../plugins/utils/index.ts';
 import ws from 'isomorphic-ws';
+import { RxGraphQLPullWSOptions } from '../../types';
 
 const { WebSocket: IsomorphicWebSocket } = ws;
 
@@ -15,7 +16,8 @@ export const GRAPHQL_WEBSOCKET_BY_URL: Map<string, WebsocketWithRefCount> = new 
 
 export function getGraphQLWebSocket(
     url: string,
-    headers?: { [k: string]: string; }
+    headers?: { [k: string]: string; },
+    options: RxGraphQLPullWSOptions = {},
 ): Client {
 
     const has = getFromMapOrCreate(
@@ -23,6 +25,7 @@ export function getGraphQLWebSocket(
         url,
         () => {
             const wsClient = createClient({
+                ...options,
                 url,
                 shouldRetry: () => true,
                 webSocketImpl: IsomorphicWebSocket,

--- a/src/plugins/replication-graphql/index.ts
+++ b/src/plugins/replication-graphql/index.ts
@@ -205,7 +205,7 @@ export function replicateGraphQL<RxDocType, CheckpointType>(
     graphqlReplicationState.start = () => {
         if (mustUseSocket) {
             const httpHeaders = pull.includeWsHeaders ? mutateableClientState.headers : undefined;
-            const wsClient = getGraphQLWebSocket(ensureNotFalsy(url.ws), httpHeaders);
+            const wsClient = getGraphQLWebSocket(ensureNotFalsy(url.ws), httpHeaders, pull.wsOptions);
 
             wsClient.on('connected', () => {
                 pullStream$.next('RESYNC');

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -1,3 +1,4 @@
+import { ClientOptions } from 'graphql-ws';
 import { RxReplicationWriteToMasterRow } from '../replication-protocol.ts';
 import { ById, MaybePromise } from '../util.ts';
 import {
@@ -27,6 +28,7 @@ export type RxGraphQLReplicationPushQueryBuilder = (
     rows: RxReplicationWriteToMasterRow<any>[]
 ) => RxGraphQLReplicationQueryBuilderResponse;
 
+export type RxGraphQLPullWSOptions = Omit<ClientOptions, 'url' | 'shouldRetry' | 'webSocketImpl' | 'connectionParams'>;
 
 export type RxGraphQLReplicationPullQueryBuilder<CheckpointType> = (
     latestPulledCheckpoint: CheckpointType | undefined,
@@ -41,6 +43,7 @@ export type GraphQLSyncPullOptions<RxDocType, CheckpointType> = Omit<
     dataPath?: string;
     responseModifier?: RxGraphQLPullResponseModifier<RxDocType, CheckpointType>;
     includeWsHeaders?: boolean;
+    wsOptions?: RxGraphQLPullWSOptions;
 };
 
 export type RxGraphQLPullResponseModifier<RxDocType, CheckpointType> = (

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1636,7 +1636,7 @@ describe('replication-graphql.test.ts', () => {
                 await c.database.destroy();
             });
             it('should respect pull.wsOptions', async () => {
-                const capturedWSStates = [];
+                const capturedWSStates: string[] = [];
                 const [c, server] = await Promise.all([
                     humansCollection.createHumanWithTimestamp(0),
                     SpawnServer.spawn()

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1679,7 +1679,9 @@ describe('replication-graphql.test.ts', () => {
 
                 await replicationState.awaitInitialReplication();
 
-                await wait(300);
+                await waitUntil(() => {
+                    return capturedWSStates.length === 2;
+                });
 
                 assert.equal(capturedWSStates.includes('connected'), true);
                 assert.equal(capturedWSStates.includes('connecting'), true);
@@ -1688,7 +1690,9 @@ describe('replication-graphql.test.ts', () => {
 
                 replicationState.cancel();
 
-                await wait(300);
+                await waitUntil(() => {
+                    return capturedWSStates.length === 3;
+                });
 
                 assert.equal(capturedWSStates.includes('closed'), true);
                 assert.equal(capturedWSStates.includes('error'), false);


### PR DESCRIPTION
This PR contains:
 - IMPROVED typings
 - A NEW FEATURE

In our project we need more flexibility with replication subscription, particularly we want it to try reconnecting until the connection is established, even if server is not responding.
