### PR TITLE
Add ETag check to updateDocumentFiles for CAS semantics

### DIFF
--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -1267,6 +1267,12 @@ export const ERROR_MESSAGES = {
         fix: 'Try to reproduce the error in a unit test and make a PR with a test case.',
         docs: 'https://rxdb.info/replication-google-drive.html?console=errors&code=GDR19'
     },
+    GDR20: {
+        message: 'Document file update conflict',
+        cause: 'Another client modified the document file during the transaction. This indicates a transaction timeout overlap.',
+        fix: 'Increase the transactionTimeout or investigate why two clients are writing to the same document concurrently.',
+        docs: 'https://rxdb.info/replication-google-drive.html?console=errors&code=GDR20'
+    },
 
 
 

--- a/src/plugins/replication-google-drive/document-handling.ts
+++ b/src/plugins/replication-google-drive/document-handling.ts
@@ -29,7 +29,7 @@ export async function getDocumentFiles(
     const params = new URLSearchParams({
         q,
         pageSize: MAX_DRIVE_PAGE_SIZE + '',
-        fields: "nextPageToken, files(id,name,mimeType,parents,modifiedTime,size)",
+        fields: "nextPageToken, files(id,name,mimeType,parents,modifiedTime,size,etag)",
         // Shared drives support (safe to include always)
         includeItemsFromAllDrives: "true",
         supportsAllDrives: "true",
@@ -109,7 +109,7 @@ export async function updateDocumentFiles<DocType>(
     googleDriveOptions: GoogleDriveOptionsWithDefaults,
     primaryPath: keyof DocType,
     docs: DocType[],
-    fileIdByDocId: Record<string, string>,
+    fileMetaByDocId: Record<string, { fileId: string; etag: string }>,
     concurrency = 5
 ) {
     const queue = docs.slice(0);
@@ -119,21 +119,33 @@ export async function updateDocumentFiles<DocType>(
         while (queue.length) {
             const doc = queue.shift()!;
             const docId = (doc as any)[primaryPath] as string;
-            const fileId = ensureNotFalsy(fileIdByDocId[docId]);
+            const meta = ensureNotFalsy(fileMetaByDocId[docId]);
+            const fileId = meta.fileId;
+            const etag = meta.etag;
 
             const url =
                 googleDriveOptions.apiEndpoint +
-                `/upload/drive/v3/files/${encodeURIComponent(fileId)}` +
+                `/upload/drive/v2/files/${encodeURIComponent(fileId)}` +
                 `?uploadType=media&supportsAllDrives=true&fields=id`;
 
             const res = await fetch(url, {
-                method: "PATCH",
+                method: "PUT",
                 headers: {
                     Authorization: `Bearer ${googleDriveOptions.authToken}`,
                     "Content-Type": "application/json; charset=UTF-8",
+                    "If-Match": etag,
                 },
                 body: JSON.stringify(doc),
             });
+
+            if (res.status === 412) {
+                throw newRxError('GDR20', {
+                    args: {
+                        docId,
+                        fileId
+                    }
+                });
+            }
 
             if (!res.ok) {
                 throw await newRxFetchError(res, {

--- a/src/plugins/replication-google-drive/google-drive-types.ts
+++ b/src/plugins/replication-google-drive/google-drive-types.ts
@@ -26,6 +26,7 @@ export interface DriveFileMetadata {
     modifiedTime?: string;
     size?: string; // Drive returns size as string
     fileSize?: string; // v2
+    etag?: string;
 }
 
 export type GoogleDriveOptions = {

--- a/src/plugins/replication-google-drive/upstream.ts
+++ b/src/plugins/replication-google-drive/upstream.ts
@@ -213,18 +213,21 @@ export async function processWalFile<RxDocType>(
         init,
         docIds as string[]
     );
-    const fileIdByDocId: Record<string, string> = {};
+    const fileMetaByDocId: Record<string, { fileId: string; etag: string }> = {};
 
     docFiles.files.forEach(file => {
         const docId = file.name.split('.')[0] as any;
-        fileIdByDocId[docId] = file.id;
+        fileMetaByDocId[docId] = {
+            fileId: file.id,
+            etag: ensureNotFalsy(file.etag),
+        };
     });
 
     const toInsert: WithDeletedAndAttachments<RxDocType>[] = [];
     const toUpdate: WithDeletedAndAttachments<RxDocType>[] = [];
     content.rows.filter(row => {
         const docId = row.newDocumentState[primaryPath];
-        const fileExists = fileIdByDocId[docId as any];
+        const fileExists = fileMetaByDocId[docId as any];
         if (!fileExists) {
             toInsert.push(row.newDocumentState);
         } else {
@@ -243,7 +246,7 @@ export async function processWalFile<RxDocType>(
             googleDriveOptions,
             primaryPath,
             toUpdate,
-            fileIdByDocId,
+            fileMetaByDocId,
         )
     ]);
 

--- a/test/replication-google-drive.test.ts
+++ b/test/replication-google-drive.test.ts
@@ -489,16 +489,16 @@ describe('replication-google-drive.test.ts', function () {
                 options.initData,
                 ids
             );
-            const fileIdByDocId: any = {};
+            const fileMetaByDocId: any = {};
             found.files.forEach((file, i) => {
                 const docId = docs[i][PRIMARY_PATH];
-                fileIdByDocId[docId] = file.id;
+                fileMetaByDocId[docId] = { fileId: file.id, etag: ensureNotFalsy(file.etag) };
             });
             await updateDocumentFiles(
                 options,
                 PRIMARY_PATH,
                 docs,
-                fileIdByDocId
+                fileMetaByDocId
             );
             const fileIds: string[] = found.files.map((f: any) => ensureNotFalsy(f.id));
             const batchResult = await fetchDocumentContents<any>(
@@ -624,7 +624,7 @@ describe('replication-google-drive.test.ts', function () {
                     options,
                     PRIMARY_PATH,
                     [firstDoc],
-                    { [firstDoc.passportId]: docFiles.files[0].id }
+                    { [firstDoc.passportId]: { fileId: docFiles.files[0].id, etag: ensureNotFalsy(docFiles.files[0].etag) } }
                 );
 
                 const changesAfterUpdate = await fetchChanges<HumanDocumentType>(


### PR DESCRIPTION
`updateDocumentFiles()` used v3 PATCH without `If-Match`. During lock breach (transaction timeout), two clients could update the same doc file concurrently with last-write-wins silently. The rest of the plugin uses v2 PUT with `If-Match` for all writes that need CAS semantics (`fillFileIfEtagMatches`, `deleteIfEtagMatches`, `writeToWal`).

- [**`src/plugins/replication-google-drive/google-drive-types.ts`**](https://github.com/dearlordylord/rxdb/blob/447bcf6c6/src/plugins/replication-google-drive/google-drive-types.ts): Add `etag` to `DriveFileMetadata`
- [**`src/plugins/replication-google-drive/document-handling.ts`**](https://github.com/dearlordylord/rxdb/blob/447bcf6c6/src/plugins/replication-google-drive/document-handling.ts): Request `etag` in `getDocumentFiles` fields; switch `updateDocumentFiles` from v3 PATCH to v2 PUT with `If-Match` etag, throw `GDR20` on 412; merge `fileIdByDocId`/`etagByDocId` into single `fileMetaByDocId` parameter
- [**`src/plugins/replication-google-drive/upstream.ts`**](https://github.com/dearlordylord/rxdb/blob/447bcf6c6/src/plugins/replication-google-drive/upstream.ts): Build `fileMetaByDocId` from file etags in `processWalFile`, pass to `updateDocumentFiles`
- [**`src/plugins/dev-mode/error-messages.ts`**](https://github.com/dearlordylord/rxdb/blob/447bcf6c6/src/plugins/dev-mode/error-messages.ts): Add GDR20 error code

build and types pass; tests pass (pre-existing backup.test.ts failure on Node 25 unrelated)