### PR TITLE
Mention required parameters for firestore replicateFirestore

### DIFF
--- a/docs-src/docs/replication-firestore.md
+++ b/docs-src/docs/replication-firestore.md
@@ -57,6 +57,11 @@ const replicationState = replicateFirestore(
             database: firestoreDatabase,
             collection: firestoreCollection
         },
+        /**
+         * (required) Enable push and pull replication with firestore by
+         * providing an object with optional filter for each type of replication desired.
+         * [default=disabled]
+         */
         pull: {},
         push: {},
         /**


### PR DESCRIPTION
## This PR contains: 

 - IMPROVED DOCS

## Describe the problem you have without this PR

Update the `replicateFirestore` documentation to emphasize that the options require `push` and `pull` to be present as empty objects (or with an optional `filter` member) to enable those types of replication.

