### PR TITLE
Normalize selector shorthands recursively in $and/$or/$nor/$not

### DIFF
--- a/src/rx-query-helper.ts
+++ b/src/rx-query-helper.ts
@@ -294,6 +294,15 @@ function normalizeQuerySelectorShorthands(selector: any): void {
                 (matcher as any[]).forEach(subSelector => normalizeQuerySelectorShorthands(subSelector));
             } else if (field === '$not' && typeof matcher === 'object') {
                 normalizeQuerySelectorShorthands(matcher);
+            } else if (!field.startsWith('$') && typeof matcher === 'object') {
+                /**
+                 * Recurse into field-level operator objects to normalize
+                 * sub-selectors like $elemMatch which contain nested selectors.
+                 */
+                const matcherObj = matcher as any;
+                if (matcherObj.$elemMatch && typeof matcherObj.$elemMatch === 'object') {
+                    normalizeQuerySelectorShorthands(matcherObj.$elemMatch);
+                }
             }
         });
 }

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -218,6 +218,68 @@ describeParallel('query-planner.test.js', () => {
                 assert.deepStrictEqual($and[0].age, { $gt: 20 });
                 assert.deepStrictEqual($and[1].firstName, { $eq: 'Alice' });
             });
+            it('should normalize shorthands inside $elemMatch', () => {
+                const schema = getHumanSchemaWithIndexes([]);
+                const query = normalizeMangoQuery<HumanDocumentType>(
+                    schema,
+                    {
+                        selector: {
+                            firstName: {
+                                $elemMatch: {
+                                    age: 30,
+                                    lastName: 'Smith'
+                                }
+                            }
+                        } as any,
+                        sort: [{ passportId: 'asc' }]
+                    }
+                );
+                const $elemMatch = (query.selector as any).firstName.$elemMatch;
+                assert.deepStrictEqual($elemMatch.age, { $eq: 30 });
+                assert.deepStrictEqual($elemMatch.lastName, { $eq: 'Smith' });
+            });
+            it('should not modify $elemMatch selectors that already use operators', () => {
+                const schema = getHumanSchemaWithIndexes([]);
+                const query = normalizeMangoQuery<HumanDocumentType>(
+                    schema,
+                    {
+                        selector: {
+                            firstName: {
+                                $elemMatch: {
+                                    age: { $gt: 20 },
+                                    lastName: 'Smith'
+                                }
+                            }
+                        } as any,
+                        sort: [{ passportId: 'asc' }]
+                    }
+                );
+                const $elemMatch = (query.selector as any).firstName.$elemMatch;
+                assert.deepStrictEqual($elemMatch.age, { $gt: 20 });
+                assert.deepStrictEqual($elemMatch.lastName, { $eq: 'Smith' });
+            });
+            it('should normalize $elemMatch inside $and', () => {
+                const schema = getHumanSchemaWithIndexes([]);
+                const query = normalizeMangoQuery<HumanDocumentType>(
+                    schema,
+                    {
+                        selector: {
+                            $and: [
+                                {
+                                    firstName: {
+                                        $elemMatch: {
+                                            age: 25
+                                        }
+                                    }
+                                }
+                            ]
+                        } as any,
+                        sort: [{ passportId: 'asc' }]
+                    }
+                );
+                const $elemMatch = (query.selector as any).$and[0].firstName.$elemMatch;
+                assert.deepStrictEqual($elemMatch.age, { $eq: 25 });
+            });
             it('should handle null values in nested selectors', () => {
                 const schema = getHumanSchemaWithIndexes([]);
                 const query = normalizeMangoQuery<HumanDocumentType>(


### PR DESCRIPTION
The selector normalization that converts shorthand values like
{foo: 'bar'} to {foo: {$eq: 'bar'}} previously only worked on
top-level selector fields. This extracts the logic into a recursive
helper function that also normalizes selectors nested inside
$and, $or, $nor arrays and $not objects.

https://claude.ai/code/session_01GPFa8swKEgaPeLjUCVXJiP