### PR TITLE
FIX type of SimplePeerConnectionHandlerOptions.webSocketConstructor

### DIFF
--- a/src/plugins/replication-webrtc/connection-handler-simple-peer.ts
+++ b/src/plugins/replication-webrtc/connection-handler-simple-peer.ts
@@ -87,7 +87,7 @@ export type SimplePeerConnectionHandlerOptions = {
     signalingServerUrl?: string;
     wrtc?: SimplePeerWrtc;
     config?: SimplePeerConfig;
-    webSocketConstructor?: WebSocket;
+    webSocketConstructor?: new (url: string, protocols?: string | string[] | undefined) => WebSocket;
 };
 
 export const SIMPLE_PEER_PING_INTERVAL = 1000 * 60 * 2;


### PR DESCRIPTION
## This PR contains:
A fix of the typing of SimplePeerConnectionHandlerOptions.webSocketConstructor.

## Describe the problem you have without this PR
Without this change the expected type is a WebSocket instance, not the constuctor.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

