### PR TITLE
Fix query cache eviction with subscribed queries

### DIFF
--- a/orga/changelog/fix-query-cache-eviction-with-subscribers.md
+++ b/orga/changelog/fix-query-cache-eviction-with-subscribers.md
@@ -1,0 +1,1 @@
+- FIX default cache replacement policy not evicting executed unsubscribed queries when subscribed queries caused the total cache size to exceed `tryToKeepMax`, because the eviction count was calculated from only the unsubscribed query count instead of the total cache size

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -92,7 +92,7 @@ export const defaultCacheReplacementPolicyMonad: (
                 maybeUncache.push(rxQuery);
             }
 
-            const mustUncache = maybeUncache.length - tryToKeepMax;
+            const mustUncache = queryCache._map.size - tryToKeepMax;
             if (mustUncache <= 0) {
                 return;
             }

--- a/test/unit/cache-replacement-policy.test.ts
+++ b/test/unit/cache-replacement-policy.test.ts
@@ -202,6 +202,66 @@ describeParallel('cache-replacement-policy.test.js', () => {
 
             col.database.remove();
         });
+        it('should evict executed unsubscribed queries when subscribed queries push total cache over tryToKeepMax', async () => {
+            const tryToKeepMax = 5;
+            const col = await humansCollection.create(0);
+
+            // Set no-op policy to prevent automatic cleanup during setup
+            col.cacheReplacementPolicy = () => { };
+
+            // Create 6 subscribed queries (more than tryToKeepMax alone)
+            const subs: Subscription[] = [];
+            for (let i = 0; i < 6; i++) {
+                subs.push(col.find({
+                    selector: { firstName: 'sub' + i }
+                }).$.subscribe());
+            }
+
+            // Create 3 executed queries without subscribers
+            const executedQueries: RxQuery[] = [];
+            for (let i = 0; i < 3; i++) {
+                const q = col.find({
+                    selector: { firstName: 'exec' + i }
+                });
+                await q.exec();
+                executedQueries.push(q);
+            }
+
+            // Total in cache: 6 subscribed + 3 executed = 9 > tryToKeepMax (5)
+            // After policy: subscribed queries cannot be removed,
+            // so the 3 executed unsubscribed ones should be evicted.
+
+            // Wait for any pending automatic cache replacement to finish
+            await wait(500);
+
+            // Set the real policy and trigger
+            let policyRan = false;
+            const realPolicy = defaultCacheReplacementPolicyMonad(tryToKeepMax, 0);
+            col.cacheReplacementPolicy = (collection, queryCache) => {
+                realPolicy(collection, queryCache);
+                policyRan = true;
+            };
+
+            triggerCacheReplacement(col);
+            await waitUntil(() => policyRan);
+
+            // Re-create the same queries.
+            // If properly evicted, these will be NEW objects (different reference).
+            // If the bug is present, they stay cached (same reference).
+            for (let i = 0; i < 3; i++) {
+                const newQ = col.find({
+                    selector: { firstName: 'exec' + i }
+                });
+                assert.notStrictEqual(
+                    newQ,
+                    executedQueries[i],
+                    'Expected executed query exec' + i + ' to be evicted from cache'
+                );
+            }
+
+            subs.forEach(sub => sub.unsubscribe());
+            col.database.close();
+        });
         it('should remove the oldest ones', async () => {
             const col = await humansCollection.create(0);
             const amount = 10;


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

The default cache replacement policy was not correctly evicting executed unsubscribed queries when the total cache size (including subscribed queries) exceeded `tryToKeepMax`. 

The bug occurred because the eviction count was calculated from only the count of unsubscribed queries (`maybeUncache.length`) instead of the total cache size (`queryCache._map.size`). This meant that when subscribed queries pushed the total cache over the limit, the policy would underestimate how many queries needed to be evicted, leaving executed unsubscribed queries in the cache.

## Changes

### Source Code
- **src/query-cache.ts**: Fixed the `defaultCacheReplacementPolicyMonad` to calculate `mustUncache` based on the total cache size rather than just the unsubscribed query count. This ensures that when the total cache exceeds `tryToKeepMax`, the correct number of queries are evicted.

### Tests
- **test/unit/cache-replacement-policy.test.ts**: Added a comprehensive test case that verifies executed unsubscribed queries are properly evicted when subscribed queries cause the total cache to exceed `tryToKeepMax`. The test confirms that evicted queries are removed from the cache by checking that recreated queries are new objects (different references).

### Documentation
- Added changelog entry documenting the fix.

## Test Plan

The added unit test `should evict executed unsubscribed queries when subscribed queries push total cache over tryToKeepMax` covers this fix by:
1. Creating 6 subscribed queries (exceeding `tryToKeepMax` of 5)
2. Creating 3 executed unsubscribed queries
3. Triggering the cache replacement policy
4. Verifying that the executed queries are evicted by confirming newly created queries with the same selectors are different objects

Existing tests continue to pass, confirming no regression in other cache replacement scenarios.

https://claude.ai/code/session_0142yKookkg4jYVaVm8botMb