### PR TITLE
state get changes from other state will get error

### DIFF
--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -96,7 +96,7 @@ export class RxStateBase<T, Reactivity = unknown> {
                             event.operation === 'INSERT' &&
                             event.documentData.sId !== this._instanceId
                         ) {
-                            mergeOperationsIntoState(this._state, event.documentData.ops);
+                            this.mergeOperationsIntoState(event.documentData.ops);
                         }
                     }
                 })
@@ -193,6 +193,20 @@ export class RxStateBase<T, Reactivity = unknown> {
         return this._writeQueue;
     }
 
+    mergeOperationsIntoState(
+        operations: RxStateOperation[]
+    ) {
+        let state = clone(this._state);
+        for (let index = 0; index < operations.length; index++) {
+            const operation = operations[index];
+            if (operation.k === '') {
+                state = clone(operation.v);
+            } else {
+                setProperty(state, operation.k, clone(operation.v));
+            }
+        }
+        this._state = state;
+    }
     get(path?: Paths<T>) {
         let ret;
         if (!path) {

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -130,25 +130,6 @@ addRxPlugin(RxDBJsonDumpPlugin);
                 assert.strictEqual(state.get('a'), 10);
                 state.collection.database.remove();
             });
-            it('get changes from other state', async () => {
-                const databaseName = randomToken(10);
-                const state1 = await getState(databaseName);
-                const state2 = await getState(databaseName);
-                await state1.set('nes', () => {
-                    return { ted: 'foo' };
-                });
-
-                await waitUntil(() => state1.nes?.ted === 'foo');
-                await waitUntil(() => state2.nes?.ted === 'foo');
-
-                await state2.set('nes.ted', () => 'foo2');
-
-                await waitUntil(() => state1.nes?.ted === 'foo2');
-                await waitUntil(() => state2.nes?.ted === 'foo2');
-
-                state1.collection.database.close();
-                state2.collection.database.close();
-            });
             it('update nested', async () => {
                 const state = await getState();
                 await state.set('nes', () => {
@@ -372,6 +353,25 @@ addRxPlugin(RxDBJsonDumpPlugin);
                     state1.set('nes.ted', () => 'foo2'),
                     state2.set('nes.ted', () => 'foo2')
                 ]);
+
+                await waitUntil(() => state1.nes?.ted === 'foo2');
+                await waitUntil(() => state2.nes?.ted === 'foo2');
+
+                state1.collection.database.close();
+                state2.collection.database.close();
+            });
+            it('get changes from other state', async () => {
+                const databaseName = randomToken(10);
+                const state1 = await getState(databaseName);
+                const state2 = await getState(databaseName);
+                await state1.set('nes', () => {
+                    return { ted: 'foo' };
+                });
+
+                await waitUntil(() => state1.nes?.ted === 'foo');
+                await waitUntil(() => state2.nes?.ted === 'foo');
+
+                await state2.set('nes.ted', () => 'foo2');
 
                 await waitUntil(() => state1.nes?.ted === 'foo2');
                 await waitUntil(() => state2.nes?.ted === 'foo2');

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -130,6 +130,25 @@ addRxPlugin(RxDBJsonDumpPlugin);
                 assert.strictEqual(state.get('a'), 10);
                 state.collection.database.remove();
             });
+            it('get changes from other state', async () => {
+                const databaseName = randomToken(10);
+                const state1 = await getState(databaseName);
+                const state2 = await getState(databaseName);
+                await state1.set('nes', () => {
+                    return { ted: 'foo' };
+                });
+
+                await waitUntil(() => state1.nes?.ted === 'foo');
+                await waitUntil(() => state2.nes?.ted === 'foo');
+
+                await state2.set('nes.ted', () => 'foo2');
+
+                await waitUntil(() => state1.nes?.ted === 'foo2');
+                await waitUntil(() => state2.nes?.ted === 'foo2');
+
+                state1.collection.database.close();
+                state2.collection.database.close();
+            });
             it('update nested', async () => {
                 const state = await getState();
                 await state.set('nes', () => {


### PR DESCRIPTION
## This PR contains:

1. a test case to reproduce
2. fix issue
## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
state get changes from other states will get follow errors. it cannot set correct state because devmode
```bash

      AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  {
+   ted: 'foo'
-   ted: 'foo2'
  }

      + expected - actual

       {
      -  "ted": "foo"
      +  "ted": "foo2"
       }
      
```
[the ci result](https://github.com/kryon-7/rxdb/actions/runs/14568603267)


