### PR TITLE
Fix RxLocalDocument.get$() emitting spurious values on nested paths

### DIFF
--- a/orga/changelog/fix-local-document-get-deep-equal.md
+++ b/orga/changelog/fix-local-document-get-deep-equal.md
@@ -1,0 +1,1 @@
+- FIX `RxLocalDocument.get$()` on nested object/array paths emitting spurious values when unrelated document fields changed, because `distinctUntilChanged()` used reference equality which always fails for non-primitive values across document revisions

--- a/src/plugins/local-documents/rx-local-document.ts
+++ b/src/plugins/local-documents/rx-local-document.ts
@@ -36,6 +36,7 @@ import type {
     RxStorageChangeEvent
 } from '../../types/';
 import {
+    deepEqual,
     ensureNotFalsy,
     flatClone,
     getFromMapOrThrow,
@@ -161,7 +162,7 @@ const RxLocalDocumentPrototype: any = {
             .pipe(
                 map((localDocument: any) => localDocument._data),
                 map((data: any) => getProperty(data, objPath)),
-                distinctUntilChanged()
+                distinctUntilChanged(deepEqual)
             );
     },
     get$$(this: RxDocument, objPath: string) {

--- a/test/unit/reactivity.test.ts
+++ b/test/unit/reactivity.test.ts
@@ -22,8 +22,10 @@ import {
 } from '../../plugins/core/index.mjs';
 
 import { RxDBQueryBuilderPlugin } from '../../plugins/query-builder/index.mjs';
+import { RxDBLocalDocumentsPlugin } from '../../plugins/local-documents/index.mjs';
 import { PREACT_SIGNAL_STATE, PreactSignalReactivityLambda, PreactSignalsRxReactivityFactory } from '../../plugins/reactivity-preact-signals/index.mjs';
 addRxPlugin(RxDBQueryBuilderPlugin);
+addRxPlugin(RxDBLocalDocumentsPlugin);
 
 
 
@@ -207,5 +209,77 @@ describeParallel('reactivity.test.ts', () => {
             await db.close();
         });
     });
-    describe('issues', () => { });
+    describe('issues', () => {
+        it('RxLocalDocument.get$() should not emit spurious values on nested object paths', async () => {
+            const collection = await getReactivityCollection();
+            const db = collection.database;
+            const localDoc = await db.insertLocal('nested-test', {
+                nested: { foo: 'bar' },
+                counter: 0
+            });
+
+            // subscribe to the nested object path via get$
+            const emitted: any[] = [];
+            const sub = localDoc.get$('nested').subscribe((val: any) => {
+                emitted.push(val);
+            });
+
+            // wait for initial emission
+            await waitUntil(() => emitted.length >= 1);
+            assert.deepStrictEqual(emitted[0], { foo: 'bar' });
+
+            // update an UNRELATED field - should NOT cause get$('nested') to re-emit
+            await localDoc.incrementalPatch({ counter: 1 });
+            await localDoc.incrementalPatch({ counter: 2 });
+
+            // give time for potential spurious emissions
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            // BUG: without deepEqual in distinctUntilChanged, we get spurious emissions
+            // because each document revision creates new object references for nested objects
+            assert.strictEqual(
+                emitted.length,
+                1,
+                'get$ on a nested object path should not emit when an unrelated field changes, but got ' + emitted.length + ' emissions'
+            );
+
+            sub.unsubscribe();
+            await db.close();
+        });
+        it('RxLocalDocument.get$$() should not emit spurious values on nested object paths', async () => {
+            const collection = await getReactivityCollection();
+            const db = collection.database;
+            const localDoc = await db.insertLocal('nested-test-signal', {
+                nested: { foo: 'bar' },
+                counter: 0
+            });
+
+            // get the reactive value for nested object path
+            const signal: ReactivityType = localDoc.get$$('nested') as any;
+
+            // subscribe to track emissions from the underlying observable
+            const emitted: any[] = [];
+            const sub = signal.obs.subscribe((val: any) => {
+                emitted.push(val);
+            });
+
+            await waitUntil(() => emitted.length >= 1);
+            assert.deepStrictEqual(emitted[0], { foo: 'bar' });
+
+            // update an UNRELATED field
+            await localDoc.incrementalPatch({ counter: 1 });
+            await localDoc.incrementalPatch({ counter: 2 });
+
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            assert.strictEqual(
+                emitted.length,
+                1,
+                'get$$ on a nested object path should not emit when an unrelated field changes, but got ' + emitted.length + ' emissions'
+            );
+
+            sub.unsubscribe();
+            await db.close();
+        });
+    });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

`RxLocalDocument.get$()` and `get$$()` were emitting spurious values when subscribing to nested object/array paths. When an unrelated field in the document changed, the observable would re-emit the nested value even though it hadn't actually changed. This occurred because `distinctUntilChanged()` was using reference equality, which always fails for non-primitive values across document revisions (each revision creates new object references).

## Solution

Updated `RxLocalDocument.get$()` to use `distinctUntilChanged(deepEqual)` instead of the default reference equality check. This ensures that nested objects and arrays are compared by value rather than by reference, preventing spurious emissions when unrelated fields change.

## Changes Made

1. **src/plugins/local-documents/rx-local-document.ts**: Modified the `get$()` method to pass `deepEqual` to `distinctUntilChanged()` operator
2. **test/unit/reactivity.test.ts**: Added two comprehensive test cases:
   - `RxLocalDocument.get$() should not emit spurious values on nested object paths` - Tests the observable-based API
   - `RxLocalDocument.get$$() should not emit spurious values on nested object paths` - Tests the signal-based API
3. **orga/changelog/fix-local-document-get-deep-equal.md**: Added changelog entry documenting the fix

## Test Plan

Added unit tests that verify the fix by:
1. Creating a local document with nested objects
2. Subscribing to a nested path via `get$()`/`get$$()`
3. Updating unrelated fields
4. Asserting that no spurious emissions occur

The tests confirm that only the initial emission is received, and subsequent unrelated field changes do not trigger re-emissions.

https://claude.ai/code/session_01L4VNEr2ifZRnezewmK8rXU