### PR TITLE
fixed query hanging after local document inserted

### DIFF
--- a/src/plugins/pipeline/rx-pipeline.ts
+++ b/src/plugins/pipeline/rx-pipeline.ts
@@ -76,7 +76,9 @@ export class RxPipeline<RxDocType> {
         this.source.onClose.push(() => this.close());
         this.destination.awaitBeforeReads.add(this.waitBeforeWriteFn);
         this.subs.push(
-            this.source.eventBulks$.subscribe((bulk) => {
+            this.source.eventBulks$.pipe(
+                filter(bulk => !this.stopped && !bulk.isLocal)
+            ).subscribe((bulk) => {
                 this.lastSourceDocTime.next(bulk.events[0].documentData._meta.lwt);
                 this.somethingChanged.next({});
             })


### PR DESCRIPTION
## This PR contains:
a bugfix and test for it

## Describe the problem you have without this PR
When all the incoming documents have been handled by pipeline if localDocument gets inserted pipeline never unlocks query to execute over destination collection. 

