### PR TITLE
Fix RxState.get$() emitting stale value on delayed subscription

### DIFF
--- a/orga/changelog/fix-rx-state-get-dollar-stale-startWith.md
+++ b/orga/changelog/fix-rx-state-get-dollar-stale-startWith.md
@@ -1,0 +1,1 @@
+- FIX `RxState.get$()` (and the `field$` proxy accessor) emitting a stale value when subscribed after the state was modified, because `startWith()` eagerly captured the current value at observable creation time instead of at subscription time

--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -1,6 +1,7 @@
 import {
     Observable,
     Subject,
+    defer,
     distinctUntilChanged,
     filter,
     map,
@@ -257,10 +258,18 @@ export class RxStateBase<T, Reactivity = unknown> {
         return ret;
     }
     get$(path?: Paths<T>): Observable<any> {
-        return this.$.pipe(
+        /**
+         * Use defer() so that the initial value passed to startWith()
+         * is evaluated lazily at subscription time, not at the time
+         * get$() is called. Otherwise, if the state changes between
+         * the get$() call and the subscription, the subscriber would
+         * first receive a stale value and only then the current one.
+         */
+        return defer(() => this.$.pipe(
             map(() => this.get(path)),
             startWith(this.get(path)),
             distinctUntilChanged(deepEqual),
+        )).pipe(
             shareReplay(RXJS_SHARE_REPLAY_DEFAULTS),
         );
     }

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -665,6 +665,48 @@ addRxPlugin(RxDBJsonDumpPlugin);
                 state.collection.database.remove();
             });
             /**
+             * The observable returned by get$()/property$ should emit the
+             * CURRENT value when subscribed, not the value that was present
+             * at the time the observable was created.
+             * Previously, startWith() was eagerly evaluated at get$() call
+             * time. If the state changed between getting the observable
+             * reference and subscribing to it, the subscriber received a
+             * stale value first and only then the current one.
+             */
+            it('get$() should emit the current value when subscribed, not a stale value from creation time', async () => {
+                if (isFastMode()) {
+                    return;
+                }
+                const state = await getState();
+                await state.set('foo', () => 'first');
+
+                // Capture the observable reference BEFORE the state change.
+                const obs = state.foo$;
+
+                // Change state AFTER getting the observable reference,
+                // but BEFORE subscribing.
+                await state.set('foo', () => 'second');
+
+                // Let any async events settle.
+                await wait(100);
+
+                // Now subscribe. Subscriber should only see the current
+                // value ('second'), not the stale one ('first').
+                const emitted: any[] = [];
+                const sub = obs.subscribe(v => emitted.push(v));
+
+                await wait(100);
+
+                assert.deepStrictEqual(
+                    emitted,
+                    ['second'],
+                    'subscriber should receive only the current value but got: ' + JSON.stringify(emitted)
+                );
+
+                sub.unsubscribe();
+                state.collection.database.remove();
+            });
+            /**
              * _cleanup() must return true when it is done
              * so that the cleanup plugin loop can terminate.
              * @link https://github.com/pubkey/rxdb/issues/XXXX


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

`RxState.get$()` and the `field$` proxy accessors were emitting stale values when subscribed to after the state had been modified. This occurred because `startWith()` was eagerly evaluated at the time `get$()` was called, rather than at subscription time. If the state changed between obtaining the observable reference and subscribing to it, the subscriber would first receive the old value and then the current one.

## Solution

Wrapped the observable pipeline in `defer()` to ensure that the initial value passed to `startWith()` is evaluated lazily at subscription time, not at observable creation time. This guarantees that subscribers always receive the current state value first, regardless of when they subscribe relative to state changes.

## Changes Made

- **src/plugins/state/rx-state.ts**: Modified `get$()` method to use `defer()` wrapper, ensuring `startWith()` captures the current value at subscription time
- **test/unit/rx-state.test.ts**: Added comprehensive test case verifying that `get$()` emits only the current value when subscribed after state modifications
- **orga/changelog/fix-rx-state-get-dollar-stale-startWith.md**: Added changelog entry documenting the fix

## Test Plan

Added unit test `get$() should emit the current value when subscribed, not a stale value from creation time` that:
1. Sets initial state value
2. Captures observable reference before state change
3. Modifies state after getting observable but before subscribing
4. Verifies subscriber receives only the current value, not the stale one

Existing tests continue to pass, confirming no regressions in observable behavior.

https://claude.ai/code/session_01PiEokjJqQnbpWeR4GFKfvV