### PR TITLE
Block unprotected write paths on CRDT-enabled documents

### DIFF
--- a/src/plugins/crdt/index.ts
+++ b/src/plugins/crdt/index.ts
@@ -352,6 +352,43 @@ export const RxDBcrdtPlugin: RxPlugin = {
                 });
             };
 
+            const oldincrementalRemove = proto.incrementalRemove;
+            proto.incrementalRemove = function (this: RxDocument) {
+                if (!this.collection.schema.jsonSchema.crdt) {
+                    return oldincrementalRemove.call(this);
+                }
+                return this.updateCRDT({
+                    ifMatch: {
+                        $set: {
+                            _deleted: true
+                        }
+                    }
+                });
+            };
+
+            const oldModify = proto.modify;
+            proto.modify = function (this: RxDocument, fn: any, context?: string) {
+                if (!this.collection.schema.jsonSchema.crdt) {
+                    return oldModify.call(this, fn, context);
+                }
+                throw newRxError('CRDT4', {
+                    id: this.primary,
+                    args: { method: 'modify' }
+                });
+            };
+
+            const oldPatch = proto.patch;
+            proto.patch = function (this: RxDocument, patch: any) {
+                if (!this.collection.schema.jsonSchema.crdt) {
+                    return oldPatch.call(this, patch);
+                }
+                return this.updateCRDT({
+                    ifMatch: {
+                        $set: patch
+                    }
+                });
+            };
+
             const oldincrementalPatch = proto.incrementalPatch;
             proto.incrementalPatch = function (this: RxDocument, patch: any) {
                 if (!this.collection.schema.jsonSchema.crdt) {
@@ -376,6 +413,16 @@ export const RxDBcrdtPlugin: RxPlugin = {
                         args: { context }
                     });
                 }
+            };
+
+            const oldUpdate = proto.update;
+            proto.update = function (this: RxDocument, updateObj: any) {
+                if (!this.collection.schema.jsonSchema.crdt) {
+                    return oldUpdate.call(this, updateObj);
+                }
+                return this.updateCRDT({
+                    ifMatch: updateObj
+                });
             };
         },
         RxCollection: (proto: any) => {

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -1163,6 +1163,12 @@ export const ERROR_MESSAGES = {
         fix: 'Remove the custom conflict handler.',
         docs: 'https://rxdb.info/crdt.html?console=errors&code=CRDT3'
     },
+    CRDT4: {
+        message: 'RxDocument.modify() cannot be used when CRDTs are activated.',
+        cause: 'modify() takes an arbitrary function that cannot be converted to a CRDT operation.',
+        fix: 'Use updateCRDT() instead of modify().',
+        docs: 'https://rxdb.info/crdt.html?console=errors&code=CRDT4'
+    },
 
     // plugins/storage-dexie/
     DXE1: {

--- a/test/unit/crdt.test.ts
+++ b/test/unit/crdt.test.ts
@@ -32,6 +32,8 @@ import {
     RxDBcrdtPlugin,
     getCRDTConflictHandler
 } from '../../plugins/crdt/index.mjs';
+import { RxDBUpdatePlugin } from '../../plugins/update/index.mjs';
+addRxPlugin(RxDBUpdatePlugin);
 addRxPlugin(RxDBcrdtPlugin);
 import config, { describeParallel } from './config.ts';
 import { replicateRxCollection } from '../../plugins/replication/index.mjs';
@@ -256,7 +258,7 @@ describeParallel('crdt.test.ts', () => {
      * when the operations are not CRDTs.
      */
     describe('disallowed methods', () => {
-        it('should throw the correct errors', async () => {
+        it('should throw on incrementalModify', async () => {
             const collection = await getCRDTCollection();
             const doc = await collection.insert(schemaObjects.humanData('foobar', 1));
 
@@ -265,6 +267,59 @@ describeParallel('crdt.test.ts', () => {
                 'RxError',
                 'CRDT2'
             );
+
+            collection.database.close();
+        });
+        it('should throw on modify', async () => {
+            const collection = await getCRDTCollection();
+            const doc = await collection.insert(schemaObjects.humanData('foobar', 1));
+
+            await AsyncTestUtil.assertThrows(
+                () => doc.modify(d => d),
+                'RxError',
+                'CRDT4'
+            );
+
+            collection.database.close();
+        });
+    });
+
+    describe('redirected methods', () => {
+        it('should redirect patch through updateCRDT', async () => {
+            const collection = await getCRDTCollection();
+            const doc = await collection.insert(schemaObjects.humanData('foobar', 1));
+
+            await doc.patch({ age: 50 });
+            const latest = doc.getLatest();
+            assert.strictEqual(latest.age, 50);
+
+            const crdts = latest.toJSON().crdts;
+            assert.ok(crdts);
+            assert.ok(crdts.operations.length > 1);
+
+            collection.database.close();
+        });
+        it('should redirect incrementalRemove through updateCRDT', async () => {
+            const collection = await getCRDTCollection();
+            const doc = await collection.insert(schemaObjects.humanData('foobar', 1));
+
+            await doc.incrementalRemove();
+            const latest = doc.getLatest();
+            assert.strictEqual(latest.deleted, true);
+
+            collection.database.close();
+        });
+        it('should redirect update through updateCRDT', async () => {
+            const collection = await getCRDTCollection();
+            const doc = await collection.insert(schemaObjects.humanData('foobar', 1));
+
+            await doc.update({ $set: { age: 99 } });
+            const latest = doc.getLatest();
+            assert.strictEqual(latest.age, 99);
+
+            const crdts = latest.toJSON().crdts;
+            assert.ok(crdts);
+            assert.ok(crdts.operations.length > 1);
 
             collection.database.close();
         });


### PR DESCRIPTION
The CRDT plugin blocks `incrementalModify` and redirects `incrementalPatch`/`remove` through `updateCRDT`, but `modify()`, `patch()`, `incrementalRemove()`, and `update()` bypass the CRDT operation log by calling `_saveData()` directly. This causes document data and the CRDT operation log to diverge silently. On the next replication conflict, `rebuildFromCRDT()` reconstructs from operations only, discarding non-CRDT changes.

- [**`src/plugins/crdt/index.ts`**](https://github.com/dearlordylord/rxdb/blob/10c77d6c7/src/plugins/crdt/index.ts): Override `modify` (throws CRDT4, arbitrary functions cannot become CRDT ops), `patch`, `incrementalRemove`, and `update` (redirect through `updateCRDT`) on the RxDocument prototype when CRDT is active
- [**`src/plugins/dev-mode/error-messages.ts`**](https://github.com/dearlordylord/rxdb/blob/10c77d6c7/src/plugins/dev-mode/error-messages.ts#L1166-L1171): Add CRDT4 error code
- [**`test/unit/crdt.test.ts`**](https://github.com/dearlordylord/rxdb/blob/10c77d6c7/test/unit/crdt.test.ts#L260-L327): Add tests for all new overrides; load `RxDBUpdatePlugin` so CRDT tests work in isolation

tests are red/green checked