### PR TITLE
MigrationStrategies type not generic

### DIFF
--- a/src/types/plugins/migration.d.ts
+++ b/src/types/plugins/migration.d.ts
@@ -9,6 +9,6 @@ export type MigrationStrategy<DocData = any> = (
     collection: RxCollection
 ) => MaybePromise<WithAttachments<DocData> | null>;
 
-export type MigrationStrategies = {
-    [toVersion: number]: MigrationStrategy<any>;
+export type MigrationStrategies<DocData = any> = {
+    [toVersion: number]: MigrationStrategy<DocData>;
 };


### PR DESCRIPTION
## This PR contains:
 - IMPROVED typings

## Describe the problem you have without this PR

The `MigrationStrategy` uses a generic type. When using the `MigrationStrategies` this is set to `any`. This PR makes it able to set the type of `MigrationStrategy` even when using `MigrationStrategies`.

This will allow us to enforce a type as the param type for each migration, if we set it correctly once, it will be correct for all


