### PR TITLE
Fix RxState full-state replacement recovery from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 <!-- ADD new changes here! -->
 
+- FIX RxState not correctly recovering full-state replacements (via `set('', modifier)`) from disk on database reopen, causing corrupted state
+
 - FIX memory storage `count()` returning incorrect results when the selector is not fully satisfied by the index and the query has a `limit` set
 
 - FIX `replicateRxCollection().remove()` on a never-started replication now creates the meta instance and deletes its data instead of skipping cleanup

--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -335,7 +335,7 @@ export async function createRxState<T>(
         } else {
             for (let index = 0; index < documents.length; index++) {
                 const document = documents[index];
-                mergeOperationsIntoState(rxState._state, document.ops);
+                rxState._state = mergeOperationsIntoState(rxState._state, document.ops);
             }
         }
     }
@@ -385,9 +385,14 @@ export async function createRxState<T>(
 export function mergeOperationsIntoState<T>(
     state: T,
     operations: RxStateOperation[]
-) {
+): T {
     for (let index = 0; index < operations.length; index++) {
         const operation = operations[index];
-        setProperty(state, operation.k, clone(operation.v));
+        if (operation.k === '') {
+            state = clone(operation.v);
+        } else {
+            setProperty(state, operation.k, clone(operation.v));
+        }
     }
+    return state;
 }

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -579,6 +579,27 @@ addRxPlugin(RxDBJsonDumpPlugin);
 
                 state.collection.database.remove();
             });
+            it('should recover correct state from disk after full-state replacement with set(\'\')', async () => {
+                const databaseName = randomToken(10);
+
+                // Create state and do a full-state replacement via set('')
+                let state = await getState(databaseName);
+                await state.set('foo', () => 'bar');
+                await state.set('a', () => 1);
+                // Replace the entire state using empty path
+                await state.set('', () => ({ foo: 'replaced', b: 99 }));
+
+                // Verify in-memory state is correct before closing
+                assert.deepStrictEqual(state.get(), { foo: 'replaced', b: 99 });
+                await state.collection.database.close();
+
+                // Reopen the database and recover state from disk
+                state = await getState(databaseName);
+                // State should match what was set before closing
+                assert.deepStrictEqual(state.get(), { foo: 'replaced', b: 99 });
+
+                await state.collection.database.remove();
+            });
             /**
              * @link https://github.com/pubkey/rxdb/pull/6503
              */


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

RxState does not correctly recover full-state replacements (via `set('', modifier)`) from disk when the database is reopened. When operations with an empty key (`''`) are replayed from disk, they were being treated as property updates instead of full-state replacements, causing the state to become corrupted.

## Changes Made

### Source Code Fix (`src/plugins/state/rx-state.ts`)
1. Modified `mergeOperationsIntoState()` to return the updated state instead of mutating in-place
2. Added special handling for operations with empty key (`''`) to perform full-state replacement via `state = clone(operation.v)`
3. Updated the call site in `createRxState()` to assign the returned state back to `rxState._state`

### Test Coverage (`test/unit/rx-state.test.ts`)
Added a comprehensive test case that:
- Creates state and performs a full-state replacement using `set('', modifier)`
- Verifies the in-memory state is correct before closing
- Closes and reopens the database
- Confirms the state is correctly recovered from disk with the replaced values

## Todos
- [x] Tests
- [x] Changelog

https://claude.ai/code/session_017mPmsfabCty1a1kYohqW4M