### PR TITLE
Show premium pricing in USD instead of EUR

### DIFF
--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -78,7 +78,7 @@ export default function Premium() {
                                         <h3>Free</h3>
                                         <p className="tier-desc">Open-source core. Get started for free.</p>
                                         <span className="tier-price-prefix">&nbsp;</span>
-                                        <div className="tier-price">€0<span>/ forever</span></div>
+                                        <div className="tier-price">$0<span>/ forever</span></div>
                                         <div className="tier-price-sub">&nbsp;</div>
                                         <div className="tier-license">Open Source license</div>
                                     </div>
@@ -109,7 +109,7 @@ export default function Premium() {
                                         <h3>Pro</h3>
                                         <p className="tier-desc">Production-grade storage engines.</p>
                                         <span className="tier-price-prefix">From</span>
-                                        <div className="tier-price">€99<span>/ month</span></div>
+                                        <div className="tier-price">$99<span>/ month</span></div>
                                         <div className="tier-price-sub">billed annually, unlimited developers</div>
                                         <div className="tier-license">&nbsp;</div>
                                     </div>
@@ -138,7 +138,7 @@ export default function Premium() {
                                         <h3>Pro Plus</h3>
                                         <p className="tier-desc">Performance plugins & server adapters.</p>
                                         <span className="tier-price-prefix">From</span>
-                                        <div className="tier-price">€169<span>/ month</span></div>
+                                        <div className="tier-price">$239<span>/ month</span></div>
                                         <div className="tier-price-sub">billed annually, unlimited developers</div>
                                         <div className="tier-license">&nbsp;</div>
                                     </div>


### PR DESCRIPTION
## What

Switches the displayed pricing tiers on the premium page from euros to US dollars, since most customers are US-based.

- Pro: `€99` → `$99` / month
- Pro Plus: `€169` → `$239` / month
- Free: `€0` → `$0` / forever

## Notes

- Only the three customer-facing tier labels in `docs-src/src/pages/premium.tsx` were changed. The `price-calculator.ts` value is only used as an internal analytics tracking number (not a displayed price), and the `€` default in `price-tag.tsx` is currently unused, so neither was touched.
- The Stripe payment links are being updated separately by the maintainer so the displayed USD amounts match what is actually charged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwAPdeUgrk5RCRMNfeEZtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwAPdeUgrk5RCRMNfeEZtp)_