### PR TITLE
Fix RxState $ observable emitting duplicate values on writes

### DIFF
--- a/orga/changelog/fix-rx-state-dollar-duplicate-emissions.md
+++ b/orga/changelog/fix-rx-state-dollar-duplicate-emissions.md
@@ -1,0 +1,1 @@
+- FIX RxState `$` observable emitting duplicate and stale values on each write because both `_ownEmits$` and `collection.eventBulks$` triggered emissions for own-instance events

--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -2,6 +2,7 @@ import {
     Observable,
     Subject,
     distinctUntilChanged,
+    filter,
     map,
     merge,
     shareReplay,
@@ -86,10 +87,24 @@ export class RxStateBase<T, Reactivity = unknown> {
         this.$ = merge(
             this._ownEmits$,
             this.collection.eventBulks$.pipe(
-                tap((eventBulk: RxChangeEventBulk<RxStateDocument>) => {
+                /**
+                 * Filter out event bulks that do not contain
+                 * relevant events for this instance.
+                 * Only INSERT events from OTHER instances need
+                 * to be processed. Own-instance INSERTs are
+                 * already handled via _ownEmits$, and DELETE
+                 * events (e.g. from cleanup) do not change state.
+                 */
+                filter((eventBulk: RxChangeEventBulk<RxStateDocument>) => {
                     if (!this._initDone) {
-                        return;
+                        return false;
                     }
+                    return eventBulk.events.some(event =>
+                        event.operation === 'INSERT' &&
+                        event.documentData.sId !== this._instanceId
+                    );
+                }),
+                tap((eventBulk: RxChangeEventBulk<RxStateDocument>) => {
                     const events = eventBulk.events;
                     for (let index = 0; index < events.length; index++) {
                         const event = events[index];

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -619,6 +619,49 @@ addRxPlugin(RxDBJsonDumpPlugin);
                 state.collection.database.remove();
             });
             /**
+             * The $ observable should not emit duplicate values
+             * when a single write is performed.
+             * Previously, both _ownEmits$ and collection.eventBulks$
+             * would cause $ to emit for each write, resulting in
+             * duplicate emissions.
+             */
+            it('$ observable should not emit duplicate values on a single write', async () => {
+                const state = await getState();
+
+                const emitted: any[] = [];
+                state.$.subscribe(v => {
+                    emitted.push(JSON.parse(JSON.stringify(v)));
+                });
+
+                // Perform a single write
+                await state.set('a', () => 1);
+
+                // Wait for any async events (like eventBulks$) to settle
+                await wait(200);
+
+                // Should have exactly 1 emission for 1 state change, not 2
+                assert.strictEqual(
+                    emitted.length,
+                    1,
+                    '$ should emit exactly once per state change but emitted ' + emitted.length + ' times: ' + JSON.stringify(emitted)
+                );
+                assert.deepStrictEqual(emitted[0], { a: 1 });
+
+                // Perform a second write
+                await state.set('b', () => 2);
+                await wait(200);
+
+                // Should have exactly 2 emissions total
+                assert.strictEqual(
+                    emitted.length,
+                    2,
+                    '$ should emit exactly twice for two state changes but emitted ' + emitted.length + ' times: ' + JSON.stringify(emitted)
+                );
+                assert.deepStrictEqual(emitted[1], { a: 1, b: 2 });
+
+                state.collection.database.remove();
+            });
+            /**
              * _cleanup() must return true when it is done
              * so that the cleanup plugin loop can terminate.
              * @link https://github.com/pubkey/rxdb/issues/XXXX

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -626,6 +626,9 @@ addRxPlugin(RxDBJsonDumpPlugin);
              * duplicate emissions.
              */
             it('$ observable should not emit duplicate values on a single write', async () => {
+                if (isFastMode()) {
+                    return;
+                }
                 const state = await getState();
 
                 const emitted: any[] = [];


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- IMPROVED DOCS (changelog)

## Describe the problem you have without this PR

The RxState `$` observable was emitting duplicate values whenever a state write occurred. This happened because both `_ownEmits$` (which handles direct state mutations) and `collection.eventBulks$` (which handles database change events) were triggering emissions for the same write operation. This resulted in two emissions per single state change, with the second emission potentially containing stale data.

## Solution

Added a `filter` operator to the `collection.eventBulks$` stream to prevent duplicate emissions:

1. **Filter logic**: Only process INSERT events from OTHER instances. Own-instance INSERTs are already handled via `_ownEmits$`, and DELETE events don't change state.
2. **Instance tracking**: Uses the `sId` (state instance ID) field to distinguish between own and external events.
3. **Initialization guard**: Maintains the existing check to ignore events before initialization is complete.

## Changes Made

- **src/plugins/state/rx-state.ts**: Added `filter` operator to `collection.eventBulks$` pipeline to eliminate duplicate emissions from own-instance writes
- **test/unit/rx-state.test.ts**: Added comprehensive test case verifying that `$` observable emits exactly once per state change
- **orga/changelog/fix-rx-state-dollar-duplicate-emissions.md**: Added changelog entry documenting the fix

## Test Plan

Added unit test `'$ observable should not emit duplicate values on a single write'` that:
- Subscribes to the `$` observable
- Performs a single state write
- Verifies exactly 1 emission occurs (not 2)
- Performs a second write
- Verifies exactly 2 total emissions occur
- Validates the emitted values are correct

The test is skipped in fast mode to avoid timing issues in CI environments.

https://claude.ai/code/session_016ysbDDKSFMe5poWJDZqPvx