### PR TITLE
Fix getJsonSchemaWithoutMeta() not removing internal fields from indexes

### DIFF
--- a/orga/changelog/fix-getjsonschemawithoutmeta-indexes.md
+++ b/orga/changelog/fix-getjsonschemawithoutmeta-indexes.md
@@ -1,0 +1,1 @@
+- FIX `getJsonSchemaWithoutMeta()` not removing internal meta field references (`_deleted`, `_meta.lwt`) from indexes, while correctly removing them from properties and required, causing the returned schema to be internally inconsistent

--- a/src/rx-schema.ts
+++ b/src/rx-schema.ts
@@ -86,6 +86,16 @@ export class RxSchema<RxDocType = any> {
             jsonSchema.required = jsonSchema.required.filter((r: string) => !r.startsWith('_'));
         }
 
+        // remove internal meta fields from indexes, consistent with properties and required cleanup
+        if (jsonSchema.indexes) {
+            jsonSchema.indexes = jsonSchema.indexes
+                .map((index: string | string[]) => {
+                    const arr: string[] = isMaybeReadonlyArray(index) ? [...index] : [index];
+                    return arr.filter((field: string) => !field.startsWith('_'));
+                })
+                .filter((index: string[]) => index.length > 0);
+        }
+
         return jsonSchema as RxJsonSchema<RxDocumentData<RxDocType>>;
     }
 

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -1479,6 +1479,38 @@ describeParallel('rx-schema.test.ts', () => {
 
             await db.close();
         });
+        it('indexes should not reference internal meta fields that are removed from properties', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage()
+            });
+            const collections = await db.addCollections({
+                humans: {
+                    schema: schemas.human
+                }
+            });
+            const schemaWithoutMeta = collections.humans.schema.getJsonSchemaWithoutMeta();
+            const propertyKeys = Object.keys(schemaWithoutMeta.properties);
+
+            // every field referenced in an index must exist in properties
+            const indexes = schemaWithoutMeta.indexes as string[][];
+            for (const index of indexes) {
+                const fields = Array.isArray(index) ? index : [index];
+                for (const field of fields) {
+                    const topLevelField = field.split('.')[0];
+                    assert.ok(
+                        propertyKeys.includes(topLevelField),
+                        'index field "' + field + '" references property "' + topLevelField + '" which does not exist in the schema returned by getJsonSchemaWithoutMeta()'
+                    );
+                }
+            }
+
+            // user-defined index fields should still be present
+            const allIndexFields = indexes.flat();
+            assert.ok(allIndexFields.includes('firstName'), 'user-defined index field "firstName" should be present');
+
+            await db.close();
+        });
     });
     describe('wait a bit', () => {
         it('w8 a bit', async () => {


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

The `getJsonSchemaWithoutMeta()` method was inconsistently handling internal meta fields. While it correctly removed internal fields (those starting with `_`) from the `properties` and `required` arrays, it was not removing references to these fields from the `indexes` array. This resulted in a schema where indexes referenced fields that no longer existed in the properties, making the returned schema internally inconsistent.

## Changes Made

### Source Code (`src/rx-schema.ts`)
Added logic to filter out internal meta field references from indexes in the `getJsonSchemaWithoutMeta()` method:
- Processes each index (which can be a string or array of strings)
- Removes any fields starting with `_` from each index
- Filters out empty indexes that contained only internal fields
- Maintains consistency with the existing cleanup of properties and required fields

### Tests (`test/unit/rx-schema.test.ts`)
Added a comprehensive test case that verifies:
- Every field referenced in an index exists in the schema properties returned by `getJsonSchemaWithoutMeta()`
- User-defined index fields (like `firstName`) are preserved
- The schema is internally consistent after removing meta fields

### Changelog
Added entry documenting the fix for the inconsistency in `getJsonSchemaWithoutMeta()`.

## Test Plan
The added unit test validates that all index field references are present in the schema properties, ensuring the fix works correctly and preventing regression.

https://claude.ai/code/session_01JzvzrsJQH7Yp3BYqWRSQHf