### PR TITLE
FIX bulkInsert with primary keys set in preInsert hook broken in v15.38.3 #6599

### DIFF
--- a/src/rx-collection.ts
+++ b/src/rx-collection.ts
@@ -387,10 +387,10 @@ export class RxCollectionBase<
         if (this.hasHooks('pre', 'insert')) {
             insertRows = await Promise.all(
                 docsData.map(docData => {
-                    ids.add((docData as any)[primaryPath]);
                     const useDocData = fillObjectDataBeforeInsert(this.schema, docData);
                     return this._runHooks('pre', 'insert', useDocData)
                         .then(() => {
+                            ids.add((useDocData as any)[primaryPath]);
                             return { document: useDocData };
                         });
                 })
@@ -400,8 +400,8 @@ export class RxCollectionBase<
             const schema = this.schema;
             for (let index = 0; index < docsData.length; index++) {
                 const docData = docsData[index];
-                ids.add((docData as any)[primaryPath]);
                 const useDocData = fillObjectDataBeforeInsert(schema, docData);
+                ids.add((useDocData as any)[primaryPath]);
                 insertRows[index] = { document: useDocData };
             }
         }


### PR DESCRIPTION
Fixes #6599.

I also believe `fillObjectDataBeforeInsert` needs to be run before collecting primary keys, in case the primary key is set there.