### PR TITLE
Fix foundationdb premium task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
       - name: pre-pull foundationdb docker images
         # ensure it has downloaded the image
         run: |
-          docker pull foundationdb/foundationdb:7.3.23
+          docker pull foundationdb/foundationdb:7.3.59
 
       - name: install FoundationDB client and server
         working-directory: ./scripts
@@ -254,7 +254,7 @@ jobs:
       - name: install npm dependencies
         run: npm install
 
-      - run: npm install foundationdb@1.1.4
+      - run: npm install foundationdb@2.0.1
 
       - name: build
         run: npm run build

--- a/docs-src/docs/rx-storage-foundationdb.md
+++ b/docs-src/docs/rx-storage-foundationdb.md
@@ -25,7 +25,7 @@ Using RxDB on top of FoundationDB, gives you many benefits compare to using the 
 ## Installation
 
 - Install the [FoundationDB client cli](https://apple.github.io/foundationdb/getting-started-linux.html) which is used to communicate with the FoundationDB cluster.
-- Install the [FoundationDB node bindings npm module](https://www.npmjs.com/package/foundationdb) via `npm install foundationdb --save`. If the latest version does not work for you, you should use the same version as stated in the `storage-foundationdb` job of the RxDB CI `main.yml`.
+- Install the [FoundationDB node bindings npm module](https://www.npmjs.com/package/foundationdb) via `npm install foundationdb`. This will install `v2.x.x`, which is only compatible with FoundationDB server and client `v7.3.x` (which is the only version currently maintained by the FoundationDB team). If you need to use an older version (e.g. `7.1.x` or `6.3.x`), you should run `npm install foundationdb@1.1.4` (though this might only work with `v6.3.x`).
 
 
 ## Usage

--- a/docs-src/docs/rx-storage-foundationdb.md
+++ b/docs-src/docs/rx-storage-foundationdb.md
@@ -26,6 +26,7 @@ Using RxDB on top of FoundationDB, gives you many benefits compare to using the 
 
 - Install the [FoundationDB client cli](https://apple.github.io/foundationdb/getting-started-linux.html) which is used to communicate with the FoundationDB cluster.
 - Install the [FoundationDB node bindings npm module](https://www.npmjs.com/package/foundationdb) via `npm install foundationdb`. This will install `v2.x.x`, which is only compatible with FoundationDB server and client `v7.3.x` (which is the only version currently maintained by the FoundationDB team). If you need to use an older version (e.g. `7.1.x` or `6.3.x`), you should run `npm install foundationdb@1.1.4` (though this might only work with `v6.3.x`).
+- Due to an outstanding bug in node foundationdb, you will need to specify an `apiVersion` of `720` even though you are using `730`. When [this PR](https://github.com/josephg/node-foundationdb/pull/86) is merged, you will be able to use `730`.
 
 
 ## Usage
@@ -45,9 +46,9 @@ const db = await createRxDatabase({
          * Version of the API of the FoundationDB cluster..
          * FoundationDB is backwards compatible across a wide range of versions,
          * so you have to specify the api version.
-         * If in doubt, set it to 620.
+         * If in doubt, set it to 720.
          */
-        apiVersion: 620,
+        apiVersion: 720,
         /**
          * Path to the FoundationDB cluster file.
          * (optional)

--- a/scripts/install-foundationdb.sh
+++ b/scripts/install-foundationdb.sh
@@ -2,13 +2,13 @@
 set -e
 
 echo "# installing FoundationDB client:"
-wget -O foundationdb-client.deb https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-clients_6.3.23-1_amd64.deb
+wget -O foundationdb-client.deb https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-clients_7.3.59-1_amd64.deb
 sudo dpkg -i foundationdb-client.deb
 rm foundationdb-client.deb
 
 
 echo "# installing FoundationDB server:"
-wget -O foundationdb-server.deb https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-server_6.3.23-1_amd64.deb
+wget -O foundationdb-server.deb https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-server_7.3.59-1_amd64.deb
 sudo dpkg -i foundationdb-server.deb
 rm foundationdb-server.deb
 

--- a/test/unit/config.ts
+++ b/test/unit/config.ts
@@ -150,7 +150,7 @@ export function getStorage(storageKey: string): RxTestStorage {
             };
             break;
         case 'foundationdb':
-            const foundationDBAPIVersion = 630;
+            const foundationDBAPIVersion = 720;
 
 
             let getStorageFnFoundation: any;


### PR DESCRIPTION
FIxing the premium task for upgrading node-foundationdb to v2.0.1.

Local testing suggests that the only thing that is necessary is installing foundationdb client and server v7.3.xx. You can then specify any apiVersion _except_ 730. 

Ive opened an issue at node-foundationdb about this https://github.com/josephg/node-foundationdb/issues/85

Hopefully the tests will pass with this PR