### PR TITLE
Fix WebMCP changes tool to strip internal meta fields

### DIFF
--- a/orga/changelog/fix-webmcp-changes-meta-fields.md
+++ b/orga/changelog/fix-webmcp-changes-meta-fields.md
@@ -1,0 +1,1 @@
+- FIX WebMCP `changes` tool returning documents with internal meta fields (`_meta`, `_rev`, `_attachments`, `_deleted`) instead of stripping them like the query, insert, upsert, and delete tools do via `toJSON()`

--- a/src/plugins/webmcp/webmcp.ts
+++ b/src/plugins/webmcp/webmcp.ts
@@ -196,7 +196,17 @@ export function registerWebMCPCollection(this: RxCollection, options?: WebMCPOpt
             const limit = args.limit || 50;
             const storageInstance = collection.storageInstance;
             const changes = await getChangedDocumentsSince(storageInstance, limit, args.checkpoint);
-            return changes;
+            return {
+                documents: changes.documents.map((doc: any) => {
+                    const cleaned = Object.assign({}, doc);
+                    delete cleaned._meta;
+                    delete cleaned._rev;
+                    delete cleaned._attachments;
+                    delete cleaned._deleted;
+                    return cleaned;
+                }),
+                checkpoint: changes.checkpoint
+            };
         })
     });
 

--- a/test/unit/webmcp.test.ts
+++ b/test/unit/webmcp.test.ts
@@ -117,6 +117,40 @@ describe('webmcp.test.ts', () => {
         assert.strictEqual(waitResolved, true);
     });
 
+    it('changes tool should return documents without internal meta fields', async () => {
+        db.registerWebMCP();
+        const tools = getTools();
+        const queryTool = tools.find((t: any) => t.name.startsWith(`rxdb_query_${db.name}_humans`));
+        const changesTool = tools.find((t: any) => t.name.startsWith(`rxdb_changes_${db.name}_humans`));
+
+        await collection.insert(schemaObjects.humanData('meta_alice'));
+
+        // Get document via query tool (uses toJSON, strips meta)
+        const queryResult = await executeTool(queryTool.name, { query: { selector: { passportId: 'meta_alice' } } });
+        assert.strictEqual(queryResult.length, 1);
+
+        // Get document via changes tool
+        const changesResult = await executeTool(changesTool.name, { limit: 10 });
+        assert.strictEqual(changesResult.documents.length, 1);
+
+        const queryDoc = queryResult[0];
+        const changesDoc = changesResult.documents[0];
+
+        // The changes tool should return documents in the same shape as query tool
+        // Internal meta fields like _meta, _rev, _attachments, _deleted should not be exposed
+        assert.strictEqual(changesDoc._meta, undefined, 'changes tool should not expose _meta');
+        assert.strictEqual(changesDoc._rev, undefined, 'changes tool should not expose _rev');
+        assert.strictEqual(changesDoc._attachments, undefined, 'changes tool should not expose _attachments');
+        assert.strictEqual(changesDoc._deleted, undefined, 'changes tool should not expose _deleted');
+
+        // The document fields should match between both tools
+        assert.deepStrictEqual(
+            Object.keys(queryDoc).sort(),
+            Object.keys(changesDoc).sort(),
+            'changes tool documents should have the same keys as query tool documents'
+        );
+    });
+
     it('should iterate over changes using checkpoint', async () => {
         db.registerWebMCP();
         const tools = getTools();


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- IMPROVED DOCS

## Describe the problem you have without this PR

The WebMCP `changes` tool was returning documents with internal RxDB meta fields (`_meta`, `_rev`, `_attachments`, `_deleted`) exposed to the client. Other WebMCP tools like `query`, `insert`, `upsert`, and `delete` properly strip these internal fields using `toJSON()`, but the `changes` tool was not doing the same, creating an inconsistency in the API surface.

## Changes

### Source Code
- Modified `registerWebMCPCollection()` in `src/plugins/webmcp/webmcp.ts` to filter out internal meta fields from documents returned by the `changes` tool, matching the behavior of other tools

### Tests
- Added comprehensive test case `'changes tool should return documents without internal meta fields'` that verifies:
  - Internal fields (`_meta`, `_rev`, `_attachments`, `_deleted`) are not exposed
  - Document structure matches between `query` and `changes` tools
  - The changes tool returns documents in the same shape as the query tool

### Documentation
- Added changelog entry documenting the fix

## Test Plan

The added unit test covers the fix by:
1. Inserting a document via the collection
2. Retrieving it via both the `query` and `changes` tools
3. Asserting that internal meta fields are undefined in the changes result
4. Verifying that both tools return documents with identical keys

Existing tests continue to pass, confirming no regressions were introduced.

https://claude.ai/code/session_013dsgjLo5pEsRyizRTMkApN