### PR TITLE
Inserting without an optional index field causes unexpected behavior

### DIFF
--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -102,15 +102,14 @@ describe('bug-report.test.js', () => {
             }
         });
 
-        // find the document in the other tab
-        await collectionInOtherTab.mycollection.insert({
-            id: randomToken(12),
-        });
-
         /*
          * assert things,
          * here your tests should fail to show that there is a bug
          */
+        assert.equal(
+          await collections.mycollection.count().exec(),
+          1
+        );
         assert.equal(
           await collectionInOtherTab.mycollection.count().exec(),
           1


### PR DESCRIPTION
## This PR contains:
A BUG REPORT

## Describe the problem you have without this PR
Documents inserted with a (not required) empty index field behave unexpectedly

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

