### PR TITLE
FIX RxPipeline error state blocking destination reads

### DIFF
--- a/orga/changelog/fix-pipeline-error-blocks-destination-reads.md
+++ b/orga/changelog/fix-pipeline-error-blocks-destination-reads.md
@@ -1,0 +1,1 @@
+- FIX `RxPipeline` error state blocking unrelated reads on the destination collection, because the pipeline's `waitBeforeWriteFn` hook always called `awaitIdle()` which re-throws the stored handler error forever. After a handler throws, reads on the destination collection now proceed normally instead of re-throwing the pipeline error.

--- a/src/plugins/pipeline/rx-pipeline.ts
+++ b/src/plugins/pipeline/rx-pipeline.ts
@@ -50,6 +50,14 @@ export class RxPipeline<RxDocType> {
 
 
     waitBeforeWriteFn = async () => {
+        /**
+         * If the pipeline is in an errored state, do not block reads on the
+         * destination collection. The error is surfaced via pipeline.awaitIdle()
+         * and should not poison unrelated reads on the destination collection.
+         */
+        if (this.error) {
+            return;
+        }
         const stack = new Error().stack;
         if (stack && (
             stack.includes(PIPELINE_FN_PREFIX)

--- a/test/unit/rx-pipeline.test.ts
+++ b/test/unit/rx-pipeline.test.ts
@@ -224,6 +224,45 @@ describe('rx-pipeline.test.js', () => {
             await c1.database.close();
             await c2.database.close();
         });
+        it('should not break reads on destination after handler throws', async () => {
+            const c1 = await humansCollection.create(0);
+            await c1.database.waitForLeadership();
+            const c2 = await humansCollection.create(0);
+
+            // Insert a pre-existing document directly into the destination.
+            // This document is written independently of the pipeline.
+            await c2.insert(schemaObjects.humanData('pre-existing'));
+
+            const pipeline = await c1.addPipeline({
+                destination: c2,
+                handler: () => {
+                    throw new Error('handlerErrorPoisonsDestination');
+                },
+                identifier: randomToken(10)
+            });
+
+            // Trigger the failing handler by writing to the source.
+            await c1.insert(schemaObjects.humanData('trigger-error'));
+
+            // The pipeline's awaitIdle rejects as expected.
+            await assertThrows(
+                () => pipeline.awaitIdle(),
+                undefined,
+                'handlerErrorPoisonsDestination'
+            );
+
+            // Reads on the destination should still work because the destination
+            // is a regular collection that existed before the pipeline. The pipeline
+            // being in an errored state should not poison unrelated reads on the
+            // destination collection.
+            const docs = await c2.find().exec();
+            assert.strictEqual(docs.length, 1);
+            assert.strictEqual(docs[0].passportId, 'pre-existing');
+
+            await pipeline.close();
+            await c1.database.close();
+            await c2.database.close();
+        });
     });
     describeParallel('checkpoints', () => {
         it('should continue from the correct checkpoint', async () => {


### PR DESCRIPTION
When a pipeline handler throws, the pipeline stores the error and
awaitIdle() re-throws it forever. But waitBeforeWriteFn (registered in
the destination's awaitBeforeReads) also called awaitIdle(), so every
read on the destination collection threw the pipeline error forever,
even for documents unrelated to the pipeline.

Skip the await in waitBeforeWriteFn when the pipeline is in an errored
state so unrelated destination reads work. The error is still surfaced
via pipeline.awaitIdle().