### PR TITLE
Increase Pro Plus tier price to €239/month

### DIFF
--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -138,7 +138,7 @@ export default function Premium() {
                                         <h3>Pro Plus</h3>
                                         <p className="tier-desc">Performance plugins & server adapters.</p>
                                         <span className="tier-price-prefix">From</span>
-                                        <div className="tier-price">€169<span>/ month</span></div>
+                                        <div className="tier-price">€239<span>/ month</span></div>
                                         <div className="tier-price-sub">billed annually, unlimited developers</div>
                                         <div className="tier-license">&nbsp;</div>
                                     </div>

--- a/orga/changelog/premium-pro-plus-price-increase.md
+++ b/orga/changelog/premium-pro-plus-price-increase.md
@@ -1,0 +1,1 @@
+- CHANGE Increase the Pro Plus tier price on the premium page from €169/month to €239/month.


### PR DESCRIPTION
## What

Increases the **Pro Plus** tier price on the premium page from `€169 / month` to `€239 / month`.

## Why

Pricing improvement requested for the Pro Plus tier.

## Changes

- `docs-src/src/pages/premium.tsx`: Pro Plus tier price `€169` → `€239` (per-month format kept consistent with the Pro tier).
- Added changelog entry under `orga/changelog/`.

## Note

The Stripe checkout link for Pro Plus (`buy.stripe.com/...bbG06`) is unchanged and still references the old price object. The actual checkout amount must be updated in the Stripe dashboard separately, as it is not configured in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R991cVhwi7fX1b8t3ZRuwM)_