### PR TITLE
Fix replication sent$ emitting null for filtered push documents

### DIFF
--- a/orga/changelog/fix-replication-sent-null-on-push-modifier-filter.md
+++ b/orga/changelog/fix-replication-sent-null-on-push-modifier-filter.md
@@ -1,0 +1,1 @@
+- FIX replication `sent$` observable emitting `null` for documents that were filtered out by a `push.modifier` returning `null`, violating its `Observable<WithDeleted<RxDocType>>` type and falsely reporting filtered documents as sent to the endpoint

--- a/src/replication-protocol/upstream.ts
+++ b/src/replication-protocol/upstream.ts
@@ -435,7 +435,18 @@ export async function startReplicationUpstream<RxDocType, CheckpointType>(
 
             writeRowsToMasterIds.forEach(docId => {
                 if (!conflictIds.has(docId)) {
-                    state.events.processed.up.next(writeRowsToMaster[docId]);
+                    /**
+                     * Skip the processed.up emission for rows that were
+                     * filtered out by the replicationHandler.masterWrite()
+                     * wrapper (e.g. via a push modifier returning null).
+                     * Such rows have their newDocumentState set to null to
+                     * signal they were not actually sent to the master.
+                     * We still persist their meta state so that the upstream
+                     * does not keep retrying them.
+                     */
+                    if (writeRowsToMaster[docId].newDocumentState !== null) {
+                        state.events.processed.up.next(writeRowsToMaster[docId]);
+                    }
                     useWriteRowsToMeta.push(writeRowsToMeta[docId]);
                 }
             });

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -271,6 +271,69 @@ describe('replication.test.ts', () => {
             localCollection.database.close();
             remoteCollection.database.close();
         });
+        it('sent$ must not emit null when the push-modifier returns null #bug', async () => {
+            const totalDocs = 10;
+            const { localCollection, remoteCollection } = await getTestCollections({
+                local: 0,
+                remote: 0
+            });
+            await localCollection.bulkInsert(
+                new Array(totalDocs).fill(0).map((_v, idx) => {
+                    return schemaObjects.humanWithTimestampData({
+                        name: 'from-local',
+                        age: idx + 1
+                    });
+                })
+            );
+            const replicationState = replicateRxCollection<HumanWithTimestampDocumentType, any>({
+                collection: localCollection,
+                replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                live: false,
+                pull: {
+                    handler: getPullHandler(remoteCollection)
+                },
+                push: {
+                    handler: getPushHandler(remoteCollection),
+                    modifier: (doc) => {
+                        // drop every second document
+                        if (doc.age % 2 === 0) {
+                            return null;
+                        }
+                        return doc;
+                    }
+                }
+            });
+
+            const sentDocs: WithDeleted<HumanWithTimestampDocumentType>[] = [];
+            replicationState.sent$.subscribe(d => sentDocs.push(d));
+
+            ensureReplicationHasNoErrors(replicationState);
+            await replicationState.awaitInitialReplication();
+
+            /**
+             * sent$ is typed as Observable<WithDeleted<RxDocType>>,
+             * so it must never emit null or undefined values,
+             * not even for documents that were filtered out
+             * by the push modifier.
+             */
+            sentDocs.forEach((doc, idx) => {
+                assert.ok(
+                    doc !== null && doc !== undefined,
+                    'sent$ emitted ' + JSON.stringify(doc) + ' at index ' + idx
+                );
+                assert.strictEqual(typeof (doc as any).id, 'string');
+            });
+
+            // Only the 5 non-filtered documents were actually sent to the endpoint
+            assert.strictEqual(
+                sentDocs.length,
+                5,
+                'sent$ must only emit for actually pushed docs, got ' + sentDocs.length
+            );
+
+            localCollection.database.close();
+            remoteCollection.database.close();
+        });
         it('should not save pulled documents that do not match the schema', async () => {
             const amount = 5;
             const { localCollection, remoteCollection } = await getTestCollections({ local: 0, remote: amount });

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -271,7 +271,7 @@ describe('replication.test.ts', () => {
             localCollection.database.close();
             remoteCollection.database.close();
         });
-        it('sent$ must not emit null when the push-modifier returns null #bug', async () => {
+        it('sent$ must not emit null when the push-modifier returns null', async () => {
             const totalDocs = 10;
             const { localCollection, remoteCollection } = await getTestCollections({
                 local: 0,


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

The replication `sent$` observable was emitting `null` values for documents that were filtered out by a `push.modifier` returning `null`. This violated the observable's type signature `Observable<WithDeleted<RxDocType>>`, which should never emit `null` or `undefined` values. Additionally, it falsely reported filtered documents as having been sent to the endpoint.

## Solution

Modified the upstream replication protocol to skip emitting to `processed.up` when a document's `newDocumentState` is `null` (indicating it was filtered out by the push modifier). The metadata state is still persisted to prevent retry loops, but the document is not reported as sent.

## Changes

**src/replication-protocol/upstream.ts:**
- Added a null check before emitting to `state.events.processed.up` 
- Documents filtered by push modifiers (with `newDocumentState === null`) are no longer emitted to the `sent$` observable
- Metadata is still persisted to track the filtering attempt

**test/unit/replication.test.ts:**
- Added comprehensive test case verifying that `sent$` never emits null/undefined values
- Test confirms that only actually-sent documents (not filtered ones) are emitted
- Test validates the type safety of the observable

## Test Plan

Added unit test `'sent$ must not emit null when the push-modifier returns null'` that:
- Creates 10 documents and filters every second one via push modifier
- Verifies `sent$` emits exactly 5 documents (the non-filtered ones)
- Validates that no null/undefined values are emitted
- Confirms all emitted documents have valid structure

Existing replication tests continue to pass.

https://claude.ai/code/session_016WE6JJwKsT7HBExCxX1raG