### PR TITLE
feat: replication-supabase querybuilder

### DIFF
--- a/docs-src/docs/replication-supabase.md
+++ b/docs-src/docs/replication-supabase.md
@@ -197,6 +197,12 @@ const replication = replicateSupabase({
       if (!doc.age) delete doc.age;
       return doc;
     }
+    // optional: customize the pull query before fetching
+    queryBuilder: ({ query }) => {
+      // Add filters, joins, or other PostgREST query modifiers
+      // This runs before checkpoint filtering and ordering
+      return query.eq("status", "active");
+    },
   },
   push: {
     batchSize: 50

--- a/src/plugins/replication-supabase/index.ts
+++ b/src/plugins/replication-supabase/index.ts
@@ -106,6 +106,18 @@ export function replicateSupabase<RxDocType>(
                 let query = options.client
                     .from(options.tableName)
                     .select('*');
+
+                if (options.pull?.queryBuilder) {
+                    const maybeNewQuery = options.pull.queryBuilder({
+                        query,
+                        lastPulledCheckpoint,
+                        batchSize,
+                    });
+                    if (maybeNewQuery) {
+                        query = maybeNewQuery;
+                    }
+                }
+
                 if (lastPulledCheckpoint) {
                     const { modified, id } = lastPulledCheckpoint;
 

--- a/src/plugins/replication-supabase/types.ts
+++ b/src/plugins/replication-supabase/types.ts
@@ -5,6 +5,20 @@ import type {
 } from '../../types';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+export type SupabasePullQueryBuilderParams = {
+    query: ReturnType<SupabaseClient['from']>['select'] extends (
+        ...args: any[]
+    ) => infer R
+        ? R
+        : never;
+    lastPulledCheckpoint: SupabaseCheckpoint | undefined;
+    batchSize: number;
+};
+
+export type SupabasePullQueryBuilder<RxDocType> = (
+    params: SupabasePullQueryBuilderParams
+) => SupabasePullQueryBuilderParams['query'] | void;
+
 export type SyncOptionsSupabase<RxDocType> = Omit<
     ReplicationOptions<RxDocType, SupabaseCheckpoint>,
     'pull' | 'push'
@@ -18,6 +32,11 @@ export type SyncOptionsSupabase<RxDocType> = Omit<
     modifiedField?: '_modified' | string;
 
     pull?: Omit<ReplicationPullOptions<RxDocType, SupabaseCheckpoint>, 'handler' | 'stream$'> & {
+        /**
+         * Allows modifying the PostgREST query before RxDB fetches remote changes.
+         * You can return a new builder instance or mutate the provided one.
+         */
+        queryBuilder?: SupabasePullQueryBuilder<RxDocType>;
     };
     push?: Omit<ReplicationPushOptions<RxDocType>, 'handler'>;
 };


### PR DESCRIPTION
feat: replication-supabase querybuilder

## This PR contains:
 - A NEW FEATURE

## Describe the problem you have without this PR
Using `replicateSupabase` I want to be able to filter the results that are pulled so I can limit them to a certain `account_id` for example. I've split my rxdb based on an account_id and I'd like to provide that id along to the query like I would normally via `.eq('account_id', accountId)`. This way I don't need to filter all queries to that account and it also limits how much is fetched by users who belong to multiple accounts (eg not syncing an account until they visit it).
