### PR TITLE
Add rxdb-extra plugin to third-party plugins documentation

### DIFF
--- a/docs-src/docs/third-party-plugins.md
+++ b/docs-src/docs/third-party-plugins.md
@@ -12,4 +12,5 @@ image: /headers/third-party-plugins.jpg
 * [rxdb-orion](https://github.com/serenysoft/rxdb-orion) Enables [replication](./replication.md) with [Laravel Orion](https://tailflow.github.io/laravel-orion-docs).
 * [rxdb-supabase](https://github.com/marceljuenemann/rxdb-supabase) Enables replication with [Supabase](https://supabase.com/).
 * [rxdb-utils](https://github.com/rafamel/rxdb-utils) Additional features for RxDB like models, timestamps, default values, view and more.
+* [rxdb-extra](https://github.com/serenysoft/rxdb-extra) Additional features for RxDB like timestamps, simple search, strict schema, and more. (Compatible with the latest versions.)
 * [loki-async-reference-adapter](https://github.com/jonnyreeves/loki-async-reference-adapter) Simple async adapter for LokiJS, suitable to use RxDB's [Lokijs RxStorage](./rx-storage-lokijs.md) with React Native.


### PR DESCRIPTION
This PR add `rxdb-extra` entry in the third-party plugins documentation.