### PR TITLE
fix get nested values after change from other state

### DIFF
--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -96,7 +96,8 @@ export class RxStateBase<T, Reactivity = unknown> {
                             event.operation === 'INSERT' &&
                             event.documentData.sId !== this._instanceId
                         ) {
-                            mergeOperationsIntoState(this._state, event.documentData.ops);
+                            const new_state = mergeOperationsIntoState(this._state, event.documentData.ops);
+                            this._state = new_state;
                         }
                     }
                 })
@@ -314,7 +315,8 @@ export async function createRxState<T>(
         } else {
             for (let index = 0; index < documents.length; index++) {
                 const document = documents[index];
-                mergeOperationsIntoState(rxState._state, document.ops);
+                const newState = mergeOperationsIntoState(rxState._state, document.ops);
+                rxState._state = newState;
             }
         }
     }
@@ -364,9 +366,17 @@ export async function createRxState<T>(
 export function mergeOperationsIntoState<T>(
     state: T,
     operations: RxStateOperation[]
-) {
+): T {
+    let newState = clone(state);
     for (let index = 0; index < operations.length; index++) {
         const operation = operations[index];
-        setProperty(state, operation.k, clone(operation.v));
+        const path = operation.k;
+        const newValue = operation.v;
+        if (path === '') {
+            newState = clone(newValue);
+        } else {
+            setProperty(newState, path, newValue);
+        }
     }
+    return newState;
 }

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -181,6 +181,26 @@ addRxPlugin(RxDBJsonDumpPlugin);
                 assert.strictEqual(state.get('foo'), 'bar2');
                 state.collection.database.remove();
             });
+            it('should get nested values after change from other state', async () => {
+                const token = randomToken(10);
+                const state = await getState(token);
+                const state2 = await getState(token);
+
+                await state.set('nes', () => {
+                    return { ted: 'foo' };
+                });
+                assert.deepStrictEqual(state.nes, { ted: 'foo' });
+                assert.deepStrictEqual(state.get('nes'), { ted: 'foo' });
+                assert.deepStrictEqual(state.get('nes.ted'), 'foo');
+
+                await state2.set('nes.ted', () => 'foo2');
+                assert.deepStrictEqual(state.nes, { ted: 'foo2' });
+                assert.deepStrictEqual(state.get('nes'), { ted: 'foo2' });
+                assert.deepStrictEqual(state.get('nes.ted'), 'foo2');
+
+                state.collection.database.remove();
+                state2.collection.database.remove();
+            });
             it('should get nested values', async () => {
                 const state = await getState();
                 await state.set('nes', () => {


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  - DO NOT COMMIT FILES FROM THE ./dist OR ./docs FOLDERS;
    THESE CONTAIN GENERATED FILES THAT SHOULD NOT BE EDITED MANUALLY.
  - EACH CHANGE TO THE SOURCE CODE, REQUIRES AT LEAST ONE TEST
    THAT COVERS THE CHANGE IN BEHAVIOR.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
<!--
 - IMPROVED DOCS
 - IMPROVED TESTS
 - IMPROVED typings
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->
1. a test case to reproduce
2. fix issue
## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
get nested values after change from other state will get follow errors
```bash
  1) rx-state.test.ts (useSchemaValidator: true)
       .get()
         should get nested values after change from other state:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  {
+   ted: 'foo'
-   ted: 'foo2'
  }

      + expected - actual

       {
      -  "ted": "foo"
      +  "ted": "foo2"
       }
      
      at Context.<anonymous> (file:///home/runner/work/rxdb/rxdb/test/unit/rx-state.test.ts:197:24)

```
[the ci result](https://github.com/kryon-7/rxdb/actions/runs/14567987733)


