### PR TITLE
test: reproduce $elemMatch operator normalization regression

### DIFF
--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -1,141 +1,87 @@
-/**
- * this is a template for a test.
- * If you found a bug, edit this test to reproduce it
- * and than make a pull-request with that failing test.
- * The maintainer will later move your test to the correct position in the test-suite.
- *
- * To run this test do:
- * - 'npm run test:node' so it runs in nodejs
- * - 'npm run test:browser' so it runs in the browser
- */
 import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
-import config from './config.ts';
-
 import {
-    createRxDatabase,
-    randomToken
+    fillWithDefaultSettings,
+    normalizeMangoQuery
 } from '../../plugins/core/index.mjs';
-import {
-    isNode
-} from '../../plugins/test-utils/index.mjs';
+
+import type {
+    RxJsonSchema
+} from '../../plugins/core/index.mjs';
+
+type ElemMatchDoc = {
+    id: string;
+    type: string;
+    roles: string[];
+};
+
 describe('bug-report.test.js', () => {
-    it('should fail because it reproduces the bug', async function () {
-
-        /**
-         * If your test should only run in nodejs or only run in the browser,
-         * you should comment in the return operator and adapt the if statement.
-         */
-        if (
-            !isNode // runs only in node
-            // isNode // runs only in the browser
-        ) {
-            // return;
-        }
-
-        if (!config.storage.hasMultiInstance) {
-            return;
-        }
-
-        // create a schema
-        const mySchema = {
+    it('should not normalize operator payloads inside $elemMatch', () => {
+        const schema: RxJsonSchema<ElemMatchDoc> = fillWithDefaultSettings({
             version: 0,
-            primaryKey: 'passportId',
+            primaryKey: 'id',
             type: 'object',
             properties: {
-                passportId: {
+                id: {
                     type: 'string',
                     maxLength: 100
                 },
-                firstName: {
-                    type: 'string'
+                type: {
+                    type: 'string',
+                    maxLength: 100
                 },
-                lastName: {
-                    type: 'string'
-                },
-                age: {
-                    type: 'integer',
-                    minimum: 0,
-                    maximum: 150
+                roles: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                }
+            },
+            required: ['id', 'type', 'roles'],
+            indexes: ['type']
+        });
+
+        const regexQuery = normalizeMangoQuery<ElemMatchDoc>(
+            schema,
+            {
+                selector: {
+                    type: { $eq: 'PERSON' },
+                    roles: {
+                        $elemMatch: {
+                            $regex: '^applicant$',
+                            $options: 'i'
+                        }
+                    }
                 }
             }
-        };
+        );
 
-        /**
-         * Always generate a random database-name
-         * to ensure that different test runs do not affect each other.
-         */
-        const name = randomToken(10);
-
-        // create a database
-        const db = await createRxDatabase({
-            name,
-            /**
-             * By calling config.storage.getStorage(),
-             * we can ensure that all variations of RxStorage are tested in the CI.
-             */
-            storage: config.storage.getStorage(),
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collections = await db.addCollections({
-            mycollection: {
-                schema: mySchema
+        assert.deepStrictEqual(
+            (regexQuery.selector as any).roles.$elemMatch,
+            {
+                $regex: '^applicant$',
+                $options: 'i'
             }
-        });
+        );
 
-        // insert a document
-        await collections.mycollection.insert({
-            passportId: 'foobar',
-            firstName: 'Bob',
-            lastName: 'Kelso',
-            age: 56
-        });
-
-        /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
-         */
-        const dbInOtherTab = await createRxDatabase({
-            name,
-            storage: config.storage.getStorage(),
-            eventReduce: true,
-            ignoreDuplicate: true
-        });
-        // create a collection
-        const collectionInOtherTab = await dbInOtherTab.addCollections({
-            mycollection: {
-                schema: mySchema
+        const eqQuery = normalizeMangoQuery<ElemMatchDoc>(
+            schema,
+            {
+                selector: {
+                    type: { $eq: 'PERSON' },
+                    roles: {
+                        $elemMatch: {
+                            $eq: 'Applicant'
+                        }
+                    }
+                }
             }
-        });
+        );
 
-        // find the document in the other tab
-        const myDocument = await collectionInOtherTab.mycollection
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
-            .exec();
-
-        /*
-         * assert things,
-         * here your tests should fail to show that there is a bug
-         */
-        assert.strictEqual(myDocument.age, 56);
-
-
-        // you can also wait for events
-        const emitted: any[] = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => {
-                emitted.push(doc);
-            });
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
-
-        // clean up afterwards
-        sub.unsubscribe();
-        db.close();
-        dbInOtherTab.close();
+        assert.deepStrictEqual(
+            (eqQuery.selector as any).roles.$elemMatch,
+            {
+                $eq: 'Applicant'
+            }
+        );
     });
 });


### PR DESCRIPTION
## Summary

This PR adds a failing bug-report test for a regression in `normalizeMangoQuery()` when `$elemMatch` already contains operators like `$eq`, `$regex`, and `$options`.

On `rxdb@17.1.0`, operator payloads inside `$elemMatch` are normalized as if they were selector shorthands. For example:

```ts
{
  roles: {
    $elemMatch: {
      $regex: '^applicant$',
      $options: 'i'
    }
  }
}
```

is rewritten into:

```ts
{
  roles: {
    $elemMatch: {
      $regex: { $eq: '^applicant$' },
      $options: { $eq: 'i' }
    }
  }
}
```

That breaks later query evaluation. In my app this surfaced as:

```txt
Invalid flags supplied to RegExp constructor '[object Object]'
```

## Regression window

- works on `16.21.1`
- fails on `17.1.0`

Likely related upstream change:
- `4766c7a` Normalize selector shorthands recursively in `$and`/`$or`/`$nor`/`$not` (`#8121`)

## Repro

This PR follows the repository issue template and puts the repro into `test/unit/bug-report.test.ts`.

The failing test covers both:
- `$elemMatch: { $regex: '^applicant$', $options: 'i' }`
- `$elemMatch: { $eq: 'Applicant' }`

Both should remain unchanged by `normalizeMangoQuery()`, but are currently wrapped in `$eq`.

## Validation

Ran:

```bash
./node_modules/.bin/eslint test/unit/bug-report.test.ts
npm run transpile
DEFAULT_STORAGE=dexie ./node_modules/.bin/mocha --expose-gc --config ./config/.mocharc.cjs ./test_tmp/unit/bug-report.test.js --grep 'operator payloads inside \$elemMatch'
```

Result:
- lint passes
- transpile succeeds
- targeted test fails with the expected assertion showing `$regex` and `$options` mutated into `{ $eq: ... }`
