### PR TITLE
Add live query update throttle option

### DIFF
--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -1,9 +1,11 @@
 import {
     BehaviorSubject,
     Observable,
-    merge
+    merge,
+    of
 } from 'rxjs';
 import {
+    auditTime,
     mergeMap,
     filter,
     map,
@@ -146,18 +148,32 @@ export class RxQueryBase<
     }
     get $(): Observable<RxQueryResult> {
         if (!this._$) {
-            const results$ = this.collection.eventBulks$.pipe(
+            const changeEventBulks$ = this.collection.eventBulks$.pipe(
                 /**
                  * Performance shortcut.
                  * Changes to local documents are not relevant for the query.
                  */
-                filter((bulk: any) => !bulk.isLocal),
+                filter((bulk: any) => !bulk.isLocal)
+            );
+            const liveQueryUpdateThrottleTime = getLiveQueryUpdateThrottleTime(this.collection);
+            const updateTrigger$ = liveQueryUpdateThrottleTime > 0 ?
+                merge(
+                    of(null),
+                    changeEventBulks$.pipe(auditTime(liveQueryUpdateThrottleTime))
+                ) :
+                changeEventBulks$.pipe(
+                    /**
+                     * Start once to ensure the querying also starts
+                     * when there where no changes.
+                     */
+                    startWith(null)
+                );
+            const results$ = updateTrigger$.pipe(
                 /**
-                 * Start once to ensure the querying also starts
-                 * when there where no changes.
+                 * Ensure query results are up to date.
+                 * When enabled, liveQueryUpdateThrottleTime groups change-triggered
+                 * reruns before this point so downstream throttling is not too late.
                  */
-                startWith(null),
-                // ensure query results are up to date.
                 mergeMap(() => _ensureEqual(this as any)),
                 // use the current result set, written by _ensureEqual().
                 map(() => this._result),
@@ -580,6 +596,20 @@ export function _getDefaultQuery<RxDocType>(): MangoQuery<RxDocType> {
     return {
         selector: {}
     };
+}
+
+function getLiveQueryUpdateThrottleTime(collection: RxCollection<any>): number {
+    const collectionThrottleTime = collection.options.liveQueryUpdateThrottleTime;
+    if (typeof collectionThrottleTime === 'number') {
+        return collectionThrottleTime;
+    }
+
+    const databaseThrottleTime = collection.database.options.liveQueryUpdateThrottleTime;
+    if (typeof databaseThrottleTime === 'number') {
+        return databaseThrottleTime;
+    }
+
+    return 0;
 }
 
 /**

--- a/test/unit/reactive-query.test.ts
+++ b/test/unit/reactive-query.test.ts
@@ -150,6 +150,95 @@ describeParallel('reactive-query.test.js', () => {
             sub.unsubscribe();
             c.database.close();
         });
+        it('groups live query write bursts before _ensureEqual when enabled', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+                multiInstance: false,
+                eventReduce: false,
+                options: {
+                    liveQueryUpdateThrottleTime: 100
+                }
+            });
+            const collections = await db.addCollections({
+                humans: {
+                    schema: schemas.human
+                }
+            });
+            const c = collections.humans;
+            const query = c.find().sort('passportId');
+            const emitted: RxDocument<HumanDocumentType>[][] = [];
+            let sub: { unsubscribe(): void; } | undefined;
+            try {
+                sub = query.$.subscribe(results => emitted.push(results));
+                await waitUntil(() => emitted.length === 1);
+                const ensureEqualAfterInitialRun = query._lastEnsureEqual;
+
+                await Promise.all(
+                    new Array(5).fill(0).map((_v, index) => {
+                        return c.insert(schemaObjects.humanData('throttle-' + index));
+                    })
+                );
+                await promiseWait(5);
+
+                assert.strictEqual(query._lastEnsureEqual, ensureEqualAfterInitialRun);
+            } finally {
+                if (sub) {
+                    sub.unsubscribe();
+                }
+                db.close();
+            }
+        });
+        it('emits the latest matching result after grouped writes', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+                multiInstance: false,
+                eventReduce: false,
+                options: {
+                    liveQueryUpdateThrottleTime: 10
+                }
+            });
+            const collections = await db.addCollections({
+                humans: {
+                    schema: schemas.human
+                }
+            });
+            const c = collections.humans;
+            await c.insert(schemaObjects.humanData('match-0', 1));
+
+            const query = c.find({
+                selector: {
+                    age: {
+                        $eq: 1
+                    }
+                },
+                sort: [
+                    {
+                        passportId: 'asc'
+                    }
+                ]
+            });
+            const emitted: RxDocument<HumanDocumentType>[][] = [];
+            const sub = query.$.subscribe(results => emitted.push(results));
+            try {
+                await waitUntil(() => emitted.length === 1);
+
+                await Promise.all([
+                    c.insert(schemaObjects.humanData('outside-result', 2)),
+                    c.insert(schemaObjects.humanData('match-1', 1))
+                ]);
+
+                await waitUntil(() => {
+                    const lastEmission = emitted[emitted.length - 1];
+                    return lastEmission &&
+                        lastEmission.map(doc => doc.primary).join(',') === 'match-0,match-1';
+                });
+            } finally {
+                sub.unsubscribe();
+                db.close();
+            }
+        });
         it('doing insert after subscribe should end with the correct results', async () => {
 
             const c = await humansCollection.create(1);


### PR DESCRIPTION
## Summary
- Add an opt-in `liveQueryUpdateThrottleTime` option that groups change-triggered live query updates before `_ensureEqual()` runs.
- Keep the first live query result immediate, so subscriptions still behave like a BehaviorSubject on startup.
- Add reactive query tests that prove write bursts are grouped and that the latest matching result is still emitted after grouped writes.

## Why this is needed
In our application we have live queries over large folders, including a case with about 155k matching documents. During initial sync and follow-up metadata updates, many writes can touch documents that stay in the same query result.

We first tried to throttle downstream with RxJS after `find(...).$`, but that was too late. RxDB had already received each change bulk and called `_ensureEqual()` before subscribers saw the value. For large result sets this means RxDB may repeatedly run EventReduce or a full storage query, map many documents through the cache, and build another large live query result before application code can throttle it.

The visible effect in the app was renderer stalls during sync. One run showed multi-second raw live-query gaps before our throttling code ran, and repeated emissions of the full 155k result set blocked the renderer. Detaching that large live query after the first final snapshot avoided the repeated work, but that is an app-level workaround and loses the normal live-query behavior.

This option gives applications a small upstream control point at the place where it matters: before `_ensureEqual()` does the expensive work. It defaults to disabled, so existing RxDB behavior is unchanged.

## Test plan
- `npm run lint`
- `npm run build`
- `npm run check-types`
- `npm run test:fast:memory`
- Focused check: `npm run transpile && npm run build:plugins && npx cross-env DEFAULT_STORAGE=memory NODE_ENV=fast mocha --config ./config/.mocharc.cjs ./test_tmp/unit/reactive-query.test.js --grep "groups live query write bursts|emits the latest matching result after grouped writes"`


Made with [Cursor](https://cursor.com)