### PR TITLE
Fix populate() for array fields with ref on items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 17.1.0 (2 April 2026)
 
+- FIX `RxDocument.populate()` throwing `DOC6` for array fields when `ref` is defined on `items` instead of on the array field itself, even though `createRxSchema` accepts both patterns
 - FIX CRDT plugin `bulkInsert` hook not including schema default values in CRDT operations, causing data loss during conflict resolution rebuild when fields rely on schema defaults
 - FIX `RxDocument.get$()` on nested object/array paths emitting spurious values when unrelated document fields changed, because `distinctUntilChanged()` used reference equality which always fails for non-primitive values across document revisions
 - FIX `incrementalUpsert()` throwing a CONFLICT error when a concurrent `upsert()`/`insert()` creates the same document between the internal `findOne()` and `insert()` calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### 17.1.0 (2 April 2026)
 
-- FIX `RxDocument.populate()` throwing `DOC6` for array fields when `ref` is defined on `items` instead of on the array field itself, even though `createRxSchema` accepts both patterns
 - FIX CRDT plugin `bulkInsert` hook not including schema default values in CRDT operations, causing data loss during conflict resolution rebuild when fields rely on schema defaults
 - FIX `RxDocument.get$()` on nested object/array paths emitting spurious values when unrelated document fields changed, because `distinctUntilChanged()` used reference equality which always fails for non-primitive values across document revisions
 - FIX `incrementalUpsert()` throwing a CONFLICT error when a concurrent `upsert()`/`insert()` creates the same document between the internal `findOne()` and `insert()` calls

--- a/orga/changelog/fix-populate-array-items-ref.md
+++ b/orga/changelog/fix-populate-array-items-ref.md
@@ -1,0 +1,1 @@
+- FIX `RxDocument.populate()` throwing `DOC6` for array fields when `ref` is defined on `items` instead of on the array field itself, even though `createRxSchema` accepts both patterns

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -198,17 +198,22 @@ export const basePrototype = {
                 path
             });
         }
-        if (!schemaObj.ref) {
+        const ref = schemaObj.ref
+            ? schemaObj.ref
+            : (schemaObj.type === 'array' && schemaObj.items && (schemaObj.items as any).ref
+                ? (schemaObj.items as any).ref
+                : undefined);
+        if (!ref) {
             throw newRxError('DOC6', {
                 path,
                 schemaObj
             });
         }
 
-        const refCollection: RxCollection = this.collection.database.collections[schemaObj.ref];
+        const refCollection: RxCollection = this.collection.database.collections[ref];
         if (!refCollection) {
             throw newRxError('DOC7', {
-                ref: schemaObj.ref,
+                ref,
                 path,
                 schemaObj
             });

--- a/test/unit/population.test.ts
+++ b/test/unit/population.test.ts
@@ -418,5 +418,62 @@ describeParallel('population.test.js', () => {
 
             db.close();
         });
+        it('populate array when ref is defined on items instead of on the array field', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+            });
+            const cols = await db.addCollections({
+                human: {
+                    schema: {
+                        version: 0,
+                        primaryKey: 'name',
+                        type: 'object',
+                        properties: {
+                            name: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            friends: {
+                                type: 'array',
+                                items: {
+                                    ref: 'human',
+                                    type: 'string'
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            const col = cols.human;
+
+            const friendNames = ['alice', 'bob', 'charlie'];
+            await Promise.all(
+                friendNames.map(name => col.insert({ name, friends: [] }))
+            );
+            await col.insert({
+                name: 'protagonist',
+                friends: friendNames
+            });
+
+            const doc = await col.findOne('protagonist').exec(true);
+
+            // populate() must work when 'ref' is on items
+            const friendDocs = await doc.populate('friends');
+            assert.ok(Array.isArray(friendDocs));
+            assert.strictEqual(friendDocs.length, 3);
+            friendDocs.forEach((friend: any) => {
+                assert.ok(isRxDocument(friend));
+            });
+            const populatedNames = friendDocs.map((d: any) => d.name);
+            assert.deepStrictEqual(populatedNames, friendNames);
+
+            // pseudo-proxy _ getter must also work
+            const friendDocs2 = await (doc as any).friends_;
+            assert.ok(Array.isArray(friendDocs2));
+            assert.strictEqual(friendDocs2.length, 3);
+
+            db.close();
+        });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

`RxDocument.populate()` was throwing a `DOC6` error when called on array fields that have the `ref` property defined on the `items` schema object instead of on the array field itself. However, `createRxSchema` accepts both patterns as valid, creating an inconsistency.

For example, this schema pattern was not supported by `populate()`:
```javascript
friends: {
    type: 'array',
    items: {
        ref: 'human',
        type: 'string'
    }
}
```

## Changes

### Source Code
Modified `src/rx-document.ts` to check for `ref` in two locations:
1. Directly on the schema object (existing behavior)
2. On the `items` property if the field is an array (new behavior)

This allows `populate()` to work with both ref definition patterns that the schema validation already accepts.

### Tests
Added comprehensive unit test in `test/unit/population.test.ts` that:
- Creates a schema with `ref` defined on array `items`
- Inserts documents with array references
- Verifies `populate()` correctly resolves the references
- Verifies the pseudo-proxy `_` getter also works with this pattern

### Documentation
Updated `CHANGELOG.md` with the fix description.

## Test Plan
Added unit tests that cover the fix. The test creates documents with array fields containing refs defined on items, calls `populate()`, and verifies the references are correctly resolved to RxDocument instances.

https://claude.ai/code/session_012UknZ1m9tWSKkdi8nmWcqJ