### PR TITLE
Fix storage query limit: 0 returning all documents instead of empty

### DIFF
--- a/orga/changelog/fix-storage-query-limit-zero.md
+++ b/orga/changelog/fix-storage-query-limit-zero.md
@@ -1,0 +1,1 @@
+- FIX storage `query()` returning all matching documents when the caller passes `limit: 0` in the mango query, because the truthy check `query.limit ? query.limit : Infinity` treated `0` as "no limit was set" (affects memory, dexie, localstorage, foundationdb, denokv, sqlite-trial, mongodb storages and the query-builder plugin).

--- a/src/plugins/query-builder/mquery/nosql-query-builder.ts
+++ b/src/plugins/query-builder/mquery/nosql-query-builder.ts
@@ -393,10 +393,10 @@ export class NoSqlQueryBuilderClass<DocType> {
             selector: this._conditions,
         };
 
-        if (this.options.skip) {
+        if (typeof this.options.skip === 'number') {
             query.skip = this.options.skip;
         }
-        if (this.options.limit) {
+        if (typeof this.options.limit === 'number') {
             query.limit = this.options.limit;
         }
         if (this.options.sort) {

--- a/src/plugins/storage-denokv/denokv-query.ts
+++ b/src/plugins/storage-denokv/denokv-query.ts
@@ -21,7 +21,12 @@ export async function queryDenoKV<RxDocType>(
     const queryPlan = preparedQuery.queryPlan;
     const query = preparedQuery.query;
     const skip = query.skip ? query.skip : 0;
-    const limit = query.limit ? query.limit : Infinity;
+    /**
+     * Use typeof so an explicit `limit: 0` from the mango query is
+     * honored. The previous truthy check treated `0` as "no limit"
+     * and returned all matching documents.
+     */
+    const limit = typeof query.limit === 'number' ? query.limit : Infinity;
     const skipPlusLimit = skip + limit;
     const queryPlanFields: string[] = queryPlan.index;
     const mustManuallyResort = !queryPlan.sortSatisfiedByIndex;

--- a/src/plugins/storage-denokv/denokv-query.ts
+++ b/src/plugins/storage-denokv/denokv-query.ts
@@ -40,6 +40,10 @@ export async function queryDenoKV<RxDocType>(
         );
     }
 
+    if (limit === 0) {
+        return { documents: [] };
+    }
+
     const kv = await instance.kvPromise;
 
     const indexForName = queryPlanFields.slice(0);

--- a/src/plugins/storage-dexie/dexie-query.ts
+++ b/src/plugins/storage-dexie/dexie-query.ts
@@ -82,7 +82,12 @@ export async function dexieQuery<RxDocType>(
     const query = preparedQuery.query;
 
     const skip = query.skip ? query.skip : 0;
-    const limit = query.limit ? query.limit : Infinity;
+    /**
+     * Use typeof so an explicit `limit: 0` from the mango query is
+     * honored. The previous truthy check treated `0` as "no limit"
+     * and returned all matching documents.
+     */
+    const limit = typeof query.limit === 'number' ? query.limit : Infinity;
     const skipPlusLimit = skip + limit;
     const queryPlan = preparedQuery.queryPlan;
 

--- a/src/plugins/storage-foundationdb/foundationdb-query.ts
+++ b/src/plugins/storage-foundationdb/foundationdb-query.ts
@@ -21,7 +21,12 @@ export async function queryFoundationDB<RxDocType>(
     const queryPlan = preparedQuery.queryPlan;
     const query = preparedQuery.query;
     const skip = query.skip ? query.skip : 0;
-    const limit = query.limit ? query.limit : Infinity;
+    /**
+     * Use typeof so an explicit `limit: 0` from the mango query is
+     * honored. The previous truthy check treated `0` as "no limit"
+     * and returned all matching documents.
+     */
+    const limit = typeof query.limit === 'number' ? query.limit : Infinity;
     const skipPlusLimit = skip + limit;
     const queryPlanFields: string[] = queryPlan.index;
     const mustManuallyResort = !queryPlan.sortSatisfiedByIndex;

--- a/src/plugins/storage-localstorage/rx-storage-instance-localstorage.ts
+++ b/src/plugins/storage-localstorage/rx-storage-instance-localstorage.ts
@@ -390,7 +390,12 @@ export class RxStorageInstanceLocalstorage<RxDocType> implements RxStorageInstan
         const query = preparedQuery.query;
 
         const skip = query.skip ? query.skip : 0;
-        const limit = query.limit ? query.limit : Infinity;
+        /**
+         * Use typeof so an explicit `limit: 0` from the mango query is
+         * honored. The previous truthy check treated `0` as "no limit"
+         * and returned all matching documents.
+         */
+        const limit = typeof query.limit === 'number' ? query.limit : Infinity;
         const skipPlusLimit = skip + limit;
 
         let queryMatcher: QueryMatcher<RxDocumentData<RxDocType>> | false = false;

--- a/src/plugins/storage-memory/rx-storage-instance-memory.ts
+++ b/src/plugins/storage-memory/rx-storage-instance-memory.ts
@@ -291,7 +291,12 @@ export class RxStorageInstanceMemory<RxDocType> implements RxStorageInstance<
         const query = preparedQuery.query;
 
         const skip = query.skip ? query.skip : 0;
-        const limit = query.limit ? query.limit : Infinity;
+        /**
+         * Use typeof so an explicit `limit: 0` from the mango query is
+         * honored. The previous truthy check treated `0` as "no limit"
+         * and returned all matching documents.
+         */
+        const limit = typeof query.limit === 'number' ? query.limit : Infinity;
         const skipPlusLimit = skip + limit;
 
         let queryMatcher: QueryMatcher<RxDocumentData<RxDocType>> | false = false;

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -359,6 +359,10 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         await this.writeQueue;
         const mongoCollection = await this.mongoCollectionPromise;
 
+        if (preparedQuery.query.limit === 0) {
+            this.runningOperations.next(this.runningOperations.getValue() - 1);
+            return { documents: [] };
+        }
         let query = mongoCollection.find(preparedQuery.mongoSelector);
         if (preparedQuery.query.skip) {
             query = query.skip(preparedQuery.query.skip);

--- a/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
+++ b/src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts
@@ -363,7 +363,7 @@ export class RxStorageInstanceMongoDB<RxDocType> implements RxStorageInstance<
         if (preparedQuery.query.skip) {
             query = query.skip(preparedQuery.query.skip);
         }
-        if (preparedQuery.query.limit) {
+        if (typeof preparedQuery.query.limit === 'number') {
             query = query.limit(preparedQuery.query.limit);
         }
         if (preparedQuery.query.sort) {

--- a/src/plugins/storage-sqlite/sqlite-storage-instance.ts
+++ b/src/plugins/storage-sqlite/sqlite-storage-instance.ts
@@ -255,7 +255,12 @@ export class RxStorageInstanceSQLite<RxDocType> implements RxStorageInstance<
         let result: RxDocumentData<RxDocType>[] = [];
         const query = originalPreparedQuery.query;
         const skip = query.skip ? query.skip : 0;
-        const limit = query.limit ? query.limit : Infinity;
+        /**
+         * Use typeof so an explicit `limit: 0` from the mango query is
+         * honored. The previous truthy check treated `0` as "no limit"
+         * and returned all matching documents.
+         */
+        const limit = typeof query.limit === 'number' ? query.limit : Infinity;
         const skipPlusLimit = skip + limit;
         const queryMatcher = getQueryMatcher(
             this.schema,

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -9,15 +9,34 @@
  * - 'npm run test:browser' so it runs in the browser
  */
 import assert from 'assert';
+import AsyncTestUtil from 'async-test-util';
 import config from './config.ts';
 
 import {
     createRxDatabase,
     randomToken
 } from '../../plugins/core/index.mjs';
-
+import {
+    isNode
+} from '../../plugins/test-utils/index.mjs';
 describe('bug-report.test.js', () => {
-    it('find({ limit: 0 }) must return an empty array', async function () {
+    it('should fail because it reproduces the bug', async function () {
+
+        /**
+         * If your test should only run in nodejs or only run in the browser,
+         * you should comment in the return operator and adapt the if statement.
+         */
+        if (
+            !isNode // runs only in node
+            // isNode // runs only in the browser
+        ) {
+            // return;
+        }
+
+        if (!config.storage.hasMultiInstance) {
+            return;
+        }
+
         // create a schema
         const mySchema = {
             version: 0,
@@ -40,7 +59,7 @@ describe('bug-report.test.js', () => {
                     maximum: 150
                 }
             }
-        } as const;
+        };
 
         /**
          * Always generate a random database-name
@@ -56,7 +75,8 @@ describe('bug-report.test.js', () => {
              * we can ensure that all variations of RxStorage are tested in the CI.
              */
             storage: config.storage.getStorage(),
-            eventReduce: true
+            eventReduce: true,
+            ignoreDuplicate: true
         });
         // create a collection
         const collections = await db.addCollections({
@@ -65,34 +85,57 @@ describe('bug-report.test.js', () => {
             }
         });
 
-        // insert a few documents so the collection is not empty
-        await collections.mycollection.bulkInsert([
-            { passportId: 'a', firstName: 'Alice', lastName: 'A', age: 10 },
-            { passportId: 'b', firstName: 'Bob', lastName: 'B', age: 20 },
-            { passportId: 'c', firstName: 'Chris', lastName: 'C', age: 30 }
-        ]);
-
-        // Sanity check: find() without limit must return all three docs.
-        const allDocs = await collections.mycollection.find().exec();
-        assert.strictEqual(allDocs.length, 3);
+        // insert a document
+        await collections.mycollection.insert({
+            passportId: 'foobar',
+            firstName: 'Bob',
+            lastName: 'Kelso',
+            age: 56
+        });
 
         /**
-         * A user specifies `limit: 0` which, per the MangoQuery public API,
-         * should be honored and return zero documents.
-         * The storage layer incorrectly interprets the falsy `0` as
-         * "no limit was set" and returns all documents instead.
+         * to simulate the event-propagation over multiple browser-tabs,
+         * we create the same database again
          */
-        const result = await collections.mycollection.find({
-            selector: {},
-            limit: 0
-        }).exec();
+        const dbInOtherTab = await createRxDatabase({
+            name,
+            storage: config.storage.getStorage(),
+            eventReduce: true,
+            ignoreDuplicate: true
+        });
+        // create a collection
+        const collectionInOtherTab = await dbInOtherTab.addCollections({
+            mycollection: {
+                schema: mySchema
+            }
+        });
 
-        assert.strictEqual(
-            result.length,
-            0,
-            'find({ limit: 0 }) must return an empty result set, got ' + result.length
-        );
+        // find the document in the other tab
+        const myDocument = await collectionInOtherTab.mycollection
+            .findOne()
+            .where('firstName')
+            .eq('Bob')
+            .exec();
 
+        /*
+         * assert things,
+         * here your tests should fail to show that there is a bug
+         */
+        assert.strictEqual(myDocument.age, 56);
+
+
+        // you can also wait for events
+        const emitted: any[] = [];
+        const sub = collectionInOtherTab.mycollection
+            .findOne().$
+            .subscribe(doc => {
+                emitted.push(doc);
+            });
+        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
+
+        // clean up afterwards
+        sub.unsubscribe();
         db.close();
+        dbInOtherTab.close();
     });
 });

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -9,34 +9,15 @@
  * - 'npm run test:browser' so it runs in the browser
  */
 import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
 import config from './config.ts';
 
 import {
     createRxDatabase,
     randomToken
 } from '../../plugins/core/index.mjs';
-import {
-    isNode
-} from '../../plugins/test-utils/index.mjs';
+
 describe('bug-report.test.js', () => {
-    it('should fail because it reproduces the bug', async function () {
-
-        /**
-         * If your test should only run in nodejs or only run in the browser,
-         * you should comment in the return operator and adapt the if statement.
-         */
-        if (
-            !isNode // runs only in node
-            // isNode // runs only in the browser
-        ) {
-            // return;
-        }
-
-        if (!config.storage.hasMultiInstance) {
-            return;
-        }
-
+    it('find({ limit: 0 }) must return an empty array', async function () {
         // create a schema
         const mySchema = {
             version: 0,
@@ -59,7 +40,7 @@ describe('bug-report.test.js', () => {
                     maximum: 150
                 }
             }
-        };
+        } as const;
 
         /**
          * Always generate a random database-name
@@ -75,8 +56,7 @@ describe('bug-report.test.js', () => {
              * we can ensure that all variations of RxStorage are tested in the CI.
              */
             storage: config.storage.getStorage(),
-            eventReduce: true,
-            ignoreDuplicate: true
+            eventReduce: true
         });
         // create a collection
         const collections = await db.addCollections({
@@ -85,57 +65,34 @@ describe('bug-report.test.js', () => {
             }
         });
 
-        // insert a document
-        await collections.mycollection.insert({
-            passportId: 'foobar',
-            firstName: 'Bob',
-            lastName: 'Kelso',
-            age: 56
-        });
+        // insert a few documents so the collection is not empty
+        await collections.mycollection.bulkInsert([
+            { passportId: 'a', firstName: 'Alice', lastName: 'A', age: 10 },
+            { passportId: 'b', firstName: 'Bob', lastName: 'B', age: 20 },
+            { passportId: 'c', firstName: 'Chris', lastName: 'C', age: 30 }
+        ]);
+
+        // Sanity check: find() without limit must return all three docs.
+        const allDocs = await collections.mycollection.find().exec();
+        assert.strictEqual(allDocs.length, 3);
 
         /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
+         * A user specifies `limit: 0` which, per the MangoQuery public API,
+         * should be honored and return zero documents.
+         * The storage layer incorrectly interprets the falsy `0` as
+         * "no limit was set" and returns all documents instead.
          */
-        const dbInOtherTab = await createRxDatabase({
-            name,
-            storage: config.storage.getStorage(),
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collectionInOtherTab = await dbInOtherTab.addCollections({
-            mycollection: {
-                schema: mySchema
-            }
-        });
+        const result = await collections.mycollection.find({
+            selector: {},
+            limit: 0
+        }).exec();
 
-        // find the document in the other tab
-        const myDocument = await collectionInOtherTab.mycollection
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
-            .exec();
+        assert.strictEqual(
+            result.length,
+            0,
+            'find({ limit: 0 }) must return an empty result set, got ' + result.length
+        );
 
-        /*
-         * assert things,
-         * here your tests should fail to show that there is a bug
-         */
-        assert.strictEqual(myDocument.age, 56);
-
-
-        // you can also wait for events
-        const emitted: any[] = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => {
-                emitted.push(doc);
-            });
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
-
-        // clean up afterwards
-        sub.unsubscribe();
         db.close();
-        dbInOtherTab.close();
     });
 });

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -1122,6 +1122,25 @@ describe('rx-query.test.ts', () => {
 
             c.database.close();
         });
+        it('find({ limit: 0 }) must return an empty result set', async () => {
+            const c = await humansCollection.create(3);
+
+            // Sanity check: without a limit we get all three docs back.
+            const all = await c.find().exec();
+            assert.strictEqual(all.length, 3);
+
+            const result = await c.find({
+                selector: {},
+                limit: 0
+            }).exec();
+            assert.strictEqual(
+                result.length,
+                0,
+                'find({ limit: 0 }) must return zero documents, got ' + result.length
+            );
+
+            c.database.close();
+        });
 
     });
     describeParallel('updates to the result of the query', () => {


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

When calling `find({ limit: 0 })` on a collection, the query was returning all matching documents instead of an empty result set. This affected all storage backends (memory, dexie, localstorage, foundationdb, denokv, sqlite, mongodb) and the query-builder plugin.

The root cause was a truthy check (`query.limit ? query.limit : Infinity`) that treated `0` as falsy, interpreting it as "no limit was set" and defaulting to `Infinity`.

## Changes

### Source Code
- Updated limit handling in 7 storage implementations and the query-builder plugin to use `typeof query.limit === 'number'` instead of truthy checks
- This ensures explicit `limit: 0` values are honored while still defaulting to `Infinity` when limit is undefined
- Applied the same fix to skip parameter in the query-builder plugin for consistency

### Tests
- Added unit test `find({ limit: 0 }) must return an empty result set` to verify the fix works correctly

### Documentation
- Added changelog entry documenting the fix across all affected storage backends

## Files Modified
- `src/plugins/storage-memory/rx-storage-instance-memory.ts`
- `src/plugins/storage-dexie/dexie-query.ts`
- `src/plugins/storage-localstorage/rx-storage-instance-localstorage.ts`
- `src/plugins/storage-foundationdb/foundationdb-query.ts`
- `src/plugins/storage-denokv/denokv-query.ts`
- `src/plugins/storage-sqlite/sqlite-storage-instance.ts`
- `src/plugins/storage-mongodb/rx-storage-instance-mongodb.ts`
- `src/plugins/query-builder/mquery/nosql-query-builder.ts`
- `test/unit/rx-query.test.ts`
- `orga/changelog/fix-storage-query-limit-zero.md`

https://claude.ai/code/session_01MLDgQ5rL3fJBRhNTqGx9Ym