### PR TITLE
Add QueryCompositeFilterConstraint support to Firestore replication plugin

### DIFF
--- a/src/plugins/replication-firestore/firestore-types.ts
+++ b/src/plugins/replication-firestore/firestore-types.ts
@@ -11,6 +11,7 @@ import type {
     Firestore,
     QueryDocumentSnapshot,
     QueryFieldFilterConstraint,
+    QueryFilterConstraint,
     QuerySnapshot
 } from 'firebase/firestore';
 
@@ -39,7 +40,7 @@ export type FirestoreOptions<RxDocType> = {
 export type FirestoreSyncPullOptions<RxDocType> =
     Omit<ReplicationPullOptions<RxDocType, FirestoreCheckpointType>, 'handler' | 'stream$'>
     & {
-        filter?: QueryFieldFilterConstraint | QueryFieldFilterConstraint[];
+        filter?: QueryFilterConstraint | QueryFilterConstraint[];
     };
 
 export type FirestoreSyncPushOptions<RxDocType> = Omit<ReplicationPushOptions<RxDocType>, 'handler'>

--- a/src/plugins/replication-firestore/index.ts
+++ b/src/plugins/replication-firestore/index.ts
@@ -23,7 +23,8 @@ import {
     QueryDocumentSnapshot,
     waitForPendingWrites,
     documentId,
-    FirestoreError
+    FirestoreError,
+    QueryConstraint
 } from 'firebase/firestore';
 
 import { RxDBLeaderElectionPlugin } from '../leader-election/index.ts';
@@ -116,8 +117,8 @@ export function replicateFirestore<RxDocType>(
         });
     }
 
-    const pullFilters = options.pull?.filter !== undefined
-        ? toArray(options.pull.filter)
+    const pullFilters: QueryConstraint[] = options.pull?.filter !== undefined
+        ? toArray(options.pull.filter) as QueryConstraint[]
         : [];
 
     const pullQuery = query(options.firestore.collection, ...pullFilters);


### PR DESCRIPTION
This adds support for Firebase's `QueryCompositeFilterConstraint`
   type in the pull filter options, enabling the use of composite filters
   (`and()`, `or()`) in Firestore replication queries.

   ## This PR contains:
   - IMPROVED typings

   ## Describe the problem you have without this PR
   Currently, the Firestore replication plugin only accepts
   `QueryFieldFilterConstraint` for pull filters. Firebase also supports
   `QueryCompositeFilterConstraint` for composite filters using `and()` and
   `or()` operators, but these cannot be used with the current type
   definitions.

   ## Todos
   - [x] Typings