### PR TITLE
Replace `appendToArray()` with `Array.concat()` which is nowadays optimized by browsers and faster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 17.0.0-beta.3 (7 January 2026)
 
+- Replace `appendToArray()` with `Array.concat()` which is nowadays optimized by browsers and faster.
 - ADD  `reactivity-angular` package.
 - CHANGE moved `reactivity-vue` and `reactivity-preact-signals` from premium to core.
 - ADD `databaseNamePrefix` option to premium SQLite RxStorage

--- a/src/change-event-buffer.ts
+++ b/src/change-event-buffer.ts
@@ -10,7 +10,6 @@ import type {
     RxStorageChangeEvent
 } from './types/index.d.ts';
 import {
-    appendToArray,
     requestIdlePromiseNoQueue
 } from './plugins/utils/index.ts';
 
@@ -76,7 +75,7 @@ export class ChangeEventBuffer<RxDocType> {
         if (events.length > this.limit) {
             this.buffer = events.slice(events.length * -1);
         } else {
-            appendToArray(this.buffer, events);
+            this.buffer = this.buffer.concat(events);
             this.buffer = this.buffer.slice(this.limit * -1);
         }
         const counterBase = counterBefore + 1;

--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -17,8 +17,9 @@ import type {
     TopLevelProperty
 } from '../../types/index.d.ts';
 import {
-    appendToArray,
-    flattenObject, getProperty, isMaybeReadonlyArray,
+    flattenObject,
+    getProperty,
+    isMaybeReadonlyArray,
     trimDots
 } from '../../plugins/utils/index.ts';
 import { rxDocumentProperties } from './entity-properties.ts';
@@ -512,7 +513,7 @@ export function checkSchema(jsonSchema: RxJsonSchema<any>) {
     (jsonSchema.indexes || [])
         .reduce((indexPaths: string[], currentIndex) => {
             if (isMaybeReadonlyArray(currentIndex)) {
-                appendToArray(indexPaths, currentIndex);
+                indexPaths = indexPaths.concat(currentIndex);
             } else {
                 indexPaths.push(currentIndex);
             }

--- a/src/plugins/replication-firestore/index.ts
+++ b/src/plugins/replication-firestore/index.ts
@@ -1,5 +1,4 @@
 import {
-    appendToArray,
     asyncFilter,
     ensureNotFalsy,
     errorToPlainJson,
@@ -186,7 +185,7 @@ export function replicateFirestore<RxDocType>(
                             const missingAmount = batchSize - useDocs.length;
                             if (missingAmount > 0) {
                                 const additionalDocs = newerQueryResult.docs.slice(0, missingAmount).filter(x => !!x);
-                                appendToArray(useDocs, additionalDocs);
+                                useDocs = useDocs.concat(additionalDocs as any);
                             }
                         }
                     });

--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -23,7 +23,6 @@ import {
     getProperty,
     setProperty,
     PROMISE_RESOLVE_VOID,
-    appendToArray,
     clone,
     randomToken,
     deepEqual,
@@ -135,7 +134,7 @@ export class RxStateBase<T, Reactivity = unknown> {
             let done = false;
             while (!done) {
                 const lastIdDoc = await this._lastIdQuery.exec();
-                appendToArray(useWrites, this._nonPersisted);
+                useWrites = useWrites.concat(this._nonPersisted);
                 this._nonPersisted = [];
                 const nextId = nextRxStateId(lastIdDoc ? lastIdDoc.id : undefined);
                 try {

--- a/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
+++ b/src/plugins/storage-denokv/rx-storage-instance-denokv.ts
@@ -24,7 +24,7 @@ import type { DenoKVIndexMeta, DenoKVSettings, DenoKVStorageInternals } from './
 import { RxStorageDenoKV } from './index.ts';
 import { CLEANUP_INDEX, DENOKV_DOCUMENT_ROOT_PATH, RX_STORAGE_NAME_DENOKV, commitWithRetry, getDenoGlobal, getDenoKVIndexName } from "./denokv-helper.ts";
 import { getIndexableStringMonad, getStartIndexStringFromLowerBound } from "../../custom-index.ts";
-import { appendToArray, batchArray, lastOfArray, toArray } from "../utils/utils-array.ts";
+import { batchArray, lastOfArray, toArray } from "../utils/utils-array.ts";
 import { ensureNotFalsy } from "../utils/utils-other.ts";
 import { categorizeBulkWriteRows } from "../../rx-storage-helper.ts";
 import { now } from "../utils/utils-time.ts";
@@ -189,7 +189,7 @@ export class RxStorageInstanceDenoKV<RxDocType> implements RxStorageInstance<
                     }
                 }
                 if (txResult && txResult.ok) {
-                    appendToArray(ret.error, categorized.errors);
+                    ret.error = ret.error.concat(categorized.errors);
                     if (categorized.eventBulk.events.length > 0) {
                         const lastState = ensureNotFalsy(categorized.newestRow).document;
                         categorized.eventBulk.checkpoint = {

--- a/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
+++ b/src/plugins/storage-foundationdb/rx-storage-instance-foundationdb.ts
@@ -47,10 +47,8 @@ import {
     getStartIndexStringFromUpperBound
 } from '../../custom-index.ts';
 import {
-    appendToArray,
     batchArray,
     ensureNotFalsy,
-    lastOfArray,
     now,
     PROMISE_RESOLVE_VOID,
     toArray
@@ -122,7 +120,7 @@ export class RxStorageInstanceFoundationDB<RxDocType> implements RxStorageInstan
                         writeBatch,
                         context
                     );
-                    appendToArray(ret.error, categorized.errors);
+                    ret.error = ret.error.concat(categorized.errors);
 
                     // INSERTS
                     categorized.bulkInsertDocs.forEach(writeRow => {

--- a/src/plugins/storage-sqlite/sqlite-basics-helpers.ts
+++ b/src/plugins/storage-sqlite/sqlite-basics-helpers.ts
@@ -546,7 +546,7 @@ export function webSQLExecuteQuery(
 
 
 /**
- * TODO the wa-sqlite module has problems
+ * The wa-sqlite module has problems
  * when running prepared statements with params
  * in parallel. So we de-parrallel the runs here.
  * This is bad for performance and should be fixed at the

--- a/src/plugins/test-utils/schema-objects.ts
+++ b/src/plugins/test-utils/schema-objects.ts
@@ -4,7 +4,6 @@
 import { HumanDocumentType } from './schemas.ts';
 import * as schemas from './schemas.ts';
 import {
-    appendToArray,
     ensureNotFalsy,
     lastOfArray,
     randomNumber
@@ -20,8 +19,8 @@ export const TEST_DATA_CHARSET_LAST_SORTED = ensureNotFalsy(lastOfArray(TEST_DAT
 const someEmojisArr = ['😊', '💩', '👵', '🍌', '🏳️‍🌈', '😃'];
 
 const baseChars = TEST_DATA_CHARSET.split('');
-const allChars = baseChars.slice(0);
-appendToArray(allChars, someEmojisArr);
+let allChars = baseChars.slice(0);
+allChars = allChars.concat(someEmojisArr);
 
 export function randomStringWithSpecialChars(
     minLength: number,

--- a/src/plugins/utils/utils-array.ts
+++ b/src/plugins/utils/utils-array.ts
@@ -135,35 +135,6 @@ export function maxOfNumbers(arr: number[]): number {
     return Math.max(...arr);
 }
 
-
-/**
- * Appends the given documents to the given array.
- * This will mutate the first given array.
- * Mostly used as faster alternative to Array.concat()
- * because .concat() is so slow.
- * @link https://www.measurethat.net/Benchmarks/Show/4223/0/array-concat-vs-spread-operator-vs-push#latest_results_block
- * 
- * TODO it turns out that in mid 2024 v8 has optimized Array.concat()
- * so it might be faster to just use concat() again:
- * @link https://jsperf.app/qiqawa/10
- */
-export function appendToArray<T>(ar: T[], add: T[] | readonly T[]): void {
-    /**
-     * Pre-increasing the array size has turned out
-     * to be way faster when big arrays must be handled.
-     * @link https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki
-     */
-    const addSize = add.length;
-    if (addSize === 0) {
-        return;
-    }
-    const baseSize = ar.length;
-    ar.length = baseSize + add.length;
-    for (let i = 0; i < addSize; ++i) {
-        ar[baseSize + i] = add[i];
-    }
-}
-
 /**
  * @link https://gist.github.com/telekosmos/3b62a31a5c43f40849bb
  */

--- a/src/replication-protocol/downstream.ts
+++ b/src/replication-protocol/downstream.ts
@@ -18,7 +18,6 @@ import type {
     RxError
 } from '../types/index.d.ts';
 import {
-    appendToArray,
     createRevision,
     ensureNotFalsy,
     flatClone,
@@ -219,14 +218,14 @@ export async function startReplicationDownstream<RxDocType, CheckpointType = any
 
     function downstreamProcessChanges(tasks: Task[]) {
         state.stats.down.downstreamProcessChanges = state.stats.down.downstreamProcessChanges + 1;
-        const docsOfAllTasks: WithDeleted<RxDocType>[] = [];
+        let docsOfAllTasks: WithDeleted<RxDocType>[] = [];
         let lastCheckpoint: CheckpointType | undefined = null as any;
 
         tasks.forEach(task => {
             if (task === 'RESYNC') {
                 throw new Error('SNH');
             }
-            appendToArray(docsOfAllTasks, task.documents);
+            docsOfAllTasks = docsOfAllTasks.concat(task.documents);
             lastCheckpoint = stackCheckpoints([lastCheckpoint, task.checkpoint]);
         });
         return persistFromMaster(

--- a/src/replication-protocol/upstream.ts
+++ b/src/replication-protocol/upstream.ts
@@ -18,7 +18,6 @@ import type {
     WithDeleted
 } from '../types/index.d.ts';
 import {
-    appendToArray,
     batchArray,
     clone,
     ensureNotFalsy,
@@ -217,7 +216,7 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
             /**
              * Merge/filter all open tasks
              */
-            const docs: RxDocumentData<RxDocType>[] = [];
+            let docs: RxDocumentData<RxDocType>[] = [];
             let checkpoint: CheckpointType | undefined;
             while (openTasks.length > 0) {
                 const taskWithTime = ensureNotFalsy(openTasks.shift());
@@ -243,12 +242,9 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
                  * to have the correct checkpoint set.
                  */
                 if (taskWithTime.task.context !== await state.downstreamBulkWriteFlag) {
-                    appendToArray(
-                        docs,
-                        taskWithTime.task.events.map(r => {
-                            return r.documentData as any;
-                        })
-                    );
+                    docs = docs.concat(taskWithTime.task.events.map(r => {
+                        return r.documentData as any;
+                    }));
                 }
                 checkpoint = stackCheckpoints([checkpoint, taskWithTime.task.checkpoint]);
             }

--- a/src/rx-change-event.ts
+++ b/src/rx-change-event.ts
@@ -15,7 +15,7 @@ import type {
     RxDocumentData,
     RxStorageChangeEvent
 } from './types/index.d.ts';
-import { appendToArray, getFromMapOrCreate } from './plugins/utils/index.ts';
+import { getFromMapOrCreate } from './plugins/utils/index.ts';
 
 export function getDocumentDataOfRxChangeEvent<T>(
     rxChangeEvent: RxStorageChangeEvent<T>
@@ -68,11 +68,11 @@ export function rxChangeEventToEventReduceChangeEvent<DocType>(
 export function flattenEvents<EventType>(
     input: EventBulk<EventType, any> | EventBulk<EventType, any>[] | EventType | EventType[]
 ): EventType[] {
-    const output: EventType[] = [];
+    let output: EventType[] = [];
     if (Array.isArray(input)) {
         input.forEach(inputItem => {
             const add = flattenEvents(inputItem);
-            appendToArray(output, add);
+            output = output.concat(add);
         });
     } else {
         if ((input as any).id && (input as any).events) {

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -19,8 +19,7 @@ import {
     PROMISE_RESOLVE_FALSE,
     RXJS_SHARE_REPLAY_DEFAULTS,
     ensureNotFalsy,
-    areRxDocumentArraysEqual,
-    appendToArray
+    areRxDocumentArraysEqual
 } from './plugins/utils/index.ts';
 import {
     newRxError,
@@ -700,7 +699,7 @@ export async function queryCollection<RxDocType>(
             // otherwise get from storage
             if (docIds.length > 0) {
                 const docsFromStorage = await collection.storageInstance.findDocumentsById(docIds, false);
-                appendToArray(docs, docsFromStorage);
+                docs = docs.concat(docsFromStorage);
             }
         } else {
             const docId = rxQuery.isFindOneByIdQuery;

--- a/src/rx-storage-helper.ts
+++ b/src/rx-storage-helper.ts
@@ -35,7 +35,6 @@ import {
     PROMISE_RESOLVE_TRUE,
     RXDB_VERSION,
     RX_META_LWT_MINIMUM,
-    appendToArray,
     createRevision,
     ensureNotFalsy,
     flatClone,
@@ -658,7 +657,8 @@ export function getWrappedStorageInstance<
                     )
                 );
 
-                appendToArray(useWriteResult.error, subResult.error);
+
+                useWriteResult.error = useWriteResult.error.concat(subResult.error);
                 const successArray = getWrittenDocumentsFromBulkWriteResponse(
                     primaryPath,
                     toStorageWriteRows,
@@ -670,9 +670,10 @@ export function getWrappedStorageInstance<
                     reInserts,
                     subResult
                 );
-                appendToArray(successArray, subSuccess);
+                successArray.push(...subSuccess);
                 return useWriteResult;
             }
+
             return useWriteResult;
         },
         query(preparedQuery) {

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -25,8 +25,7 @@ import {
     stringToArrayBuffer,
     arrayBufferToString,
     clone,
-    errorToPlainJson,
-    appendToArray
+    errorToPlainJson
 } from '../../plugins/core/index.mjs';
 import config from './config.ts';
 
@@ -178,20 +177,6 @@ describe('util.test.js', () => {
                 }
             });
 
-        });
-    });
-    describe('.appendToArray()', () => {
-        it('should correctly merge the arrays', () => {
-            const base = [1, 2, 3];
-            const add = [4, 5, 6];
-            appendToArray(base, add);
-            assert.deepStrictEqual(base, [1, 2, 3, 4, 5, 6]);
-        });
-        it('should correctly merge the arrays', () => {
-            const base = [1, 2, 3];
-            const add: number[] = [];
-            appendToArray(base, add);
-            assert.deepStrictEqual(base, [1, 2, 3]);
         });
     });
     describe('base64 helpers', () => {


### PR DESCRIPTION
Replace `appendToArray()` with `Array.concat()` which is nowadays optimized by browsers and faster.