### PR TITLE
Allow connectionParams to be provided as part of wsOptions for replication-graphql

### DIFF
--- a/docs-src/docs/replication-graphql.md
+++ b/docs-src/docs/replication-graphql.md
@@ -333,7 +333,9 @@ const replicationState = replicateGraphQL(
             
             // Websocket options that can be passed as a parameter to initialize the subscription
             // Can be applied anything from the graphql-ws ClientOptions - https://the-guild.dev/graphql/ws/docs/interfaces/client.ClientOptions
-            // Excepting parameters: 'url', 'shouldRetry', 'webSocketImpl', 'connectionParams' - locked for the internal usage
+            // Except these parameters: 'url', 'shouldRetry', 'webSocketImpl' - locked for internal usage
+            // Note: if you provide connectionParams as a wsOption, make sure it returns any necessary headers (e.g. authorization)
+            // because providing your own connectionParams prevents headers from being included automatically
             wsOptions: { 
                 retryAttempts: 10,
             }

--- a/src/plugins/replication-graphql/graphql-websocket.ts
+++ b/src/plugins/replication-graphql/graphql-websocket.ts
@@ -24,12 +24,13 @@ export function getGraphQLWebSocket(
         GRAPHQL_WEBSOCKET_BY_URL,
         url,
         () => {
+            const connectionParamsHeaders = headers ? { headers } : undefined;
             const wsClient = createClient({
                 ...options,
                 url,
                 shouldRetry: () => true,
                 webSocketImpl: IsomorphicWebSocket,
-                connectionParams: headers ? { headers } : undefined,
+                connectionParams: options.connectionParams || connectionParamsHeaders,
             });
             return {
                 url,

--- a/src/types/plugins/replication-graphql.d.ts
+++ b/src/types/plugins/replication-graphql.d.ts
@@ -28,7 +28,7 @@ export type RxGraphQLReplicationPushQueryBuilder = (
     rows: RxReplicationWriteToMasterRow<any>[]
 ) => RxGraphQLReplicationQueryBuilderResponse;
 
-export type RxGraphQLPullWSOptions = Omit<ClientOptions, 'url' | 'shouldRetry' | 'webSocketImpl' | 'connectionParams'>;
+export type RxGraphQLPullWSOptions = Omit<ClientOptions, 'url' | 'shouldRetry' | 'webSocketImpl'>;
 
 export type RxGraphQLReplicationPullQueryBuilder<CheckpointType> = (
     latestPulledCheckpoint: CheckpointType | undefined,

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -1693,8 +1693,14 @@ describe('replication-graphql.test.ts', () => {
                                 },
                                 'error': () => {
                                     capturedWSStates.push('error');
-                                }
-                            }
+                                },
+                            },
+                            connectionParams: () => {
+                                capturedWSStates.push('connectionParams');
+                                return {
+                                    token: 'Bearer token'
+                                };
+                            },
                         },
                     },
                     headers: {
@@ -1709,18 +1715,19 @@ describe('replication-graphql.test.ts', () => {
                 await replicationState.awaitInitialReplication();
 
                 await waitUntil(() => {
-                    return capturedWSStates.length === 2;
+                    return capturedWSStates.length === 3;
                 });
 
                 assert.equal(capturedWSStates.includes('connected'), true);
                 assert.equal(capturedWSStates.includes('connecting'), true);
+                assert.equal(capturedWSStates.includes('connectionParams'), true);
                 assert.equal(capturedWSStates.includes('closed'), false);
                 assert.equal(capturedWSStates.includes('error'), false);
 
                 replicationState.cancel();
 
                 await waitUntil(() => {
-                    return capturedWSStates.length === 3;
+                    return capturedWSStates.length === 4;
                 });
 
                 assert.equal(capturedWSStates.includes('closed'), true);


### PR DESCRIPTION
## This PR contains:
A new feature: ability to provide a connectionParams function as part of wsOptions 

## Describe the problem you have without this PR
When opening a websocket for a graphql subscription, we need to provide authorization headers to authenticate. Currently, this works fine on the initial connection, but if the original token provided expires and graphql-ws needs to reconnect, there is currently no way to update the headers. Calling .setHeaders on the replicationState does not change the headers rxdb provides to graphql-ws when reconnecting.

To fix this issue, we need to be able to provide a connectionParams function which will ensure that a fresh access token can always be sent as part of the connection headers.
