### PR TITLE
Add test with graphql and sqlite storage

### DIFF
--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -24,7 +24,8 @@ import {
     ensureNotFalsy,
     RxReplicationWriteToMasterRow,
     ReplicationPullHandlerResult,
-    RxCollection
+    RxCollection,
+    addRxPlugin
 } from '../../plugins/core/index.mjs';
 
 import {
@@ -67,6 +68,8 @@ import {
 import { ReplicationPushHandlerResult, RxDocumentData } from '../../plugins/core/index.mjs';
 import { HumanWithTimestampDocumentType } from '../../src/plugins/test-utils/schema-objects.ts';
 import { normalizeString } from '../../plugins/utils/index.mjs';
+import { RxDBMigrationSchemaPlugin } from '../../plugins/migration-schema/index.mts';
+import { RxDBUpdatePlugin } from '../../plugins/update/index.mts';
 
 declare type WithDeleted<T> = T & { deleted: boolean; };
 
@@ -2895,6 +2898,132 @@ describe('replication-graphql.test.ts', () => {
 
                 c.database.close();
                 server.close();
+            });
+
+            it.only('should not leak _attachments when using a sqlite storage', async () => {
+                SpawnServer = await import('../helper/graphql-server.js');
+                const server = await SpawnServer.spawn();
+                addRxPlugin(RxDBMigrationSchemaPlugin);
+                addRxPlugin(RxDBUpdatePlugin);
+
+                const pushQueryBuilderWithAssert = (rows: RxReplicationWriteToMasterRow<HumanWithTimestampDocumentType>[]) => {
+                    if (!rows || rows.length === 0) {
+                        throw new Error('test pushQueryBuilder(): called with no docs');
+                    }
+                    const query = `
+                    mutation CreateHumans($writeRows: [HumanWriteRow!]) {
+                        writeHumans(writeRows: $writeRows) {
+                            id
+                            name
+                            age
+                            updatedAt
+                            deleted
+                        }
+                    }
+                    `;
+
+                    // It should fail when using a sqlite storage
+                    const firstRow = rows[0];
+                    if (firstRow.assumedMasterState) {
+                        console.log('in the _attachments assert');
+                        assert.strictEqual(firstRow.assumedMasterState._attachments, undefined);
+                    }
+
+                    const variables = {
+                        writeRows: rows
+                    };
+                    return Promise.resolve({
+                        query,
+                        operationName: 'CreateHumans',
+                        variables
+                    });
+                };
+
+                const dbName = randomToken(10);
+
+                // TODO : change the storage type for a sqlite. It should leak _attachments when applying the new migration
+                // I can't get a sqlite storage because I don't have access to the premium package
+                const storage = config.storage.getStorage();
+
+                const db = await createRxDatabase({
+                    name: dbName,
+                    storage,
+                    multiInstance: false,
+                    eventReduce: true,
+                });
+                const schema: RxJsonSchema<any> = clone(schemas.humanWithTimestampAllIndex);
+                const collections = await db.addCollections({
+                    humans: {
+                        schema,
+                    },
+                });
+
+                const collection = collections.humans;
+
+                // add one doc to the client database
+                const testData = getTestData(1).pop();
+                delete (testData as any).deleted;
+                await collection.insert(testData);
+
+                await db.close();
+                const db2 = await createRxDatabase({
+                    name: dbName,
+                    storage,
+                    multiInstance: false,
+                    eventReduce: true,
+                });
+
+                const schemaV2 = clone(schema);
+                schemaV2.version = 1;
+                const newCollection = await db2.addCollections({
+                    humans: {
+                        schema: schemaV2,
+                        autoMigrate: false,
+                        migrationStrategies: {
+                            1: (doc) => doc
+                        }
+                    },
+                });
+
+                // const server = await SpawnServer.spawn();
+                assert.strictEqual(server.getDocuments().length, 0);
+
+                // start live replication
+                const replicationState = replicateGraphQL({
+                    replicationIdentifier: randomToken(10),
+                    collection: newCollection.humans,
+                    url: server.url,
+                    push: {
+                        batchSize,
+                        queryBuilder: pushQueryBuilderWithAssert,
+                    },
+                    pull: {
+                        batchSize,
+                        queryBuilder: pullQueryBuilder,
+                    },
+                    live: true,
+                    deletedField: 'deleted'
+                });
+
+                ensureReplicationHasNoErrors(replicationState);
+                await replicationState.awaitInitialReplication();
+
+                // make sure the migration should be executed
+                assert.strictEqual(await newCollection.humans.migrationNeeded(), true);
+                await newCollection.humans.startMigration();
+
+                // Should sync in the replication ({assumedMasterState, newDocumentState})
+                await newCollection.humans.findOne({ selector: { id: testData?.id } }).update({ $set: {
+                        age: 12
+                    }
+                });
+
+                const graphQlData = server.getDocuments();
+                assert.strictEqual(graphQlData.length, 1);
+                assert.strictEqual(graphQlData._attachments, undefined);
+
+                await db2.close();
+                await server.close();
             });
         });
     });


### PR DESCRIPTION
this is a copy of pull request (https://github.com/pubkey/rxdb/pull/6782). This pull request uses RxDB 16 instead of 15.39. If possible, we would like the fix to be in 15.39.

## This PR contains:

A unit test that executes a migration on a database with a sqlite storage. Then a graphql server sends an update with leaked property (assumedMasterState contains the _attachments property). I wrote some comments in the test, because I don't have access to the premium package (RxStorageSQLite) in this repository.

When we use a different storage (e.g in memory or another default storage in the public package), the test passed. 

## Describe the problem you have without this PR

In our project, we use a RxDatabase with 
- a Sqlite storage (RxStorageSQLite from the premium package)
- a graphQL server to push updates to our backend

In one of our schemas, we add a new migration. when executed, it seems that the _attachments property is followed. When a user updates a property in an entity, the graphQL server push the update to our backend, causing an error in the serialization (input -> classes). 

![image](https://github.com/user-attachments/assets/69aac2e6-9032-480d-9f0a-b303a9650027)
  
Here is a payload of one of our shemas with the problem. In the entity's masterState, we can see that the _attachments property is leaked.

```
{
  "query": "mutation PushContractAgreements($pushRows: [PushRowContractAgreementInput!]!) {
    pushContractAgreements(contractAgreements: $pushRows) {
        id
        status
        date
        number
        lunchBreaks {
          from
          durationInMinutes
          startsOnNextDay
        }
        signature
        signedAt
        updatedAt
        isDeleted
    }
  }",
  "operationName": "PushContractAgreements",
  "variables": {
    "pushRows": [
      {
        "assumedMasterState": {
          "id": "c3fdbc58-4588-4fe4-a3b4-e0e5467e1d82",
          "status": "created",
          "date": "2025-01-23T12:00:00.000Z",
          "number": null,
          "lunchBreaks": [],
          "signature": null,
          "signedAt": null,
          "updatedAt": 1737640220258,
          "_attachments": {},
          "isDeleted": false
        },
        "newDocumentState": {
          "id": "c3fdbc58-4588-4fe4-a3b4-e0e5467e1d82",
          "status": "ongoing",
          "date": "2025-01-23T12:00:00.000Z",
          "number": null,
          "lunchBreaks": [],
          "signature": null,
          "signedAt": null,
          "updatedAt": 1737647944354,
          "isDeleted": false
        }
      }
    ]
  }
}

```

Here is our database setup 

 ```
db = await createRxDatabase<RxGuayCollections>({
      eventReduce: true,
      multiInstance: false,
      name: dbName,
      password: env.DATABASE_PASSWORD,
      storage: getRxStorageSQLite({
        sqliteBasics: getSQLiteBasicsExpoSQLiteAsync(ExpoSqliteStorageNext.openDatabaseAsync),
        // log: console.log.bind(console),
      }),
      ignoreDuplicate: isTest,
      cleanupPolicy: {
        minimumDeletedTime: 1000 * 60 * 60 * 24 * 31, // one month,
        minimumCollectionAge: 1000 * 60, // 60 seconds
        runEach: 1000 * 60 * 5, // 5 minutes
        awaitReplicationsInSync: true,
        waitForLeadership: false,
      },
      allowSlowCount: true,
    });

 db.addCollections({
      contract_agreement: {
        autoMigrate: true,
        migrationStrategies: {
          1: (doc: never): never => doc,
        },
        schema: {
          description: 'describes a contract agreement',
          keyCompression: true,
          primaryKey: 'id',
          indexes: ['updatedAt'],
          properties: {
            id: {
              maxLength: 100,
              type: 'string', // <- the primary key must have set maxLength
            },
            isDeleted: {
              type: 'boolean',
            },
            lunchBreaks: {
              items: {
                description: 'describes a time range',
                properties: {
                  from: {
                    type: 'string',
                  },
                  durationInMinutes: {
                    type: 'number',
                  },
                  startsOnNextDay: {
                    type: 'boolean',
                  },
                },
                type: 'object',
              },
              type: 'array',
            },
            number: {
              type: ['null', 'number'],
            },
            signature: {
              type: ['string', 'null'],
            },
            signedAt: {
              type: ['string', 'null'],
            },
            status: {
              type: 'string',
            },
            updatedAt: {
              type: 'number',
              minimum: 0,
              maximum: 99999999999999,
              multipleOf: 1,
            },
          },
          required: ['id', 'status'],
          title: 'Contract agreement schema',
          type: 'object',
          version: 1,
        },
      },
    });
```

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog