### PR TITLE
REMOVE outdated isomorphic-ws dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -548,7 +548,6 @@
     "graphql": "16.12.0",
     "graphql-ws": "5.16.2",
     "is-my-json-valid": "2.20.6",
-    "isomorphic-ws": "5.0.0",
     "js-base64": "3.7.8",
     "jsonschema-key-compression": "1.7.0",
     "mingo": "7.1.1",

--- a/src/plugins/replication-graphql/graphql-websocket.ts
+++ b/src/plugins/replication-graphql/graphql-websocket.ts
@@ -1,9 +1,7 @@
 import { Client, createClient } from 'graphql-ws';
 import { getFromMapOrCreate, getFromMapOrThrow } from '../../plugins/utils/index.ts';
-import ws from 'isomorphic-ws';
+import { WebSocket } from 'ws';
 import { RxGraphQLPullWSOptions } from '../../types';
-
-const { WebSocket: IsomorphicWebSocket } = ws;
 
 export type WebsocketWithRefCount = {
     url: string;
@@ -29,7 +27,7 @@ export function getGraphQLWebSocket(
                 ...options,
                 url,
                 shouldRetry: () => true,
-                webSocketImpl: IsomorphicWebSocket,
+                webSocketImpl: WebSocket,
                 connectionParams: options.connectionParams || connectionParamsHeaders,
             });
             return {

--- a/src/plugins/replication-websocket/websocket-client.ts
+++ b/src/plugins/replication-websocket/websocket-client.ts
@@ -9,7 +9,7 @@ import {
 
 import ReconnectingWebSocket from 'reconnecting-websocket';
 
-import IsomorphicWebSocket from 'isomorphic-ws';
+import { WebSocket } from 'ws';
 import {
     errorToPlainJson,
     randomToken,
@@ -39,11 +39,8 @@ export type WebsocketClient = {
 
 /**
  * Copied and adapted from the 'reconnecting-websocket' npm module.
- * Some bundlers have problems with bundling the isomorphic-ws plugin
- * so we directly check the correctness in RxDB to ensure that we can
- * throw a helpful error.
  */
-export function ensureIsWebsocket(w: typeof IsomorphicWebSocket) {
+export function ensureIsWebsocket(w: typeof WebSocket) {
     const is = typeof w !== 'undefined' && !!w && w.CLOSING === 2;
     if (!is) {
         console.dir(w);
@@ -53,13 +50,11 @@ export function ensureIsWebsocket(w: typeof IsomorphicWebSocket) {
 
 
 export async function createWebSocketClient<RxDocType>(options: WebsocketClientOptions<RxDocType>): Promise<WebsocketClient> {
-    ensureIsWebsocket(IsomorphicWebSocket);
+    ensureIsWebsocket(WebSocket);
     const wsClient = new ReconnectingWebSocket(
         options.url,
         [],
-        {
-            WebSocket: IsomorphicWebSocket
-        }
+        { WebSocket }
     );
     const connected$ = new BehaviorSubject<boolean>(false);
     const message$ = new Subject<any>();

--- a/src/plugins/replication-websocket/websocket-server.ts
+++ b/src/plugins/replication-websocket/websocket-server.ts
@@ -4,12 +4,11 @@ import type {
     RxReplicationHandler
 } from '../../types/index.d.ts';
 
-import type {
-    WebSocket,
-    ServerOptions
-} from 'isomorphic-ws';
-import pkg from 'isomorphic-ws';
-const { WebSocketServer } = pkg;
+import {
+    type WebSocket,
+    WebSocketServer,
+    type ServerOptions,
+} from 'ws';
 
 import type {
     WebsocketMessageResponseType,

--- a/test/helper/graphql-server.ts
+++ b/test/helper/graphql-server.ts
@@ -11,7 +11,7 @@ import {
     subscribe
 } from 'graphql';
 import { createServer } from 'node:http';
-import ws from 'ws';
+import { WebSocketServer } from 'ws';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import { Request, Response, NextFunction } from 'express';
 
@@ -302,7 +302,7 @@ export async function spawn(
 
             const wsPort = port + 500;
             const wss = createServer(server);
-            const wsServer = new (ws as any).Server({
+            const wsServer = new WebSocketServer({
                 server: wss,
                 path: GRAPHQL_SUBSCRIPTION_PATH,
             });

--- a/test/unit/replication-graphql.test.ts
+++ b/test/unit/replication-graphql.test.ts
@@ -5,8 +5,7 @@ import {
     wait,
     waitUntil
 } from 'async-test-util';
-import pkg from 'isomorphic-ws';
-const { WebSocket: IsomorphicWebSocket } = pkg;
+import { WebSocket } from 'ws';
 
 
 import {
@@ -310,7 +309,7 @@ describe('replication-graphql.test.ts', () => {
                 const client = createClient({
                     url: endpointUrl,
                     shouldRetry: () => false,
-                    webSocketImpl: IsomorphicWebSocket,
+                    webSocketImpl: WebSocket,
                 });
 
                 const query = `subscription onHumanChanged {


### PR DESCRIPTION
Since newer Node.js versions have a built-in WebSocket client (stable since v22.4.0), there's no need to rely on unmaintened isomorphic-ws library
