### PR TITLE
Fix backup plugin not removing folders of deleted documents

### DIFF
--- a/orga/changelog/fix-backup-delete-folder-not-removed.md
+++ b/orga/changelog/fix-backup-delete-folder-not-removed.md
@@ -1,0 +1,1 @@
+- FIX backup plugin not removing the folder of a deleted document when the change batch only contained deletions, because `findByIds()` returned an empty map and the loop exited early before running the deletion handler

--- a/src/plugins/backup/index.ts
+++ b/src/plugins/backup/index.ts
@@ -149,7 +149,11 @@ export class RxBackupState {
                             this.options.batchSize ? this.options.batchSize : 0,
                             lastCheckpoint
                         );
-                        lastCheckpoint = changesResult.documents.length > 0 ? changesResult.checkpoint : lastCheckpoint;
+                        if (changesResult.documents.length === 0) {
+                            hasMore = false;
+                            continue;
+                        }
+                        lastCheckpoint = changesResult.checkpoint;
                         meta.collectionStates[collectionName].checkpoint = lastCheckpoint;
 
                         const docIds: string[] = changesResult.documents
@@ -168,10 +172,6 @@ export class RxBackupState {
                         await this.database.requestIdlePromise();
 
                         const docs: Map<string, RxDocument> = await collection.findByIds(docIds).exec();
-                        if (docs.size === 0) {
-                            hasMore = false;
-                            continue;
-                        }
                         await Promise.all(
                             Array
                                 .from(docs.values())

--- a/test/unit/backup.test.ts
+++ b/test/unit/backup.test.ts
@@ -182,7 +182,7 @@ describe('backup.test.ts', () => {
          * an empty result and the loop exited early.
          * The folders of the deleted documents remained in the backup.
          */
-        it('#7176 should remove the folder of a deleted document', async () => {
+        it('should remove the folder of a deleted document', async () => {
             if (!config.storage.hasAttachments) {
                 return;
             }

--- a/test/unit/backup.test.ts
+++ b/test/unit/backup.test.ts
@@ -175,4 +175,61 @@ describe('backup.test.ts', () => {
             assert.strictEqual(backupState.isStopped, true);
         });
     });
+    describe('issues', () => {
+        /**
+         * When a batch of changes contains only deleted documents,
+         * the deletion handler was skipped because findByIds() returned
+         * an empty result and the loop exited early.
+         * The folders of the deleted documents remained in the backup.
+         */
+        it('#7176 should remove the folder of a deleted document', async () => {
+            if (!config.storage.hasAttachments) {
+                return;
+            }
+            const collection = await createAttachments(1);
+            const firstDoc = await collection.findOne().exec(true);
+            const docId = firstDoc.primary;
+            const directory = getBackupDir();
+            const options = {
+                live: false,
+                directory,
+                attachments: true
+            };
+
+            const backupState1 = collection.database.backup(options);
+            await backupState1.awaitInitialBackup();
+
+            const docFolder = path.join(directory, docId);
+            assert.ok(
+                fs.existsSync(docFolder),
+                'doc folder should exist after initial backup'
+            );
+
+            // remove the only document in the collection
+            await firstDoc.getLatest().remove();
+
+            // run backup again, it should pick up from the last checkpoint
+            // and remove the folder of the deleted document
+            const emitted: RxBackupWriteEvent[] = [];
+            const backupState2 = collection.database.backup(options);
+            const sub = backupState2.writeEvents$.subscribe(ev => emitted.push(ev));
+            await backupState2.awaitInitialBackup();
+
+            assert.strictEqual(
+                fs.existsSync(docFolder),
+                false,
+                'the folder of the deleted document must not exist anymore'
+            );
+            const deletedEvents = emitted.filter(ev => ev.deleted);
+            assert.strictEqual(
+                deletedEvents.length,
+                1,
+                'exactly one delete event must be emitted'
+            );
+            assert.strictEqual(deletedEvents[0].documentId, docId);
+
+            sub.unsubscribe();
+            await collection.database.close();
+        });
+    });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- Changelog entry

## Describe the problem you have without this PR

When a batch of changes in the backup plugin contained only deleted documents, the deletion handler was skipped because `findByIds()` returned an empty result set. This caused the loop to exit early via an early `continue` statement, preventing the deletion logic from executing. As a result, the folders of deleted documents remained in the backup, causing data inconsistency.

## Changes

### Source Code Fix
Modified `src/plugins/backup/index.ts` to properly handle batches containing only deletions:
- Moved the empty check for `changesResult.documents` before attempting to fetch documents
- Removed the early exit condition that checked if `findByIds()` returned an empty map
- This ensures that even when `findByIds()` returns no documents (because they were deleted), the deletion handler still processes the change records and removes their backup folders

### Test Coverage
Added a comprehensive test case `should remove the folder of a deleted document` that:
- Creates a document with attachments
- Verifies the backup folder exists after initial backup
- Deletes the only document in the collection
- Runs backup again to pick up changes from the checkpoint
- Asserts that the deleted document's folder is removed
- Verifies that exactly one delete event is emitted with the correct document ID

### Changelog
Added entry documenting the fix for the backup plugin deletion handling issue.

## Test Plan
The added unit test in `test/unit/backup.test.ts` covers the specific scenario where a change batch contains only deletions. The test verifies both that the folder is removed and that the appropriate delete event is emitted.

https://claude.ai/code/session_01QU3w5SN6n4JtQUnQXw3mfS