### PR TITLE
Fix populate() array order when documents reference same IDs differently

### DIFF
--- a/orga/changelog/fix-population-array-order.md
+++ b/orga/changelog/fix-population-array-order.md
@@ -1,0 +1,1 @@
+- FIX `populate()` on array ref fields returning documents in wrong order when two documents reference the same set of IDs in different order, because `findByIds` query cache deduplication reused a cached query whose Map iteration order matched the first caller instead of preserving each document's own ref array order

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -216,8 +216,17 @@ export const basePrototype = {
 
         if (schemaObj.type === 'array') {
             return refCollection.findByIds(value).exec().then(res => {
-                const valuesIterator = res.values();
-                return Array.from(valuesIterator) as any;
+                // Preserve the original array order of the ref ids
+                // instead of using the Map iteration order which depends
+                // on the query cache and storage return order.
+                const result = [];
+                for (let i = 0; i < value.length; i++) {
+                    const doc = res.get(value[i]);
+                    if (doc) {
+                        result.push(doc);
+                    }
+                }
+                return result as any;
             });
         } else {
             return refCollection.findOne(value).exec();

--- a/test/unit/population.test.ts
+++ b/test/unit/population.test.ts
@@ -354,5 +354,69 @@ describeParallel('population.test.js', () => {
 
             db.close();
         });
+        it('populate array should preserve the order of ref ids when two documents reference the same set in different order', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+            });
+            const cols = await db.addCollections({
+                human: {
+                    schema: {
+                        version: 0,
+                        primaryKey: 'name',
+                        type: 'object',
+                        properties: {
+                            name: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            friends: {
+                                type: 'array',
+                                ref: 'human',
+                                items: {
+                                    type: 'string'
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            const col = cols.human;
+
+            const friendNames = ['charlie', 'alice', 'bob', 'eve', 'dave'];
+            await Promise.all(
+                friendNames.map(name => col.insert({ name, friends: [] }))
+            );
+
+            // Two documents reference the same set of friends but in different order.
+            // Because findByIds uses a sorted cache key, the second populate call
+            // would reuse the first cached query and return documents in the wrong order.
+            const orderA = ['eve', 'bob', 'charlie', 'alice', 'dave'];
+            const orderB = ['dave', 'alice', 'charlie', 'bob', 'eve'];
+            await col.insert({ name: 'protagonist-a', friends: orderA });
+            await col.insert({ name: 'protagonist-b', friends: orderB });
+
+            const docA = await col.findOne('protagonist-a').exec(true);
+            const docB = await col.findOne('protagonist-b').exec(true);
+
+            const friendDocsA = await docA.populate('friends');
+            const friendDocsB = await docB.populate('friends');
+
+            const populatedNamesA = friendDocsA.map((d: any) => d.name);
+            const populatedNamesB = friendDocsB.map((d: any) => d.name);
+
+            assert.deepStrictEqual(
+                populatedNamesA,
+                orderA,
+                'populated array order for docA must match its ref id order'
+            );
+            assert.deepStrictEqual(
+                populatedNamesB,
+                orderB,
+                'populated array order for docB must match its ref id order'
+            );
+
+            db.close();
+        });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

When calling `populate()` on array ref fields, if two documents reference the same set of IDs but in different orders, the second document's populated array would be returned in the wrong order. This occurred because `findByIds()` uses a query cache with a sorted cache key for deduplication. When the cache was hit, the Map iteration order from the first caller's query would be reused instead of preserving each document's own ref array order.

## Solution

Modified the `populate()` implementation in `rx-document.ts` to explicitly preserve the original array order of ref IDs instead of relying on Map iteration order. After fetching documents via `findByIds()`, the code now iterates through the original ref ID array and retrieves each document from the result Map in the correct order.

## Changes

- **src/rx-document.ts**: Updated array population logic to iterate through the original ref ID array and maintain order
- **test/unit/population.test.ts**: Added comprehensive test case that verifies two documents referencing the same set of friends in different orders both populate with correct ordering
- **orga/changelog/fix-population-array-order.md**: Added changelog entry documenting the fix

## Test Plan

Added unit test `populate array should preserve the order of ref ids when two documents reference the same set in different order` that:
1. Creates multiple documents with array ref fields
2. Inserts two documents that reference the same set of IDs in different orders
3. Populates both documents and verifies each maintains its own ref array order
4. Asserts that the populated arrays match the original ref ID order for each document

https://claude.ai/code/session_01G15zT27RNZ2Vquj3oFYHdc