### PR TITLE
Fix analytics initialization in non-production environments

### DIFF
--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -338,13 +338,16 @@ Topic-specific documentation files:
             'classic',
             /** @type {import('@docusaurus/preset-classic').Options} */
             {
-                gtag: {
+                // Only enable analytics in production builds. In local dev (or when
+                // an ad-blocker blocks the gtag script) window.gtag is undefined and
+                // the route-change tracker throws "window.gtag is not a function".
+                gtag: process.env.NODE_ENV === 'production' ? {
                     trackingID: 'G-62D63SY3S0',
                     anonymizeIP: false,
-                },
-                googleTagManager: {
+                } : undefined,
+                googleTagManager: process.env.NODE_ENV === 'production' ? {
                     containerId: 'GTM-PL63TR5',
-                },
+                } : undefined,
                 sitemap: {
                     lastmod: 'date',
                     changefreq: 'weekly',


### PR DESCRIPTION
## This PR contains:
- A BUGFIX

## Describe the problem you have without this PR

Analytics tracking (Google Analytics and Google Tag Manager) were being initialized in all environments, including local development. When an ad-blocker or other factors prevent the gtag script from loading, `window.gtag` becomes undefined, causing the route-change tracker to throw a "window.gtag is not a function" error in development builds.

## Solution

Conditionally enable analytics only in production builds by checking `process.env.NODE_ENV`. Both `gtag` and `googleTagManager` configurations are now set to `undefined` in non-production environments, preventing initialization of analytics tracking during local development.

## Test Plan

No testing needed. This is a configuration change that prevents analytics initialization in development environments. The fix can be verified by:
1. Running the docs site locally and confirming no analytics errors appear in the console
2. Building for production and confirming analytics are properly initialized

https://claude.ai/code/session_018Vb2V3X46L8aG3ufVAfFtT