### PR TITLE
fix dist/types/index.d.ts exporting index.d.d.ts

### DIFF
--- a/scripts/fix-types.mjs
+++ b/scripts/fix-types.mjs
@@ -4,7 +4,14 @@ async function main () {
     const file = './dist/types/index.d.ts';
     try {
         let content = await fs.readFile(file, { encoding: 'utf-8' });
-        content = content.replaceAll('.ts', '.d.ts');
+        // Convert only bare '.ts' specifier endings, keep existing '.d.ts' intact.
+        content = content.replace(/(?<!\.d)\.ts(?=['"])/g, '.d.ts');
+
+        // Guard against malformed declaration specifiers.
+        if (/\.d\.d\.ts(?=['"])/.test(content)) {
+            throw new Error('malformed declaration specifier found (.d.d.ts)');
+        }
+
         content = `// @ts-nocheck
         ${content}`;
         await fs.writeFile(file, content);


### PR DESCRIPTION
#7906  introduced a bug when running `npm run build:types`

`src/index.ts` changed from `export type * from './types/index.ts';` to `export type * from './types/index.d.ts';`

I think i made this change because it was causing typescript stuff to not resolve properly in the IDE.

But then` scripts/fix-types.mjs` causes `dist/types/index.d.ts` to become `export type * from './types/index.d.d.ts';`

This changes to a regex that only replaces `.ts` if not preceded by `.d`. Also throws an error if it finds `.d.d.ts`