### PR TITLE
Fix RxDocument.populate() silently returning null for invalid paths

### DIFF
--- a/orga/changelog/fix-populate-silent-null-invalid-path.md
+++ b/orga/changelog/fix-populate-silent-null-invalid-path.md
@@ -1,0 +1,1 @@
+- FIX `RxDocument.populate()` silently returning `null` for invalid schema paths and non-ref fields when the value at that path was falsy. The documented `DOC5` / `DOC6` errors are now thrown consistently, regardless of whether the document has a value at the given path.

--- a/src/rx-document.ts
+++ b/src/rx-document.ts
@@ -194,10 +194,12 @@ export const basePrototype = {
             this.collection.schema.jsonSchema,
             path
         );
-        const value = this.get(path);
-        if (!value) {
-            return PROMISE_RESOLVE_NULL;
-        }
+        /**
+         * Validate the schema path BEFORE looking at the document value
+         * so that invalid paths and non-ref fields surface as DOC5/DOC6
+         * errors even when the value at that path happens to be falsy.
+         * Previously the `!value` short-circuit below swallowed these errors.
+         */
         if (!schemaObj) {
             throw newRxError('DOC5', {
                 path
@@ -222,6 +224,11 @@ export const basePrototype = {
                 path,
                 schemaObj
             });
+        }
+
+        const value = this.get(path);
+        if (!value) {
+            return PROMISE_RESOLVE_NULL;
         }
 
         if (schemaObj.type === 'array') {

--- a/test/unit/population.test.ts
+++ b/test/unit/population.test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import AsyncTestUtil from 'async-test-util';
 import config, { describeParallel } from './config.ts';
 
 import {
@@ -268,6 +269,78 @@ describeParallel('population.test.js', () => {
                 const doc2 = await doc.populate(doc.primaryPath);
                 assert.ok(doc2.collection === col2);
 
+                db.close();
+            });
+        });
+        describe('negative', () => {
+            it('throw DOC5 for a path that does not exist in the schema, even when the value is falsy', async () => {
+                const db = await createRxDatabase({
+                    name: randomToken(10),
+                    storage: config.storage.getStorage(),
+                });
+                const cols = await db.addCollections({
+                    human: {
+                        schema: {
+                            version: 0,
+                            primaryKey: 'name',
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string', maxLength: 100 },
+                                bestFriend: {
+                                    ref: 'human',
+                                    type: 'string'
+                                }
+                            },
+                            required: ['name']
+                        }
+                    }
+                });
+                const col = cols.human;
+                await col.insert({ name: 'alice' });
+                const doc = await col.findOne('alice').exec(true);
+
+                // Calling populate with a path that does not exist in the schema
+                // must throw DOC5 so that typos are surfaced as errors instead of
+                // being silently swallowed as a "no ref value" null result.
+                await AsyncTestUtil.assertThrows(
+                    () => doc.populate('nonExistentField'),
+                    'RxError',
+                    'DOC5'
+                );
+                db.close();
+            });
+            it('throw DOC6 when populating a non-ref schema field, even when the value is falsy', async () => {
+                const db = await createRxDatabase({
+                    name: randomToken(10),
+                    storage: config.storage.getStorage(),
+                });
+                const cols = await db.addCollections({
+                    human: {
+                        schema: {
+                            version: 0,
+                            primaryKey: 'name',
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string', maxLength: 100 },
+                                nickname: { type: 'string' }
+                            },
+                            required: ['name']
+                        }
+                    }
+                });
+                const col = cols.human;
+                // insert without `nickname` so that value is undefined
+                await col.insert({ name: 'alice' });
+                const doc = await col.findOne('alice').exec(true);
+
+                // Populating a field that exists in the schema but has no
+                // ref defined must throw DOC6 regardless of whether the value
+                // happens to be unset.
+                await AsyncTestUtil.assertThrows(
+                    () => doc.populate('nickname'),
+                    'RxError',
+                    'DOC6'
+                );
                 db.close();
             });
         });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

`RxDocument.populate()` was silently returning `null` when called with:
1. A schema path that doesn't exist (should throw `DOC5`)
2. A schema field that exists but has no `ref` defined (should throw `DOC6`)

This only occurred when the value at that path was falsy (undefined, null, empty string, etc.). The error validation was being short-circuited by an early `!value` check, causing invalid paths and non-ref fields to be silently swallowed instead of surfacing as documented errors.

## Solution

Reordered the validation logic in `RxDocument.populate()` to validate the schema path **before** checking the document value. This ensures that `DOC5` and `DOC6` errors are thrown consistently, regardless of whether the document has a value at the given path.

The fix:
- Moves schema validation (`getSchemaByObjectPath()` and ref checks) before the `!value` short-circuit
- Preserves the original behavior of returning `null` for valid ref fields with falsy values
- Adds comprehensive test coverage for both error cases

## Test Plan

Added two new test cases in the "negative" describe block:
1. Verifies `DOC5` is thrown when populating a non-existent schema path with a falsy value
2. Verifies `DOC6` is thrown when populating a non-ref field with a falsy value

Both tests confirm that typos and schema misconfigurations are now properly surfaced as errors instead of being silently ignored.

https://claude.ai/code/session_0119TW6jqkuq76gTRFunuJip