### PR TITLE
Include RxDB version details in MongoDB handshake

### DIFF
--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -52,6 +52,7 @@ import {
     swapMongoToRxDoc,
     swapRxDocToMongo
 } from './mongodb-helper.ts';
+import { RXDB_VERSION } from '../utils/utils-rxdb-version.ts';
 
 export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
     RxDocType,
@@ -105,7 +106,7 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         const mongoOptions: any = {};
         mongoOptions.driverInfo = {
             name: 'RxDB',
-            version: 'X.Y.Z'
+            version: RXDB_VERSION
         };
         this.mongoClient = new MongoClient(storage.databaseSettings.connection, mongoOptions);
         this.mongoDatabase = this.mongoClient.db(databaseName + '-v' + this.schema.version);

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -101,7 +101,6 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         }
         this.primaryPath = getPrimaryFieldOfPrimaryKey(this.schema.primaryKey);
         this.inMongoPrimaryPath = this.primaryPath === '_id' ? MONGO_ID_SUBSTITUTE_FIELDNAME : this.primaryPath;
-
         
         const mongoOptions: any = {};
         mongoOptions.driverInfo = {

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -100,7 +100,14 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         }
         this.primaryPath = getPrimaryFieldOfPrimaryKey(this.schema.primaryKey);
         this.inMongoPrimaryPath = this.primaryPath === '_id' ? MONGO_ID_SUBSTITUTE_FIELDNAME : this.primaryPath;
-        this.mongoClient = new MongoClient(storage.databaseSettings.connection);
+
+        
+        const mongoOptions: any = {};
+        mongoOptions.driverInfo = {
+            name: 'RxDB',
+            version: 'X.Y.Z'
+        };
+        this.mongoClient = new MongoClient(storage.databaseSettings.connection, mongoOptions);
         this.mongoDatabase = this.mongoClient.db(databaseName + '-v' + this.schema.version);
 
         const indexes = (this.schema.indexes ? this.schema.indexes.slice() : []).map(index => {


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2024-01-27T23:10:40.108Z"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn16235","msg":"client metadata","attr":{"remote":"127.0.0.1:1094","client":"conn16235","doc":{"driver":{`"name":"nodejs|RxDB"`,`"version":"6.12.0|16.0.0"`},"platform":"Node.js v18.18.2, LE","os":{"name":"linux","architecture":"x64","version":"5.15.133+","type":"Linux"}}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

TODO
- [x] Add proper version RxDB version tracking (I'm not sure where to pull this from)