### PR TITLE
feat: db8 error handling

### DIFF
--- a/dist/types/plugins/dev-mode/error-messages.d.ts
+++ b/dist/types/plugins/dev-mode/error-messages.d.ts
@@ -43,7 +43,6 @@ export declare const ERROR_MESSAGES: {
     DB4: string;
     DB5: string;
     DB6: string;
-    DB8: string;
     DB9: string;
     DB11: string;
     DB12: string;

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -70,9 +70,9 @@ export const ERROR_MESSAGES = {
     DB5: 'RxDatabase.addCollections(): collection-name not allowed',
     DB6: 'RxDatabase.addCollections(): another instance created this collection with a different schema. Read this https://rxdb.info/questions-answers.html?console=qa#cant-change-the-schema ',
     // removed in 13.0.0 (now part of the encryption plugin) DB7: 'RxDatabase.addCollections(): schema encrypted but no password given',
-    DB8: 'createRxDatabase(): A RxDatabase with the same name and adapter already exists.\n' +
-        'Make sure to use this combination only once or set ignoreDuplicate to true if you do this intentional-\n' +
-        'This often happens in react projects with hot reload that reloads the code without reloading the process.',
+    // removed in xxxx (new instances wait for old instances to close) DB8: 'createRxDatabase(): A RxDatabase with the same name and adapter already exists.\n' +
+    //    'Make sure to use this combination only once or set ignoreDuplicate to true if you do this intentional-\n' +
+    //    'This often happens in react projects with hot reload that reloads the code without reloading the process.',
     DB9: 'ignoreDuplicate is only allowed in dev-mode and must never be used in production',
     // removed in 14.0.0 - PouchDB RxStorage is removed - DB9: 'createRxDatabase(): Adapter not added. Use addPouchPlugin(require(\'pouchdb-adapter-[adaptername]\'));',
     // removed in 14.0.0 - PouchDB RxStorage is removed DB10: 'createRxDatabase(): To use leveldown-adapters, you have to add the leveldb-plugin. Use addPouchPlugin(require(\'pouchdb-adapter-leveldb\'));',

--- a/test/unit/rx-database.test.ts
+++ b/test/unit/rx-database.test.ts
@@ -212,19 +212,51 @@ describeParallel('rx-database.test.ts', () => {
             });
             it('do not allow 2 databases with same name and storage', async () => {
                 const name = randomToken(10);
-                const db = await createRxDatabase({
+                const storage = config.storage.getStorage();
+
+                let db1: RxDatabase | undefined;
+                let db2: RxDatabase | undefined;
+
+                const db1Promise = createRxDatabase({
                     name,
-                    storage: config.storage.getStorage()
+                    storage,
+                }).then((db1PromiseValue) => {
+                    db1 = db1PromiseValue;
+                    assert.ok(db2 === undefined);
+
+                    setTimeout(() => {
+                        db1PromiseValue.close();
+                    }, 500);
+
+                    return db1PromiseValue;
                 });
-                await AsyncTestUtil.assertThrows(
-                    () => createRxDatabase({
-                        name,
-                        storage: config.storage.getStorage()
-                    }),
-                    'RxError',
-                    'ignoreDuplicate'
-                );
-                db.close();
+                const db2Promise = createRxDatabase({
+                    name,
+                    storage,
+                }).then((db2PromiseValue) => {
+                    db2 = db2PromiseValue;
+                    assert.ok(db1?.closed);
+
+                    return db2PromiseValue;
+                });
+
+
+                const resolvedDb1 = await db1Promise;
+                const resolvedDb2 = await db2Promise;
+
+                assert.ok(resolvedDb1.closed);
+                assert.ok(!resolvedDb2.closed);
+
+                resolvedDb2.close();
+
+                const db3 = await createRxDatabase({
+                    name,
+                    storage,
+                });
+
+                assert.ok(!db3.closed);
+
+                db3.close();
             });
         });
     });


### PR DESCRIPTION
## This PR contains:
 - A NEW FEATURE
 - A BREAKING CHANGE (kind of?)

## Describe the problem you have without this PR
The problem is described and discussed here: https://github.com/pubkey/rxdb/issues/6988

This PR makes the `DB8` erro obsolete because a new instance with the same db-name and storage will only initialize when no other with the same combination exists:

```js
const db1Promise = createRxDatabase({ name, storage });
const db2Promise = createRxDatabase({ name, storage }); // this promise will only resolve once db1 is closed and db2 is fully initialized
```

In the issue above I've also mentioned to implement a `AbortSignal` parameter which is not contained in this PR yet as I want to first wait for feedback.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Typings
- [ ] Changelog

