### PR TITLE
Draft: Turn off node integration

### DIFF
--- a/docs-src/docs/electron.md
+++ b/docs-src/docs/electron.md
@@ -17,10 +17,6 @@ To use RxDB in [electron](./electron-database.md), it is recommended to run the 
 To do this in a convenient way, the RxDB electron plugin provides the helper functions `exposeIpcMainRxStorage` and `getRxStorageIpcRenderer`.
 Similar to the [Worker RxStorage](./rx-storage-worker.md), these wrap any other [RxStorage](./rx-storage.md) once in the main process and once in each renderer process. In the renderer you can then use the storage to create a [RxDatabase](./rx-database.md) which communicates with the storage of the main process to store and query data.
 
-:::note
-`nodeIntegration` must be enabled in [Electron](https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions).
-:::
-
 ```ts
 //  main.js
 const { exposeIpcMainRxStorage } = require('rxdb/plugins/electron');

--- a/examples/electron/.gitignore
+++ b/examples/electron/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 log.txt
 config.json
 /rxdb-local.tgz
+/dist

--- a/examples/electron/index.html
+++ b/examples/electron/index.html
@@ -18,5 +18,5 @@
         <button onclick="addHero();" id="input-submit">Insert</button>
     </div>
   </body>
-  <script src="renderer.js"></script>
+  <script src="dist/bundle.js"></script>
 </html>

--- a/examples/electron/main.js
+++ b/examples/electron/main.js
@@ -24,8 +24,8 @@ function createWindow() {
         width,
         height,
         webPreferences: {
-            contextIsolation: false,
-            nodeIntegration: true,
+            contextIsolation: true,
+            nodeIntegration: false,
             preload: path.join(__dirname, 'preload.js')
         }
     });

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "preinstall": "npm run preinstall:rxdb",
     "preinstall:rxdb": "(cd ../../ && npx yarn@1.22.22 pack ../../ --filename ./examples/electron/rxdb-local.tgz)",
-    "start": "npm run electron",
+    "start": "npm run build && npm run electron",
     "electron": "electron . -enable-logging",
-    "test": "mocha"
+    "test": "mocha",
+    "build": "webpack"
   },
   "//": "NOTICE: For the Github CI we use the local RxDB build (rxdb-local.tgz). In your app should just install 'rxdb' from npm instead",
   "dependencies": {
@@ -18,6 +19,8 @@
   },
   "devDependencies": {
     "mocha": "11.1.0",
-    "playwright-core": "1.50.1"
+    "playwright-core": "1.50.1",
+    "webpack": "^5.98.0",
+    "webpack-cli": "^6.0.1"
   }
 }

--- a/examples/electron/webpack.config.js
+++ b/examples/electron/webpack.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+    entry: './renderer.js',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+    },
+    mode: 'development',
+    target: 'electron-renderer',
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-env'],
+                    },
+                },
+            },
+        ],
+    },
+};


### PR DESCRIPTION
## This PR contains:
A demonstration that nodeIntegration can be false (and contextIsolation can be true) when using RxDB in Electron.
It seems that one reason (hopefully the only reason) it is set to true today is because of the way node_modules are being imported in the renderer.js code. Adding webpack seems to let me turn off nodeIntegration and the example still works.
Can someone more familiar with the RxDB take a look and determine if this is correct?

## Describe the problem you have without this PR
There are warnings in the Electron docs against enabling nodeIntegration and disabling contextIsolation: https://www.electronjs.org/docs/latest/tutorial/security

