### PR TITLE
fix toggleOnDocumentVisible isVisible not always truthy

### DIFF
--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -422,14 +422,11 @@ export class RxReplicationState<RxDocType, CheckpointType> {
     }
 
     isPaused(): boolean {
-        return this.internalReplicationState ? this.internalReplicationState.events.paused.getValue() : false;
+        return !!(this.internalReplicationState && this.internalReplicationState.events.paused.getValue());
     }
 
     isStopped(): boolean {
-        if (this.subjects.canceled.getValue()) {
-            return true;
-        }
-        return false;
+        return !!this.subjects.canceled.getValue();
     }
 
     isStoppedOrPaused() {
@@ -585,7 +582,7 @@ export function replicateRxCollection<RxDocType, CheckpointType>(
             if (replicationState.isStopped()) {
                 return;
             }
-            const isVisible = document.visibilityState;
+            const isVisible = document.visibilityState === 'visible';
             if (isVisible) {
                 replicationState.start();
             } else {


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
When the `toggleOnDocumentVisible` flag was `true` our app started hanging on Safari iOS, further explanation can be found [here](https://github.com/pubkey/rxdb/issues/6810#issuecomment-2815932461) and [here](https://github.com/pubkey/rxdb/issues/6810#issuecomment-2816648422).

I firmly believe that `replicationState.start()` also has some side-effects which cause this problem to even happen.

This PR only fixes the `visibilitychange` event handler, so that it is not only starting the replication, since `document.visibilityState` is a string and not a boolean.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

