### PR TITLE
Remove unnecessary setEndpointRealtime from Appwrite client examples

### DIFF
--- a/docs-src/docs/replication-appwrite.md
+++ b/docs-src/docs/replication-appwrite.md
@@ -208,7 +208,6 @@ const collection = db.humans;
 ```ts
 const client = new Client();
 client.setEndpoint('https://cloud.appwrite.io/v1');
-client.setEndpointRealtime('https://cloud.appwrite.io/v1');
 client.setProject('YOUR_APPWRITE_PROJECT_ID');
 ```
 
@@ -217,7 +216,6 @@ client.setProject('YOUR_APPWRITE_PROJECT_ID');
 ```ts
 const client = new Client();
 client.setEndpoint('http://localhost/v1');
-client.setEndpointRealtime('http://localhost/v1');
 client.setProject('YOUR_APPWRITE_PROJECT_ID');
 ```
 


### PR DESCRIPTION
## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR

The `setEndpointRealtime` method is only necessary in situations where a custom proxy is used, and Appwrite's expected default realtime endpoint may not work. Also, in this case, the endpoint used is incorrect.

This PR removes `setEndpointRealtime` from the Appwrite client examples in the Appwrite integrations docs.
