### PR TITLE
Fix Firestore replication ignoring initialCheckpoint

### DIFF
--- a/src/plugins/replication-firestore/index.ts
+++ b/src/plugins/replication-firestore/index.ts
@@ -214,7 +214,8 @@ export function replicateFirestore<RxDocType>(
             },
             batchSize: ensureNotFalsy(options.pull).batchSize,
             modifier: ensureNotFalsy(options.pull).modifier,
-            stream$: pullStream$.asObservable()
+            stream$: pullStream$.asObservable(),
+            initialCheckpoint: options.pull.initialCheckpoint
         };
     }
 


### PR DESCRIPTION
## This PR contains:
- a bugfix for the Firestore replication ignoring the initialCheckpoint variable, causing a new replication to replicate all documents 


## Describe the problem you have without this PR
- Firestore replication useless if the collection you wanna replicate has many documents

## Todos 
- adding documentation for the initialCheckpoint variable to https://rxdb.info/replication-firestore.html

Example how to 'build' the initialCheckpoint variable, something you could put in the docs:

```
 // 1. Query Firestore for the "boundary" document.
    let initialCheckpoint: any = null;
    try {
      const q = query(
          collection(this.firestore, 'collection'), // Your Firestore collection
          where('serverTimestamp', '>=', twoMonthsAgo), // Filter: serverTimestamp>= 2 months ago
          orderBy('serverTimestamp', 'asc'), // Order by createdAt ascending
          limit(1) // Get only the first (oldest) matching document
      );
      const querySnapshot = await getDocs(q);

      if (!querySnapshot.empty) {
        // 2. Construct the initialCheckpoint.
        const docData = querySnapshot.docs[0].data();
        initialCheckpoint = {
          id: querySnapshot.docs[0].id,  // Document ID
          serverTimestamp: docData['serverTimestamp'].toDate().toISOString(), // Server timestamp
        };
        console.log("Calculated initialCheckpoint:", initialCheckpoint);
      } else {
        // No documents within the last two months.  Handle as needed.
        // Option 1: Start with no checkpoint (sync all)
        // initialCheckpoint = null;
        // Option 2:  Don't start replication, show a message, etc.
        console.log("No documents found within the last two months.");
        return; // Or handle appropriately
      }


    } catch (error) {
      console.error("Error querying Firestore:", error);
      return; // Handle the error appropriately
    }
```
