### PR TITLE
Fix docs branch cleanup to preserve .git worktree file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,9 @@ jobs:
             git worktree add --orphan /tmp/docs-branch docs
 
           # Wipe everything that was previously in the docs branch,
-          # including hidden files and directories.
-          find /tmp/docs-branch -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          # including hidden files and directories. Keep the worktree's
+          # .git file so subsequent git commands keep working.
+          find /tmp/docs-branch -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} +
 
           # Copy the fresh build output into ./docs
           mkdir -p /tmp/docs-branch/docs


### PR DESCRIPTION
## This PR contains:
- A BUGFIX

## Describe the problem you have without this PR

The docs branch cleanup step in the build workflow was removing all files and directories in the worktree, including the `.git` file that git uses to reference the worktree's actual git directory. This causes subsequent git commands in the workflow to fail because the worktree loses its connection to the repository.

## Changes

Modified the `find` command in `.github/workflows/build.yml` to exclude the `.git` file when cleaning up the docs branch worktree. This preserves the worktree's git metadata while still removing all other files and directories from the previous build.

The fix adds the `-not -name '.git'` predicate to the find command, ensuring that only the generated documentation files are removed, not the worktree's git configuration.

## Test Plan

The fix will be validated by the existing CI workflow - if subsequent git commands in the build job succeed, the worktree's `.git` file has been properly preserved.

https://claude.ai/code/session_0161GK3s7Rap4vBrMwPHPivT