### PR TITLE
Fix patch and incremental patch for nested values

### DIFF
--- a/package.json
+++ b/package.json
@@ -511,6 +511,7 @@
     "mingo": "6.5.6",
     "mongodb": "6.20.0",
     "nats": "2.29.3",
+    "object-deep-merge": "1.0.5",
     "oblivious-set": "1.4.0",
     "reconnecting-websocket": "4.4.0",
     "simple-peer": "9.11.1",

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -41,6 +41,8 @@ import { getSchemaByObjectPath } from './rx-schema-helper.ts';
 import { getWrittenDocumentsFromBulkWriteResponse, throwIfIsStorageWriteError } from './rx-storage-helper.ts';
 import { modifierFromPublicToInternal } from './incremental-write.ts';
 
+import { merge } from 'object-deep-merge';
+
 export const basePrototype = {
     get primaryPath() {
         const _this: RxDocument = this as any;
@@ -301,12 +303,7 @@ export const basePrototype = {
         patch: Partial<RxDocType>
     ) {
         const oldData = this._data;
-        const newData = clone(oldData);
-        Object
-            .entries(patch)
-            .forEach(([k, v]) => {
-                (newData as any)[k] = v;
-            });
+        const newData = merge(clone(oldData), patch);
         return this._saveData(newData, oldData);
     },
 
@@ -318,12 +315,7 @@ export const basePrototype = {
         patch: Partial<RxDocumentType>
     ): Promise<RxDocument<RxDocumentType>> {
         return this.incrementalModify((docData) => {
-            Object
-                .entries(patch)
-                .forEach(([k, v]) => {
-                    (docData as any)[k] = v;
-                });
-            return docData;
+            return merge(docData, patch);
         });
     },
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -70,3 +70,5 @@ import './unit/import-export.test.ts';
 import './unit/database-lifecycle.ts';
 import './unit/plugin.test.ts';
 import './unit/last.test.ts';
+import './unit/deep-incremental-patch.test.ts';
+

--- a/test/unit/deep-incremental-patch.test.ts
+++ b/test/unit/deep-incremental-patch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests that `patch` and `incrementalPatch` can patch objects with deeply nested values without splicing out other values.
+ */
+import assert from 'assert';
+import AsyncTestUtil from 'async-test-util';
+import config from './config.ts';
+
+import {
+    createRxDatabase,
+    randomToken
+} from '../../plugins/core/index.mjs';
+
+describe('deep-incremental-patch.test.js', () => {
+    it('should incrementally patch deeply nested values without splicing out other value', async function () {
+        if (!config.storage.hasMultiInstance) {
+            return;
+        }
+
+        // create a schema
+        const mySchema = {
+            version: 0,
+            primaryKey: 'passportId',
+            type: 'object',
+            properties: {
+                passportId: {
+                    type: 'string',
+                    maxLength: 100
+                },
+                data: {
+                    type: 'object',
+                    properties: {
+                        firstName: {
+                            type: 'string'
+                        },
+                        lastName: {
+                            type: 'string'
+                        },
+                        age: {
+                            type: 'integer',
+                            minimum: 0,
+                            maximum: 150
+                        },
+                        deep: {
+                            type: 'object',
+                            properties: {
+                                value: {
+                                    type: 'boolean'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        /**
+         * Always generate a random database-name
+         * to ensure that different test runs do not affect each other.
+         */
+        const name = randomToken(10);
+
+        // create a database
+        const db = await createRxDatabase({
+            name,
+            /**
+             * By calling config.storage.getStorage(),
+             * we can ensure that all variations of RxStorage are tested in the CI.
+             */
+            storage: config.storage.getStorage(),
+            eventReduce: true,
+            ignoreDuplicate: true
+        });
+        // create a collection
+        const collections = await db.addCollections({
+            mycollection: {
+                schema: mySchema
+            }
+        });
+
+        // insert a document
+        await collections.mycollection.insert({
+            passportId: 'foobar',
+            data: {
+                firstName: 'Bob',
+                lastName: 'Kelso',
+                age: 56,
+                deep: {
+                    value: true
+                }
+            }
+
+        });
+
+        /**
+         * to simulate the event-propagation over multiple browser-tabs,
+         * we create the same database again
+         */
+        const dbInOtherTab = await createRxDatabase({
+            name,
+            storage: config.storage.getStorage(),
+            eventReduce: true,
+            ignoreDuplicate: true
+        });
+        // create a collection
+        const collectionInOtherTab = await dbInOtherTab.addCollections({
+            mycollection: {
+                schema: mySchema
+            }
+        });
+
+        // find the document in the other tab
+        let myDocument = await collectionInOtherTab.mycollection
+            .findOne()
+            .where('passportId')
+            .eq('foobar')
+            .exec();
+
+        myDocument = await myDocument.incrementalPatch({
+            data: {
+                firstName: 'RxDb Developer'
+            }
+        });
+
+        /*
+         * assert things,
+         * here your tests should fail to show that there is a bug
+         */
+        assert.strictEqual(myDocument.data.firstName, 'RxDb Developer');
+
+        // These would fail pre-change.
+        assert.strictEqual(myDocument.data.lastName, 'Kelso');
+        assert.strictEqual(myDocument.data.age, 56);
+        assert.strictEqual(myDocument.data.deep.value, true);
+
+
+        myDocument = await myDocument.patch({
+            data: {
+                deep: {
+                    value: false
+                }
+            }
+        });
+        assert.strictEqual(myDocument.data.deep.value, false);
+
+        // These would fail pre-change.
+        assert.strictEqual(myDocument.data.firstName, 'RxDb Developer');
+        assert.strictEqual(myDocument.data.lastName, 'Kelso');
+        assert.strictEqual(myDocument.data.age, 56);
+
+
+
+        // you can also wait for events
+        const emitted: any[] = [];
+        const sub = collectionInOtherTab.mycollection
+            .findOne().$
+            .subscribe(doc => {
+                emitted.push(doc);
+            });
+        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
+
+        // clean up afterwards
+        sub.unsubscribe();
+        db.close();
+        dbInOtherTab.close();
+    });
+});


### PR DESCRIPTION
## This PR contains:
 - An updated implementation of `patch` and `incrementalPatch`
 - A new third patty dependency https://www.npmjs.com/package/object-deep-merge
 - Supporting tests.
 
 This PR contains 2 commits that;
1.   Recreate the bug
2.  Fix the bug


## Describe the problem you have without this PR
[patch`and incrementalPatch can splice out nested values](https://github.com/pubkey/rxdb/issues/7430)

## Todos 
- [ ] Tests
- [ ] Changelog

