### PR TITLE
Fix database-level local doc observable leaking collection events

### DIFF
--- a/orga/changelog/fix-local-document-observable-cross-parent-leak.md
+++ b/orga/changelog/fix-local-document-observable-cross-parent-leak.md
@@ -1,0 +1,1 @@
+- FIX database-level `RxLocalDocument.$` observable emitting events from a collection-level local document that shares the same id, because the filter on the database event stream only checked `isLocal` and did not exclude events that originated from a collection

--- a/src/plugins/local-documents/rx-local-document.ts
+++ b/src/plugins/local-documents/rx-local-document.ts
@@ -93,8 +93,19 @@ const RxLocalDocumentPrototype: any = {
         const state = getFromMapOrThrow(LOCAL_DOC_STATE_BY_PARENT_RESOLVED, this.parent);
 
         const id = this.primary;
+        /**
+         * When the parent is the RxDatabase,
+         * the eventBulks$ stream contains events from all collections.
+         * Local documents on the database and on a collection can share the same id
+         * so we must filter out events that belong to a collection-level local doc
+         * to not leak their state into the database-level local doc observable.
+         */
+        const parentIsDatabase = isRxDatabase(_this.parent);
         return _this.parent.eventBulks$.pipe(
-            filter((bulk: RxChangeEventBulk<any>) => !!bulk.isLocal),
+            filter((bulk: RxChangeEventBulk<any>) =>
+                !!bulk.isLocal &&
+                (parentIsDatabase ? !bulk.collectionName : true)
+            ),
             map((bulk: RxChangeEventBulk<any>) => bulk.events.find((ev: RxStorageChangeEvent<any>) => ev.documentId === id)),
             filter((event: RxStorageChangeEvent<any> | undefined) => !!event),
             map((changeEvent: any) => getDocumentDataOfRxChangeEvent(ensureNotFalsy(changeEvent))),
@@ -102,7 +113,7 @@ const RxLocalDocumentPrototype: any = {
             distinctUntilChanged((prev: any, curr: any) => prev._rev === curr._rev),
             map((docData: any) => state.docCache.getCachedRxDocument(docData)),
             shareReplay(RXJS_SHARE_REPLAY_DEFAULTS)
-        ) as Observable<any>;;
+        ) as Observable<any>;
     },
     get $$(): any {
         const _this: RxLocalDocumentClass = this as any;

--- a/test/unit/local-documents.test.ts
+++ b/test/unit/local-documents.test.ts
@@ -832,5 +832,57 @@ describeParallel('local-documents.test.ts', () => {
 
             db.close();
         });
+        it('database-level local doc $ must not be affected by collection-level local doc with same id', async () => {
+            type LDType = { level: string; };
+            const name = randomToken(10);
+            const db = await createRxDatabase({
+                name,
+                storage: config.storage.getStorage(),
+                localDocuments: true
+            });
+            const cols = await db.addCollections({
+                humans: {
+                    schema: schemas.primaryHuman,
+                    localDocuments: true
+                }
+            });
+
+            const sharedId = 'shared-id';
+            const dbDoc = await db.insertLocal<LDType>(sharedId, {
+                level: 'db'
+            });
+            const colDoc = await cols.humans.insertLocal<LDType>(sharedId, {
+                level: 'collection'
+            });
+
+            const dbEmitted: LDType[] = [];
+            const sub = dbDoc.$.subscribe(d => {
+                dbEmitted.push(d.toJSON().data as LDType);
+            });
+            await waitUntil(() => dbEmitted.length === 1);
+            assert.strictEqual(dbEmitted[0].level, 'db');
+
+            // update the collection-level doc: the db-level $ must NOT pick this up
+            await colDoc.incrementalPatch({ level: 'collection-updated' });
+            await wait(100);
+            assert.strictEqual(
+                dbEmitted.length,
+                1,
+                'database local doc observable leaked events from collection local doc. Got: ' +
+                JSON.stringify(dbEmitted)
+            );
+
+            // now update the db-level doc: must emit the db-level data
+            await dbDoc.incrementalPatch({ level: 'db-updated' });
+            await waitUntil(() => dbEmitted.length === 2);
+            assert.strictEqual(dbEmitted[1].level, 'db-updated');
+
+            // the getLatest() of the db-level doc must still return the db-level data
+            const latest = dbDoc.getLatest();
+            assert.strictEqual(latest.get('level'), 'db-updated');
+
+            sub.unsubscribe();
+            await db.close();
+        });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- A CHANGELOG ENTRY

## Describe the problem you have without this PR

When a database-level local document and a collection-level local document share the same ID, updates to the collection-level document were incorrectly being emitted through the database-level document's `$` observable. This occurred because the event filter only checked for `isLocal` flag but did not exclude events originating from collections.

## Solution

Modified the event filter in `RxLocalDocument.$` observable to additionally check the `collectionName` property when the parent is a database. Events from collection-level local documents (which have a `collectionName`) are now filtered out when observing database-level local documents.

The fix:
1. Detects when the parent is an `RxDatabase` instance
2. Filters out events that have a `collectionName` set (indicating they're from a collection)
3. Allows all events through for collection-level local documents (where `collectionName` filtering doesn't apply)

## Changes Made

- **src/plugins/local-documents/rx-local-document.ts**: Updated the `$` observable filter to exclude collection-level events when parent is a database
- **test/unit/local-documents.test.ts**: Added comprehensive test case verifying database and collection local documents with shared IDs don't interfere with each other
- **orga/changelog/fix-local-document-observable-cross-parent-leak.md**: Added changelog entry

## Test Plan

Added unit test `'database-level local doc $ must not be affected by collection-level local doc with same id'` that:
- Creates a database and collection both with local documents enabled
- Inserts local documents with the same ID at both levels
- Verifies that updates to the collection-level document don't emit through the database-level observable
- Verifies that updates to the database-level document still emit correctly
- Confirms `getLatest()` returns the correct database-level data

https://claude.ai/code/session_01EgGck4Q4MCsKUZH1pS63Kv