### PR TITLE
Fix encryption plugin schema transformation for nested encrypted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 <!-- ADD new changes here! -->
 
+- FIX encryption plugin schema transformation not handling nested encrypted field paths (e.g. `'credentials.password'`), causing constraints like `maxLength` to not be stripped from the internal schema and producing validation errors with the encrypted ciphertext
+
 - FIX memory storage `count()` returning incorrect results when the selector is not fully satisfied by the index and the query has a `limit` set
 
 - FIX `replicateRxCollection().remove()` on a never-started replication now creates the meta instance and deletes its data instead of skipping cleanup

--- a/src/plugins/encryption-crypto-js/index.ts
+++ b/src/plugins/encryption-crypto-js/index.ts
@@ -104,7 +104,12 @@ export function wrappedKeyEncryptionCryptoJsStorage<Internals, InstanceCreationO
                  * they do not apply to the encrypted ciphertext string.
                  */
                 ensureNotFalsy(params.schema.encrypted).forEach(key => {
-                    (schemaWithoutEncrypted as any).properties[key] = { type: 'string' };
+                    const keyParts = key.split('.');
+                    let schemaObj: any = schemaWithoutEncrypted;
+                    for (let i = 0; i < keyParts.length - 1; i++) {
+                        schemaObj = schemaObj.properties[keyParts[i]];
+                    }
+                    schemaObj.properties[keyParts[keyParts.length - 1]] = { type: 'string' };
                 });
 
                 const instance = await args.storage.createStorageInstance(

--- a/test/unit/encryption.test.ts
+++ b/test/unit/encryption.test.ts
@@ -691,5 +691,83 @@ describeParallel('encryption.test.ts', () => {
 
             await db.remove();
         });
+        it('should work with nested encrypted field paths that have maxLength in schema', async () => {
+            if (config.storage.hasEncryption) {
+                return;
+            }
+            type DocType = {
+                id: string;
+                credentials: {
+                    password: string;
+                    username: string;
+                };
+            };
+            const mySchema: RxJsonSchema<DocType> = {
+                version: 0,
+                primaryKey: 'id',
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        maxLength: 100
+                    },
+                    credentials: {
+                        type: 'object',
+                        properties: {
+                            password: {
+                                type: 'string',
+                                maxLength: 50
+                            },
+                            username: {
+                                type: 'string'
+                            }
+                        },
+                        required: ['password', 'username']
+                    }
+                },
+                required: ['id', 'credentials'],
+                encrypted: ['credentials.password']
+            };
+            const db = await createRxDatabase<{ test: RxCollection<DocType>; }>({
+                name: randomToken(10),
+                storage: wrappedKeyEncryptionCryptoJsStorage({
+                    storage: wrappedValidateAjvStorage({
+                        storage: getRxStorageMemory()
+                    })
+                }),
+                password: await getPassword()
+            });
+            const collections = await db.addCollections({
+                test: {
+                    schema: mySchema
+                }
+            });
+
+            // insert a document - the encrypted ciphertext is longer than maxLength
+            // but this should still work because maxLength should be stripped
+            // from the nested encrypted field in the internal schema
+            await collections.test.insert({
+                id: 'test-1',
+                credentials: {
+                    password: 'my secret password',
+                    username: 'alice'
+                }
+            });
+            const doc = await collections.test.findOne('test-1').exec(true);
+            assert.strictEqual(doc.credentials.password, 'my secret password');
+            assert.strictEqual(doc.credentials.username, 'alice');
+
+            // update the encrypted nested field
+            await doc.incrementalPatch({
+                credentials: {
+                    password: 'new secret password',
+                    username: 'alice'
+                }
+            });
+            const updatedDoc = await collections.test.findOne('test-1').exec(true);
+            assert.strictEqual(updatedDoc.credentials.password, 'new secret password');
+
+            await db.remove();
+        });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- CHANGELOG

## Describe the problem you have without this PR

When using nested encrypted field paths (e.g., `'credentials.password'`) in the encryption plugin, the schema transformation logic was not properly handling the nested structure. This caused constraints like `maxLength` to not be stripped from the internal schema, resulting in validation errors when the encrypted ciphertext exceeded the original field's `maxLength` constraint.

## Changes

### Source Code
Modified `src/plugins/encryption-crypto-js/index.ts` to properly traverse nested object paths when transforming encrypted field schemas. Instead of directly accessing the top-level properties, the code now:
1. Splits the encrypted field path by dots (e.g., `'credentials.password'` → `['credentials', 'password']`)
2. Traverses through the nested schema structure to reach the target field
3. Replaces only the final nested field with a simple `{ type: 'string' }` schema

This ensures that all constraints (like `maxLength`) are properly removed from encrypted fields, regardless of nesting depth.

### Tests
Added comprehensive test case `'should work with nested encrypted field paths that have maxLength in schema'` that:
- Defines a schema with a nested encrypted field (`credentials.password`) that has a `maxLength` constraint
- Inserts a document where the encrypted ciphertext exceeds the original `maxLength`
- Verifies the document is stored and retrieved correctly
- Tests updating the encrypted nested field to ensure the fix works for both insert and update operations

## Test Plan
The added unit test covers the specific scenario that was failing: inserting and updating documents with nested encrypted fields that have `maxLength` constraints. The test verifies that encryption/decryption works correctly even when the ciphertext exceeds the original field's length constraint.

https://claude.ai/code/session_01GqForW2pYn6M18MUnV7dXR