### PR TITLE
Remove unused deprecated leveldown devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -686,7 +686,6 @@
     "karma-sourcemap-loader": "0.4.0",
     "karma-spec-reporter": "0.0.36",
     "karma-webpack": "5.0.1",
-    "leveldown": "6.1.1",
     "madge": "8.0.0",
     "microsoft-onedrive-mock": "1.0.5",
     "mini-css-extract-plugin": "2.10.2",


### PR DESCRIPTION
## Summary

- Remove `leveldown@6.1.1` from devDependencies. It is deprecated ("Superseded by classic-level") and produces a `npm warn deprecated` warning during `npm install`. It is not imported or used anywhere in the source code or tests.

## Test plan

- [x] `npm run build` passes
- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [x] Verified `leveldown` is not imported in any `src/` or `test/` files
- [x] Verified no other package in the dependency tree depends on `leveldown`

https://claude.ai/code/session_017BJYbh5XZyx4LfZHnaTLMs