### PR TITLE
Update transactions-conflicts-revisions.md

### DIFF
--- a/docs-src/docs/transactions-conflicts-revisions.md
+++ b/docs-src/docs/transactions-conflicts-revisions.md
@@ -51,7 +51,7 @@ A local conflict can happen when a write operation assumes a different previous 
 
 When a local conflict appears, RxDB will throw a `409 CONFLICT` error. The calling code must then handle the error properly, depending on the application logic.
 
-Instead of handling local conflicts, in most cases it is easier to ensure that they cannot happen, by using `incremental` database operations like [incrementalModify()](./rx-document.md), [incrementalPatch()](./rx-document.md) or [incrementalUpsert()](./rx-collection.md). These write operations have a build in way to handle conflicts by re-applying the mutation functions to the conflicting document state.
+Instead of handling local conflicts, in most cases it is easier to ensure that they cannot happen, by using `incremental` database operations like [incrementalModify()](./rx-document.md), [incrementalPatch()](./rx-document.md) or [incrementalUpsert()](./rx-collection.md). These write operations have a built-in way to handle conflicts by re-applying the mutation functions to the conflicting document state.
 
 ## Replication conflicts
 


### PR DESCRIPTION

## This PR contains:
 - IMPROVED DOCS


## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
The sentence has a small grammatical error, using "then" instead of "than"
Also changes "build in" to "built-in"