### PR TITLE
migration-schema docs: use non-deprecated subscribe signature

### DIFF
--- a/docs-src/docs/migration-schema.md
+++ b/docs-src/docs/migration-schema.md
@@ -131,11 +131,11 @@ messageCol.startMigration(10); // 10 is the batch-size, how many docs will run a
 const migrationState = messageCol.getMigrationState();
 
 // 'start' the observable
-migrationState.$.subscribe(
-  state => console.dir(state),
-  error => console.error(error),
-  done => console.log('done')
-);
+migrationState.$.subscribe({
+    next: state => console.dir(state),
+    error: error => console.error(error),
+    complete: () => console.log('done')
+});
 
 // the emitted states look like this:
 {


### PR DESCRIPTION
## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR

The example code in the doc use a deprecated signature for rxjs subscribe, this PR replace it with the new version.

I looked for other instances of the deprecated signature being used and couldn't find any

