### PR TITLE
Fix/notification popup

### DIFF
--- a/docs-src/src/theme/Root.tsx
+++ b/docs-src/src/theme/Root.tsx
@@ -112,11 +112,11 @@ const callToActions: CallToActionItem[] = [
 
 const POPUP_DISABLED_IF_CLOSED_TIME = 1000 * 60 * 10; // 10 minutes
 // const POPUP_DISABLED_IF_CLOSED_TIME = 1000 * 10; // 10 seconds
-function getPopupPeriod() {
-    const now = new Date().getTime();
-    const period = now - (now % POPUP_DISABLED_IF_CLOSED_TIME);
-    return 'notification_popup_closed_at_period_' + period;
-}
+// function getPopupPeriod() {
+//     const now = new Date().getTime();
+//     const period = now - (now % POPUP_DISABLED_IF_CLOSED_TIME);
+//     return 'notification_popup_closed_at_period_' + period;
+// }
 
 // Default implementation, that you can customize
 export default function Root({ children }) {
@@ -154,8 +154,8 @@ export default function Root({ children }) {
                  * we do not show it again for the POPUP_DISABLED_IF_CLOSED_TIME
                  * to ensure it does not annoy people.
                  */
-                const alreadyClosedThisPeriod = localStorage.getItem(getPopupPeriod());
-                if (alreadyClosedThisPeriod) {
+                const closedAt = localStorage.getItem('notification_popup_closed_at');
+                if (closedAt && Date.now() - Number(closedAt) < POPUP_DISABLED_IF_CLOSED_TIME) {
                     return null;
                 }
 
@@ -191,7 +191,7 @@ export default function Root({ children }) {
     function closePopup() {
         setShowPopup(undefined);
         document.title = document.title.replace(DOC_TITLE_PREFIX, '');
-        localStorage.setItem(getPopupPeriod(), '1');
+        localStorage.setItem('notification_popup_closed_at', Date.now().toString());
     }
     return <>
         {children}

--- a/docs-src/src/theme/Root.tsx
+++ b/docs-src/src/theme/Root.tsx
@@ -111,12 +111,6 @@ const callToActions: CallToActionItem[] = [
 
 
 const POPUP_DISABLED_IF_CLOSED_TIME = 1000 * 60 * 10; // 10 minutes
-// const POPUP_DISABLED_IF_CLOSED_TIME = 1000 * 10; // 10 seconds
-// function getPopupPeriod() {
-//     const now = new Date().getTime();
-//     const period = now - (now % POPUP_DISABLED_IF_CLOSED_TIME);
-//     return 'notification_popup_closed_at_period_' + period;
-// }
 
 // Default implementation, that you can customize
 export default function Root({ children }) {


### PR DESCRIPTION
Notification popup key was being stored with Date.getTime() embedded directly in the key. Unfortunately this won't work because every time a user refreshes the page or navigates to a new page, the Date.getTime() is different, and therefore localStorage is unable to find the entry for when the popup was closed, so it thinks that it hasn't happened yet.

Evidence of this is seeing dozens of notification_popup_closed_at values in the local storage
<img width="433" alt="Screenshot 2025-02-09 at 11 50 16" src="https://github.com/user-attachments/assets/50911ddf-eb5e-448a-9419-becc4fdd769d" />

To fix this, we can store the time as a value, we can simply look up the `notification_popup_closed_at` key, and then perform the comparison on the time instead.