### PR TITLE
Point premium Buy buttons to new USD Stripe links

### DIFF
--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -125,7 +125,7 @@ export default function Premium() {
                                         <li>Fulltext Search</li>
                                     </ul>
 
-                                    <Button primary href="https://buy.stripe.com/eVq00k3fx1TbaIV0c1bbG05" target="_blank" style={{ width: '100%', marginBottom: 15 }} icon={<IconChevronsRight />}>Buy Pro</Button>
+                                    <Button primary href="https://buy.stripe.com/6oUdRa17p1TbeZb0c1bbG07" target="_blank" style={{ width: '100%', marginBottom: 15 }} icon={<IconChevronsRight />}>Buy Pro</Button>
                                     <div style={{ minHeight: 0, display: 'flex', flexDirection: 'column' }}>
                                         <a href="/license-preview/" className="tier-agreement" target="_blank">Preview License Agreement</a>
                                     </div>
@@ -156,7 +156,7 @@ export default function Premium() {
                                         <li>Logger plugin (Compatible with Sentry)</li>
                                     </ul>
 
-                                    <Button href="https://buy.stripe.com/3cIcN6aHZcxP6sF5wlbbG06" target="_blank" style={{ width: '100%', marginBottom: 15 }} icon={<IconChevronsRight />}>Buy Pro Plus</Button>
+                                    <Button href="https://buy.stripe.com/14A4gAeYf41j6sF4shbbG08" target="_blank" style={{ width: '100%', marginBottom: 15 }} icon={<IconChevronsRight />}>Buy Pro Plus</Button>
                                     <div style={{ minHeight: 0, display: 'flex', flexDirection: 'column' }}>
                                         <a href="/license-preview/" className="tier-agreement" target="_blank">Preview License Agreement</a>
                                     </div>


### PR DESCRIPTION
## What

Points the "Buy Pro" and "Buy Pro Plus" buttons on the premium page to the new USD-priced Stripe payment links, so the checkout currency matches the displayed `$99` / `$239` pricing (merged in #8642).

- Pro button → new USD payment link
- Pro Plus button → new USD payment link

## Why

After switching the displayed prices to USD, the buttons still linked to the old EUR-priced Stripe payment links. Stripe payment links have a fixed price/currency and cannot be repointed to a different price object, so new USD payment links were created and are swapped in here. The old EUR links are being deactivated on the Stripe side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwAPdeUgrk5RCRMNfeEZtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwAPdeUgrk5RCRMNfeEZtp)_