### PR TITLE
Fix remote storage remove() not completing changeStream observable

### DIFF
--- a/orga/changelog/fix-remote-storage-remove-cleanup.md
+++ b/orga/changelog/fix-remote-storage-remove-cleanup.md
@@ -1,0 +1,1 @@
+- FIX remote storage `remove()` not unsubscribing from internal subscriptions and not completing the `changeStream()` observable, unlike `close()` which correctly performs both cleanup steps

--- a/src/plugins/storage-remote/rx-storage-remote.ts
+++ b/src/plugins/storage-remote/rx-storage-remote.ts
@@ -281,6 +281,8 @@ export class RxStorageInstanceRemote<RxDocType> implements RxStorageInstance<RxD
             throw new Error('already closed');
         }
         this.closed = (async () => {
+            this.subs.forEach(sub => sub.unsubscribe());
+            this.changes$.complete();
             await this.requestRemote('remove', []);
             await closeMessageChannel(this.internals.messageChannel);
         })();

--- a/test/unit/rx-storage-remote.test.ts
+++ b/test/unit/rx-storage-remote.test.ts
@@ -402,6 +402,45 @@ describeParallel('rx-storage-remote.test.ts', () => {
             await database.close();
         });
     });
+    describe('remove()', () => {
+        it('should complete the changeStream observable when remove() is called', async () => {
+            const port = await nextPort();
+            const server = await startRxStorageRemoteWebsocketServer({
+                port,
+                storage: memoryStorageWithValidation
+            });
+            assert.ok(server);
+
+            const storage = getRxStorageRemoteWebsocket({
+                url: 'ws://localhost:' + port,
+                mode: 'storage'
+            });
+            const storageInstance = await storage.createStorageInstance({
+                databaseInstanceToken: randomToken(10),
+                databaseName: randomToken(10),
+                collectionName: randomToken(10),
+                devMode: true,
+                multiInstance: false,
+                options: {},
+                schema: fillWithDefaultSettings(schemas.human)
+            });
+
+            let completed = false;
+            storageInstance.changeStream().subscribe({
+                complete() {
+                    completed = true;
+                }
+            });
+
+            await storageInstance.remove();
+
+            /**
+             * The changeStream() observable must complete
+             * after calling remove(), just like it does after close().
+             */
+            assert.strictEqual(completed, true);
+        });
+    });
     describe('custom requests', () => {
         it('should send the message and get the answer', async () => {
             const port = await nextPort();


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

The `remove()` method in `RxStorageInstanceRemote` was not properly cleaning up internal subscriptions or completing the `changeStream()` observable, unlike the `close()` method which correctly performs both cleanup steps. This inconsistency could lead to memory leaks and subscribers not being notified when the storage instance is removed.

## Changes Made

### Source Code
- Updated `RxStorageInstanceRemote.remove()` to unsubscribe from all internal subscriptions and complete the `changes$` observable before removing the remote storage instance, matching the cleanup behavior of `close()`

### Tests
- Added comprehensive unit test verifying that `changeStream()` observable completes when `remove()` is called on a remote storage instance

### Documentation
- Added changelog entry documenting the fix

## Test Plan

The added unit test (`should complete the changeStream observable when remove() is called`) verifies that:
1. A remote storage instance can be created with a WebSocket server
2. A subscription to `changeStream()` is established
3. After calling `remove()`, the changeStream observable completes as expected

This ensures the fix works correctly and prevents regression.

https://claude.ai/code/session_0139kXkpQaRPk7e1rFvYNELc