### PR TITLE
Fix key-compression dropping index hints from queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 17.1.0 (2 April 2026)
 
+- FIX Key-compression dropping the `index` hint from queries because `compressQuery()` does not forward the `index` field, causing user-specified index hints to be silently ignored
 - FIX CRDT plugin `bulkInsert` hook not including schema default values in CRDT operations, causing data loss during conflict resolution rebuild when fields rely on schema defaults
 - FIX `RxDocument.get$()` on nested object/array paths emitting spurious values when unrelated document fields changed, because `distinctUntilChanged()` used reference equality which always fails for non-primitive values across document revisions
 - FIX `incrementalUpsert()` throwing a CONFLICT error when a concurrent `upsert()`/`insert()` creates the same document between the internal `findOne()` and `insert()` calls

--- a/src/plugins/key-compression/index.ts
+++ b/src/plugins/key-compression/index.ts
@@ -193,6 +193,17 @@ export function wrappedKeyCompressionStorage<Internals, InstanceCreationOptions>
                             preparedQuery.query as any
                         ) as any;
 
+                        /**
+                         * compressQuery() from jsonschema-key-compression does not know
+                         * about the 'index' field, so it is dropped.
+                         * We have to manually compress and re-add it.
+                         */
+                        if (preparedQuery.query.index) {
+                            compressedQuery.index = preparedQuery.query.index.map(
+                                field => compressedPath(compressionState.table, field)
+                            );
+                        }
+
                         const compressedPreparedQuery = prepareQuery(
                             compressionState.compressedSchema,
                             compressedQuery

--- a/test/unit/key-compression.test.ts
+++ b/test/unit/key-compression.test.ts
@@ -563,5 +563,113 @@ describeParallel('key-compression.test.js', () => {
             assert.deepStrictEqual(result.map(d => d.passportId), ['1', '2']);
             db.close();
         });
+        it('should forward the query index hint through key compression', async () => {
+            /**
+             * The compressQuery() function from jsonschema-key-compression
+             * creates a new query object but does NOT copy the 'index' property.
+             * This means user-specified index hints are silently dropped
+             * when key compression is enabled.
+             */
+            let capturedQueryIndex: string[] | undefined;
+
+            const baseStorage = config.storage.getStorage();
+            const spyStorage: typeof baseStorage = Object.assign(
+                {},
+                baseStorage,
+                {
+                    async createStorageInstance<RxDocType>(params: any) {
+                        const instance = await baseStorage.createStorageInstance<RxDocType>(params);
+                        const originalQuery = instance.query.bind(instance);
+                        (instance as any).query = function (preparedQuery: any) {
+                            capturedQueryIndex = preparedQuery.query.index;
+                            return originalQuery(preparedQuery);
+                        };
+                        return instance;
+                    }
+                }
+            );
+
+            const schema: RxJsonSchema<{
+                passportId: string;
+                firstName: string;
+                lastName: string;
+                age: number;
+            }> = {
+                version: 0,
+                keyCompression: true,
+                primaryKey: 'passportId',
+                type: 'object',
+                properties: {
+                    passportId: {
+                        type: 'string',
+                        maxLength: 128,
+                    },
+                    firstName: {
+                        type: 'string',
+                        maxLength: 128,
+                    },
+                    lastName: {
+                        type: 'string',
+                        maxLength: 128,
+                    },
+                    age: {
+                        type: 'integer',
+                        minimum: 0,
+                        maximum: 150,
+                        multipleOf: 1
+                    }
+                },
+                required: [
+                    'passportId',
+                    'firstName',
+                    'lastName'
+                ],
+                indexes: [
+                    'firstName',
+                    'lastName',
+                    ['firstName', 'lastName']
+                ]
+            };
+
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: wrappedKeyCompressionStorage({ storage: spyStorage })
+            });
+            const collections = await db.addCollections({
+                humans: { schema }
+            });
+
+            await collections.humans.bulkInsert([
+                { passportId: '1', firstName: 'Alice', lastName: 'Smith', age: 30 },
+                { passportId: '2', firstName: 'Bob', lastName: 'Jones', age: 25 },
+                { passportId: '3', firstName: 'Charlie', lastName: 'Brown', age: 35 }
+            ]);
+
+            const result = await collections.humans.find({
+                selector: {
+                    firstName: { $eq: 'Alice' }
+                },
+                index: ['firstName']
+            }).exec();
+
+            assert.strictEqual(result.length, 1);
+            assert.strictEqual(result[0].passportId, '1');
+
+            // The captured index on the inner storage query should exist
+            // and should contain compressed field names.
+            assert.ok(
+                capturedQueryIndex,
+                'index hint must be forwarded to the inner storage query'
+            );
+
+            // Verify that the index contains compressed field names
+            // (not the original uncompressed ones).
+            assert.ok(
+                !capturedQueryIndex.includes('firstName'),
+                'compressed query index must not contain uncompressed field name "firstName"'
+            );
+
+            db.close();
+        });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

When key compression is enabled on a collection, user-specified index hints passed via the `index` property in query options are silently dropped. This occurs because the `compressQuery()` function from `jsonschema-key-compression` does not know about or forward the `index` field, causing it to be lost during query compression.

This means that explicit index hints intended to optimize query performance are ignored when key compression is active, potentially degrading query performance and defeating the purpose of the index hint.

## Changes

### Source Code
- **src/plugins/key-compression/index.ts**: Added logic to manually compress and re-add the `index` field after `compressQuery()` processes the query. The index field names are now properly compressed using `compressedPath()` before being attached to the compressed query object.

### Tests
- **test/unit/key-compression.test.ts**: Added comprehensive test case `'should forward the query index hint through key compression'` that:
  - Creates a schema with key compression enabled and defined indexes
  - Spies on the storage layer to capture the actual query sent to the underlying storage
  - Executes a query with an explicit index hint
  - Verifies that the index hint is forwarded to the storage layer
  - Confirms that the index field names are properly compressed (not the original uncompressed names)

### Documentation
- **CHANGELOG.md**: Added entry documenting the fix

## Test Plan

The added unit test comprehensively covers this fix by:
1. Setting up a database with key compression enabled
2. Intercepting storage queries to capture the actual query object
3. Executing a find query with an explicit `index` hint
4. Asserting that the index hint is present in the captured query
5. Verifying that field names in the index are compressed (not the original uncompressed names)

The test ensures the fix works end-to-end and prevents regression of this issue.

https://claude.ai/code/session_01RicqjgiKCsVTwqcqK2gzqn