### PR TITLE
Validate ORM attachment method names against RxAttachment reserved names

### DIFF
--- a/orga/changelog/fix-orm-attachment-method-name-conflict.md
+++ b/orga/changelog/fix-orm-attachment-method-name-conflict.md
@@ -1,0 +1,1 @@
+- FIX ORM attachment-method names conflicting with built-in `RxAttachment` methods (`getData`, `getStringData`, `getDataBase64`, `remove`) not being validated, silently shadowing the built-in method on every attachment instance and preventing users from retrieving their attachment data. Dev-mode now throws a clear `RxError` (COL17) during collection creation.

--- a/src/plugins/dev-mode/check-orm.ts
+++ b/src/plugins/dev-mode/check-orm.ts
@@ -6,10 +6,32 @@ import type { KeyFunctionMap, RxJsonSchema } from '../../types/index.d.ts';
 import { rxCollectionProperties, rxDocumentProperties } from './entity-properties.ts';
 
 /**
+ * Built-in property and method names on RxAttachment instances.
+ * Hard-coded here (instead of read from the RxAttachment class)
+ * so the dev-mode plugin does not have to import the attachments plugin.
+ * ORM attachment-methods that share a name with any of these would
+ * silently shadow the built-in method on each attachment instance.
+ */
+export const RX_ATTACHMENT_RESERVED_NAMES: string[] = [
+    'doc',
+    'id',
+    'type',
+    'length',
+    'digest',
+    'remove',
+    'getData',
+    'getStringData',
+    'getDataBase64'
+];
+
+/**
  * checks if the given static methods are allowed
  * @throws if not allowed
  */
-export function checkOrmMethods(statics?: KeyFunctionMap) {
+export function checkOrmMethods(
+    statics?: KeyFunctionMap,
+    additionalReservedNames?: string[]
+) {
     if (!statics) {
         return;
     }
@@ -37,7 +59,8 @@ export function checkOrmMethods(statics?: KeyFunctionMap) {
 
             if (
                 rxCollectionProperties().includes(k) ||
-                rxDocumentProperties().includes(k)
+                rxDocumentProperties().includes(k) ||
+                (additionalReservedNames && additionalReservedNames.includes(k))
             ) {
                 throw newRxError('COL17', {
                     name: k

--- a/src/plugins/dev-mode/index.ts
+++ b/src/plugins/dev-mode/index.ts
@@ -15,7 +15,8 @@ import {
 } from './check-schema.ts';
 import {
     checkOrmDocumentMethods,
-    checkOrmMethods
+    checkOrmMethods,
+    RX_ATTACHMENT_RESERVED_NAMES
 } from './check-orm.ts';
 import { checkMigrationStrategies } from './check-migration-strategies.ts';
 import {
@@ -188,7 +189,7 @@ Docs: ${err.docs}`;
                 // check ORM-methods
                 checkOrmMethods(args.creator.statics);
                 checkOrmMethods(args.creator.methods);
-                checkOrmMethods(args.creator.attachments);
+                checkOrmMethods(args.creator.attachments, RX_ATTACHMENT_RESERVED_NAMES);
 
                 // check migration strategies
                 if (args.creator.schema && args.creator.migrationStrategies) {

--- a/test/unit/orm.test.ts
+++ b/test/unit/orm.test.ts
@@ -381,56 +381,85 @@ describeParallel('orm.test.js', () => {
              *
              * The fix: checkOrmMethods must reject attachment ORM method
              * names that conflict with the built-in RxAttachment methods.
+             *
+             * To stay in sync with future RxAttachment changes, this test
+             * creates a real attachment, enumerates its instance and
+             * prototype property names, and asserts that none of them can
+             * be registered as an attachment ORM method.
              */
             if (!config.storage.hasAttachments) {
                 return;
             }
-            const db = await createRxDatabase({
-                name: randomToken(10),
-                storage: config.storage.getStorage(),
-                multiInstance: false
-            });
 
-            type DocType = {
-                id: string;
-            };
-
+            type DocType = { id: string; };
             const schema: RxJsonSchema<DocType> = {
                 version: 0,
                 type: 'object',
                 primaryKey: 'id',
                 properties: {
-                    id: {
-                        type: 'string',
-                        maxLength: 100
-                    }
+                    id: { type: 'string', maxLength: 100 }
                 },
                 required: ['id'],
                 attachments: {}
             };
 
-            /**
-             * 'getData' is a built-in RxAttachment method.
-             * Defining an attachment ORM method with this name must throw
-             * a clear RxError during collection creation, not silently
-             * override the built-in at attachment access time.
-             */
-            await AsyncTestUtil.assertThrows(
-                () => db.addCollections({
-                    humans: {
-                        schema,
-                        attachments: {
-                            getData: function () {
-                                return 'hijacked';
+            // 1. Create a real attachment to introspect.
+            const introspectDb = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+                multiInstance: false
+            });
+            const cols = await introspectDb.addCollections({
+                humans: { schema }
+            });
+            const doc = await cols.humans.insert({ id: 'a' });
+            const attachment = await doc.putAttachment({
+                id: 'cat.txt',
+                data: new Blob(['meow'], { type: 'text/plain' }),
+                type: 'text/plain'
+            });
+
+            // Collect every own property name on the instance and on its
+            // prototype chain (skipping Object.prototype and 'constructor'),
+            // since both are reachable on each attachment instance and would
+            // be silently shadowed by an ORM method of the same name.
+            const reservedNames = new Set<string>();
+            Object.getOwnPropertyNames(attachment).forEach(n => reservedNames.add(n));
+            let proto = Object.getPrototypeOf(attachment);
+            while (proto && proto !== Object.prototype) {
+                Object.getOwnPropertyNames(proto)
+                    .filter(n => n !== 'constructor')
+                    .forEach(n => reservedNames.add(n));
+                proto = Object.getPrototypeOf(proto);
+            }
+            await introspectDb.close();
+
+            assert.ok(reservedNames.size > 0, 'expected at least one reserved name');
+
+            // 2. For each reserved name, attempt to register an attachment
+            //    ORM method with that name and assert it throws.
+            for (const reservedName of reservedNames) {
+                const db = await createRxDatabase({
+                    name: randomToken(10),
+                    storage: config.storage.getStorage(),
+                    multiInstance: false
+                });
+                await AsyncTestUtil.assertThrows(
+                    () => db.addCollections({
+                        humans: {
+                            schema,
+                            attachments: {
+                                [reservedName]: function () {
+                                    return 'hijacked';
+                                }
                             }
                         }
-                    }
-                }),
-                'RxError',
-                'getData'
-            );
-
-            db.close();
+                    }),
+                    'RxError',
+                    reservedName
+                );
+                await db.close();
+            }
         });
         it('ORM method with populate-getter suffix should throw COL18', async () => {
             /**

--- a/test/unit/orm.test.ts
+++ b/test/unit/orm.test.ts
@@ -370,6 +370,68 @@ describeParallel('orm.test.js', () => {
         });
     });
     describe('ISSUES', () => {
+        it('attachment ORM method with built-in name should throw', async () => {
+            /**
+             * BUG: Attachment ORM methods with a name that matches a
+             * built-in RxAttachment method (getData, getStringData,
+             * getDataBase64, remove) silently override that built-in
+             * method on every attachment instance via Object.defineProperty.
+             * The user thinks they're adding a new method, but they've
+             * replaced the data-retrieval API without any warning.
+             *
+             * The fix: checkOrmMethods must reject attachment ORM method
+             * names that conflict with the built-in RxAttachment methods.
+             */
+            if (!config.storage.hasAttachments) {
+                return;
+            }
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+                multiInstance: false
+            });
+
+            type DocType = {
+                id: string;
+            };
+
+            const schema: RxJsonSchema<DocType> = {
+                version: 0,
+                type: 'object',
+                primaryKey: 'id',
+                properties: {
+                    id: {
+                        type: 'string',
+                        maxLength: 100
+                    }
+                },
+                required: ['id'],
+                attachments: {}
+            };
+
+            /**
+             * 'getData' is a built-in RxAttachment method.
+             * Defining an attachment ORM method with this name must throw
+             * a clear RxError during collection creation, not silently
+             * override the built-in at attachment access time.
+             */
+            await AsyncTestUtil.assertThrows(
+                () => db.addCollections({
+                    humans: {
+                        schema,
+                        attachments: {
+                            getData: function () {
+                                return 'hijacked';
+                            }
+                        }
+                    }
+                }),
+                'RxError',
+                'getData'
+            );
+
+            db.close();
+        });
         it('ORM method with populate-getter suffix should throw COL18', async () => {
             /**
              * BUG: The schema generates populate getters for each field


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

ORM attachment methods with names matching built-in `RxAttachment` methods (`getData`, `getStringData`, `getDataBase64`, `remove`) silently override those built-in methods on every attachment instance via `Object.defineProperty`. Users think they're adding a new method, but they've actually replaced the data-retrieval API without any warning, breaking attachment functionality.

## Solution

Added validation in dev-mode's `checkOrmMethods` function to reject attachment ORM method names that conflict with reserved `RxAttachment` property and method names. The validation now throws a clear `RxError` (COL17) during collection creation instead of silently shadowing built-in methods at runtime.

### Changes:
- **src/plugins/dev-mode/check-orm.ts**: 
  - Added `RX_ATTACHMENT_RESERVED_NAMES` constant listing all built-in RxAttachment properties/methods
  - Extended `checkOrmMethods` to accept optional `additionalReservedNames` parameter for attachment-specific validation
  
- **src/plugins/dev-mode/index.ts**: 
  - Updated attachment ORM method validation to pass `RX_ATTACHMENT_RESERVED_NAMES` to `checkOrmMethods`

- **test/unit/orm.test.ts**: 
  - Added comprehensive test case verifying that defining an attachment ORM method with a reserved name (`getData`) throws an `RxError` during collection creation

## Todos
- [x] Tests
- [x] Changelog

https://claude.ai/code/session_01KewTXP51UVs5YRe36aNRqQ