### PR TITLE
schema using 'patternProperties' with square bracket character classes gets interpreted as array access

### DIFF
--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -496,6 +496,7 @@ export function checkSchema(jsonSchema: RxJsonSchema<any>) {
             return split.join('.');
         })
         .filter(key => key !== '')
+        .filter(key => key.indexOf('.patternProperties.') == -1 ) // regex in patternProperties not interpreted
         .filter((elem, pos, arr) => arr.indexOf(elem) === pos) // unique
         .filter(key => { // check if this path defines an index
             const value = getProperty(jsonSchema, key);

--- a/test/unit/bug-report.test.ts
+++ b/test/unit/bug-report.test.ts
@@ -1,41 +1,12 @@
-/**
- * this is a template for a test.
- * If you found a bug, edit this test to reproduce it
- * and than make a pull-request with that failing test.
- * The maintainer will later move your test to the correct position in the test-suite.
- *
- * To run this test do:
- * - 'npm run test:node' so it runs in nodejs
- * - 'npm run test:browser' so it runs in the browser
- */
 import assert from 'assert';
-import AsyncTestUtil from 'async-test-util';
 import config from './config.ts';
 
 import {
     createRxDatabase,
     randomToken
 } from '../../plugins/core/index.mjs';
-import {
-    isNode
-} from '../../plugins/test-utils/index.mjs';
-describe('bug-report.test.js', () => {
+describe('allow character classes in patternProperties', () => {
     it('should fail because it reproduces the bug', async function () {
-
-        /**
-         * If your test should only run in nodejs or only run in the browser,
-         * you should comment in the return operator and adapt the if statement.
-         */
-        if (
-            !isNode // runs only in node
-            // isNode // runs only in the browser
-        ) {
-            // return;
-        }
-
-        if (!config.storage.hasMultiInstance) {
-            return;
-        }
 
         // create a schema
         const mySchema = {
@@ -47,33 +18,23 @@ describe('bug-report.test.js', () => {
                     type: 'string',
                     maxLength: 100
                 },
-                firstName: {
-                    type: 'string'
+                personFields: {
+                    type: 'object',
+                    patternProperties: {
+                        '^[a-z]\\w*$': {   // here is a regex that includes square brackets
+                            type: 'string'
+                        }
+                    },
+                    additionalProperties: false
                 },
-                lastName: {
-                    type: 'string'
-                },
-                age: {
-                    type: 'integer',
-                    minimum: 0,
-                    maximum: 150
-                }
             }
         };
 
-        /**
-         * Always generate a random database-name
-         * to ensure that different test runs do not affect each other.
-         */
         const name = randomToken(10);
 
         // create a database
         const db = await createRxDatabase({
             name,
-            /**
-             * By calling config.storage.getStorage(),
-             * we can ensure that all variations of RxStorage are tested in the CI.
-             */
             storage: config.storage.getStorage(),
             eventReduce: true,
             ignoreDuplicate: true
@@ -88,15 +49,11 @@ describe('bug-report.test.js', () => {
         // insert a document
         await collections.mycollection.insert({
             passportId: 'foobar',
-            firstName: 'Bob',
-            lastName: 'Kelso',
-            age: 56
+            personFields: {
+                'firstLower': 'lower',
+            },
         });
 
-        /**
-         * to simulate the event-propagation over multiple browser-tabs,
-         * we create the same database again
-         */
         const dbInOtherTab = await createRxDatabase({
             name,
             storage: config.storage.getStorage(),
@@ -112,29 +69,15 @@ describe('bug-report.test.js', () => {
 
         // find the document in the other tab
         const myDocument = await collectionInOtherTab.mycollection
-            .findOne()
-            .where('firstName')
-            .eq('Bob')
+            .findOne('foobar')
             .exec();
 
         /*
          * assert things,
          * here your tests should fail to show that there is a bug
          */
-        assert.strictEqual(myDocument.age, 56);
+        assert.strictEqual(myDocument.personFields.firstLower, 'lower');
 
-
-        // you can also wait for events
-        const emitted: any[] = [];
-        const sub = collectionInOtherTab.mycollection
-            .findOne().$
-            .subscribe(doc => {
-                emitted.push(doc);
-            });
-        await AsyncTestUtil.waitUntil(() => emitted.length === 1);
-
-        // clean up afterwards
-        sub.unsubscribe();
         db.close();
         dbInOtherTab.close();
     });


### PR DESCRIPTION
## This PR contains:

BUG TEST CASE

## Describe the problem

I want to include objects as fields in an RxJsonSchema. If I specify that deep objects properties by *patternProperties* I want
to use *character classes* in the regex. rxdb seems to interpret the square brackets (originating from the regex character classes) as indicating array indizes and bails out.

## Describe solution

Regexs in *patternProperties* should NOT be interpreted as array indizes - at least not directly. *If* such indizes serve a purpose, only interpret square brackets that are *not* part of the regex as such (e.g. escaped by backslash for a 'literal' square bracket).
