### PR TITLE
Added documentation for encryption, schema migrations, shared workers

### DIFF
--- a/docs-src/docs/encryption.md
+++ b/docs-src/docs/encryption.md
@@ -159,3 +159,9 @@ const mySchema = {
     }
 };
 ```
+
+## Encryption and workers
+
+If you are using [Worker RxStorage](./rx-storage-worker.md) or [SharedWorker RxStorage](./rx-storage-shared-worker.md) with encryption, it's recommended to run encryption inside of the worker. Encryption can be very cpu intensive and would take away CPU-power from the main thread which is the main reason to use workers.
+
+You do not need to worry about setting the password inside of the worker. The password will be set when calling createRxDatabase from the main thread, and will be passed internally to the storage in the worker automatically.

--- a/docs-src/docs/migration-schema.md
+++ b/docs-src/docs/migration-schema.md
@@ -213,3 +213,7 @@ Also the `migrationState.$` events are emitted between browser tabs.
 If you use any of the [RxReplication](./replication.md) plugins, the migration will also run on the internal replication-state storage. It will migrate all `assumedMasterState` documents
 so that after the migration is done, you do not have to re-run the replication from scratch.
 RxDB assumes that you run the exact same migration on the servers and the clients. Notice that the replication `pull-checkpoint` will not be migrated. Your backend must be compatible with pull-checkpoints of older versions.
+
+## Migration should be run on all database instances
+
+If you have multiple database instances (for example, if you are running replication inside of a [Worker](./rx-storage-worker.md) or [SharedWorker](./rx-storage-shared-worker.md) and have created a database instance inside of the worker), schema migration should be started on all database instances. All instances must know about all migration strategies and any updated schema versions.

--- a/docs-src/docs/rx-storage-shared-worker.md
+++ b/docs-src/docs/rx-storage-shared-worker.md
@@ -115,7 +115,7 @@ When you know that you only ever create your RxDatabase inside of the shared wor
 
 ## Replication with SharedWorker
 
-When a SharedWorker RxStorage is used, it is recommended to run the replication **inside** of the worker. You can do that by opening another [RxDatabase](./rx-database.md) inside of it and starting the replication there.
+When a SharedWorker RxStorage is used, it is recommended to run the replication **inside** of the worker. This is the best option for performance. You can do that by opening another [RxDatabase](./rx-database.md) inside of it and starting the replication there. If you are not concerned about performance, you can still start replication on the main thread instead. But you should never run replication on both the main thread **and** the worker.
 
 ```ts
 // shared-worker.ts


### PR DESCRIPTION
## This PR contains:
Improved documentation for encryption, schema migrations, and shared workers

## Describe the problem you have without this PR
The documentation was a little unclear on:
- where to run replication if you are using SharedWorker storage
- where to run encryption if you are using SharedWorker or Worker storage
- how to set the password for encryption if you are using SharedWorker or Worker storage
- where to run migrations if you are using SharedWorker or Worker storage
- 