### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,5 +26,18 @@
             "Edit(plugins/**)",
             "Delete(plugins/**)"
         ]
+    },
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "npx block-no-verify@1.1.2"
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, preserving existing configuration (permissions.allow for npm/cat/ls/grep).

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. All existing configuration is preserved unchanged.

Closes #8132

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
