### PR TITLE
Fix RxState write queue breaking when modifier throws

### DIFF
--- a/orga/changelog/fix-rxstate-write-queue-recover-after-modifier-throws.md
+++ b/orga/changelog/fix-rxstate-write-queue-recover-after-modifier-throws.md
@@ -1,0 +1,1 @@
+- FIX `RxState.set()` permanently breaking the write queue when a user-supplied modifier throws, causing all subsequent `set()` calls to reject with an unrelated `SNH` error instead of performing the write

--- a/src/plugins/state/rx-state.ts
+++ b/src/plugins/state/rx-state.ts
@@ -42,7 +42,6 @@ import {
     RxStateOperation,
     RxStateModifier
 } from './types.ts';
-import { newRxError } from '../../rx-error.ts';
 import { runPluginHooks } from '../../hooks.ts';
 
 
@@ -144,7 +143,7 @@ export class RxStateBase<T, Reactivity = unknown> {
      * that would throw conflict errors and trigger a retry.
      */
     _triggerWrite() {
-        this._writeQueue = this._writeQueue.then(async () => {
+        const next = this._writeQueue.then(async () => {
             if (this._nonPersisted.length === 0) {
                 return;
             }
@@ -207,13 +206,10 @@ export class RxStateBase<T, Reactivity = unknown> {
                     await promiseWait(0);
                 }
             }
-        }).catch(error => {
-            throw newRxError('SNH', {
-                name: 'RxState WRITE QUEUE ERROR',
-                error
-            });
         });
-        return this._writeQueue;
+        // Keep the shared queue alive so a failing write does not block subsequent ones.
+        this._writeQueue = next.catch(() => { });
+        return next;
     }
 
     mergeOperationsIntoState(

--- a/test/unit/rx-state.test.ts
+++ b/test/unit/rx-state.test.ts
@@ -745,6 +745,38 @@ addRxPlugin(RxDBJsonDumpPlugin);
 
                 state.collection.database.remove();
             });
+            /**
+             * When a modifier passed to set() throws, the write queue
+             * must not be permanently broken. Subsequent writes with
+             * valid modifiers should still succeed.
+             */
+            it('write queue should recover after a modifier throws', async () => {
+                const state = await getState();
+
+                await state.set('a', () => 1);
+                assert.strictEqual(state.get('a'), 1);
+
+                const thrownError = new Error('bad modifier');
+                let caughtError: any;
+                try {
+                    await state.set('a', () => {
+                        throw thrownError;
+                    });
+                } catch (err) {
+                    caughtError = err;
+                }
+                assert.ok(caughtError, 'the first set() should reject');
+
+                // a subsequent valid write must still succeed
+                await state.set('a', () => 2);
+                assert.strictEqual(state.get('a'), 2);
+
+                // and a later write should still work
+                await state.set('a', (prev: any) => prev + 1);
+                assert.strictEqual(state.get('a'), 3);
+
+                state.collection.database.remove();
+            });
         });
     });
 });


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS
- CHANGELOG

## Describe the problem you have without this PR

When a user-supplied modifier function passed to `RxState.set()` throws an error, the write queue becomes permanently broken. All subsequent `set()` calls reject with an unrelated `SNH` (Should Not Happen) error instead of performing the write operation. This makes the state unusable after any modifier error.

## Solution

The issue was in the `_triggerWrite()` method in `rx-state.ts`. The write queue promise chain was being broken by a `.catch()` handler that threw a new error, which prevented the queue from recovering.

**Changes made:**

1. **src/plugins/state/rx-state.ts**: 
   - Removed the `.catch()` handler that was throwing `newRxError` and permanently breaking the queue
   - Changed the queue assignment to use `.catch(() => { })` on the next promise, allowing the queue to recover from errors while still returning the original promise to the caller
   - This ensures that modifier errors are properly propagated to the caller, but don't block subsequent writes

2. **test/unit/rx-state.test.ts**:
   - Added comprehensive test case `'write queue should recover after a modifier throws'` that verifies:
     - A modifier that throws is properly rejected
     - Subsequent valid writes succeed after a modifier error
     - Multiple writes continue to work correctly

## Test Plan

Added unit test that covers the fix by:
1. Setting an initial state value
2. Attempting a write with a throwing modifier and verifying it rejects
3. Performing a subsequent valid write and verifying it succeeds
4. Performing another write to ensure the queue remains functional

The test ensures the write queue recovers and continues to function normally after a modifier throws.

https://claude.ai/code/session_014tc6zBEehiTWbdrPpnCfR8