### PR TITLE
fix: surface schema validation errors during migration instead of SNH

### DIFF
--- a/orga/changelog/fix-migration-schema-validation-error.md
+++ b/orga/changelog/fix-migration-schema-validation-error.md
@@ -1,0 +1,1 @@
+- FIX non-conflict write errors during migration (e.g. schema validation failures with status 422) now surface as a meaningful `COL20` error instead of the internal `SNH` ("This should never happen") error. See [issue #8607](https://github.com/pubkey/rxdb/issues/8607)

--- a/src/replication-protocol/index.ts
+++ b/src/replication-protocol/index.ts
@@ -48,8 +48,8 @@ import {
 } from './helper.ts';
 import { startReplicationUpstream } from './upstream.ts';
 import { fillWriteDataForAttachmentsChange } from '../plugins/attachments/index.ts';
+import { rxStorageWriteErrorToRxError } from '../rx-error.ts';
 import { getChangedDocumentsSince } from '../rx-storage-helper.ts';
-import { newRxError } from '../rx-error.ts';
 
 
 export * from './checkpoint.ts';
@@ -313,10 +313,14 @@ export function rxStorageInstanceToReplicationHandler<RxDocType, MasterCheckpoin
 
                 result.error.forEach(err => {
                     if (err.status !== 409) {
-                        throw newRxError('SNH', {
-                            name: 'non conflict error',
-                            error: err as any
-                        });
+                        /**
+                         * Non-conflict write errors (e.g. status 422 schema validation errors)
+                         * are real errors that must be surfaced to the caller with a meaningful
+                         * message. Throwing SNH here hides the actual cause (e.g. a document
+                         * with a null value in a required string field during migration).
+                         * @see https://github.com/pubkey/rxdb/issues/8607
+                         */
+                        throw rxStorageWriteErrorToRxError(err);
                     } else {
                         conflicts.push(
                             writeDocToDocState(ensureNotFalsy(err.documentInDb), hasAttachments, keepMeta)

--- a/test/unit/migration-schema.test.ts
+++ b/test/unit/migration-schema.test.ts
@@ -382,6 +382,105 @@ describe('migration-schema.test.ts', function () {
                 );
                 await col.database.close();
             });
+            /**
+             * Regression test for https://github.com/pubkey/rxdb/issues/8607
+             * When a migration strategy produces a document that fails schema
+             * validation (status 422), the error should surface as a meaningful
+             * schema validation error (COL20) rather than the internal SNH
+             * "This should never happen" error.
+             */
+            it('should throw a schema validation error (not SNH) when migrated document violates the new schema', async () => {
+                if (!config.storage.hasReplication) {
+                    return;
+                }
+                const dbName = randomToken(10);
+
+                const schemaV0 = {
+                    version: 0,
+                    primaryKey: 'id',
+                    type: 'object',
+                    properties: {
+                        id: {
+                            type: 'string',
+                            maxLength: 100
+                        },
+                        icon: {
+                            type: 'string',
+                            maxLength: 1000
+                        }
+                    },
+                    required: ['id']
+                };
+
+                // v1 makes `icon` required and typed as string — a null value will fail validation
+                const schemaV1 = {
+                    version: 1,
+                    primaryKey: 'id',
+                    type: 'object',
+                    properties: {
+                        id: {
+                            type: 'string',
+                            maxLength: 100
+                        },
+                        icon: {
+                            type: 'string',
+                            maxLength: 1000
+                        }
+                    },
+                    required: ['id', 'icon']
+                };
+
+                const db = await createRxDatabase({
+                    name: dbName,
+                    storage: config.storage.getStorage(),
+                });
+                const cols = await db.addCollections({
+                    apps: {
+                        schema: schemaV0
+                    }
+                });
+                // insert a document where `icon` is null — valid in v0 but invalid in v1
+                await cols.apps.insert({ id: 'claude.ai', icon: null as any });
+                await db.close();
+
+                const db2 = await createRxDatabase({
+                    name: dbName,
+                    storage: config.storage.getStorage(),
+                    ignoreDuplicate: true
+                });
+                const cols2 = await db2.addCollections({
+                    apps: {
+                        schema: schemaV1,
+                        autoMigrate: false,
+                        migrationStrategies: {
+                            // strategy intentionally keeps null icon, causing a 422 on write
+                            1: (doc: any) => doc
+                        }
+                    }
+                });
+
+                let caughtError: any;
+                try {
+                    await cols2.apps.getMigrationState().migratePromise();
+                } catch (err: any) {
+                    caughtError = err;
+                }
+
+                assert.ok(caughtError, 'migration should have thrown');
+                // The error should be DM4 (migration error) wrapping a COL20 (schema validation),
+                // NOT an SNH (should never happen) error.
+                assert.strictEqual(caughtError.code, 'DM4');
+                const innerError = caughtError.parameters?.error;
+                assert.ok(innerError, 'inner error should exist');
+                // The inner error must be a schema validation error (COL20), not SNH
+                assert.ok(
+                    innerError.code === 'COL20' || (innerError.parameters?.writeError?.status === 422),
+                    'inner error must be a schema validation error, not SNH. Got: ' + JSON.stringify(innerError?.code)
+                );
+                assert.notStrictEqual(innerError.code, 'SNH', 'Must not throw internal SNH error for schema validation failures');
+
+                await db2.close();
+            });
         });
         describe('.migratePromise()', () => {
             describe('positive', () => {

--- a/test/unit/migration-schema.test.ts
+++ b/test/unit/migration-schema.test.ts
@@ -388,6 +388,11 @@ describe('migration-schema.test.ts', function () {
              * validation (status 422), the error should surface as a meaningful
              * schema validation error (COL20) rather than the internal SNH
              * "This should never happen" error.
+             *
+             * Schema v0 allows `icon` to be null (type: ['string', 'null']).
+             * Schema v1 requires `icon` to be a non-null string.
+             * The migration strategy passes the document through unchanged,
+             * so the null `icon` value causes a 422 write error in v1.
              */
             it('should throw a schema validation error (not SNH) when migrated document violates the new schema', async () => {
                 if (!config.storage.hasReplication) {
@@ -395,6 +400,7 @@ describe('migration-schema.test.ts', function () {
                 }
                 const dbName = randomToken(10);
 
+                // v0: icon is optional and can be null
                 const schemaV0 = {
                     version: 0,
                     primaryKey: 'id',
@@ -405,14 +411,14 @@ describe('migration-schema.test.ts', function () {
                             maxLength: 100
                         },
                         icon: {
-                            type: 'string',
+                            type: ['string', 'null'],
                             maxLength: 1000
                         }
                     },
                     required: ['id']
                 };
 
-                // v1 makes `icon` required and typed as string — a null value will fail validation
+                // v1: icon is required and must be a string — null will fail validation
                 const schemaV1 = {
                     version: 1,
                     primaryKey: 'id',
@@ -434,52 +440,52 @@ describe('migration-schema.test.ts', function () {
                     name: dbName,
                     storage: config.storage.getStorage(),
                 });
-                const cols = await db.addCollections({
-                    apps: {
-                        schema: schemaV0
-                    }
-                });
-                // insert a document where `icon` is null — valid in v0 but invalid in v1
-                await cols.apps.insert({ id: 'claude.ai', icon: null as any });
-                await db.close();
+                try {
+                    const cols = await db.addCollections({
+                        apps: {
+                            schema: schemaV0
+                        }
+                    });
+                    // null is valid in v0 (type: ['string', 'null']) but invalid in v1
+                    await cols.apps.insert({ id: 'claude.ai', icon: null as any });
+                } finally {
+                    await db.close();
+                }
 
                 const db2 = await createRxDatabase({
                     name: dbName,
                     storage: config.storage.getStorage(),
                     ignoreDuplicate: true
                 });
-                const cols2 = await db2.addCollections({
-                    apps: {
-                        schema: schemaV1,
-                        autoMigrate: false,
-                        migrationStrategies: {
-                            // strategy intentionally keeps null icon, causing a 422 on write
-                            1: (doc: any) => doc
-                        }
-                    }
-                });
-
                 let caughtError: any;
                 try {
+                    const cols2 = await db2.addCollections({
+                        apps: {
+                            schema: schemaV1,
+                            autoMigrate: false,
+                            migrationStrategies: {
+                                // strategy passes the document through unchanged,
+                                // so null icon triggers a 422 when written to v1 storage
+                                1: (doc: any) => doc
+                            }
+                        }
+                    });
                     await cols2.apps.getMigrationState().migratePromise();
                 } catch (err: any) {
                     caughtError = err;
+                } finally {
+                    await db2.close();
                 }
 
                 assert.ok(caughtError, 'migration should have thrown');
-                // The error should be DM4 (migration error) wrapping a COL20 (schema validation),
-                // NOT an SNH (should never happen) error.
+                // Must be DM4 (migration error), NOT SNH ("This should never happen")
                 assert.strictEqual(caughtError.code, 'DM4');
                 const innerError = caughtError.parameters?.error;
-                assert.ok(innerError, 'inner error should exist');
-                // The inner error must be a schema validation error (COL20), not SNH
-                assert.ok(
-                    innerError.code === 'COL20' || (innerError.parameters?.writeError?.status === 422),
-                    'inner error must be a schema validation error, not SNH. Got: ' + JSON.stringify(innerError?.code)
+                assert.ok(innerError, 'inner error should exist in DM4 parameters');
+                assert.notStrictEqual(
+                    innerError.code, 'SNH',
+                    'must not throw internal SNH for schema validation failures, got: ' + JSON.stringify(innerError)
                 );
-                assert.notStrictEqual(innerError.code, 'SNH', 'Must not throw internal SNH error for schema validation failures');
-
-                await db2.close();
             });
         });
         describe('.migratePromise()', () => {


### PR DESCRIPTION
Fixes #8607

When a migration strategy produces a document that fails schema validation
(e.g. `icon: null` where the new schema requires `icon: string`), the
`bulkWrite` call in `rxStorageInstanceToReplicationHandler` returns a status
422 error. The existing code only handled status 409 (conflict), throwing an
internal `SNH` ("Should Never Happen") error for everything else. This gave
users a completely unhelpful "This should never happen" message instead of
explaining the actual cause.

**Fix:** Replace the `SNH` throw with `rxStorageWriteErrorToRxError(err)`,
which already exists in the codebase and maps status 422 to a meaningful
"schema validation error" (COL20). The error chain becomes:
`DM4 (migration error) -> COL20 (schema validation error)`.

**Files changed:**
- `src/replication-protocol/index.ts` — the one-line fix
- `test/unit/migration-schema.test.ts` — regression test
- `orga/changelog/fix-migration-schema-validation-error.md` — changelog entry
