### PR TITLE
fix(storage-sqlite): remove console.dir that throws on React Native / Hermes

### DIFF
--- a/.claude/hooks/no-console-dir-storage-sqlite.mjs
+++ b/.claude/hooks/no-console-dir-storage-sqlite.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PreToolUse hook.
+ *
+ * Blocks any Write/Edit/MultiEdit that would introduce `console.dir(...)`
+ * into the `src/plugins/storage-sqlite` code.
+ *
+ * `console.dir` is `undefined` in production React Native / Hermes runtimes,
+ * so calling it inside the storage-sqlite code throws
+ * `TypeError: undefined is not a function` and masks the real error.
+ * See https://github.com/pubkey/rxdb/issues/8635
+ */
+
+const CONSOLE_DIR_REGEX = /console\s*\.\s*dir\b/;
+const STORAGE_SQLITE_PATH = 'src/plugins/storage-sqlite';
+
+async function readStdin() {
+    const chunks = [];
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString('utf8');
+}
+
+function collectTexts(toolInput) {
+    const texts = [];
+    if (typeof toolInput.content === 'string') {
+        texts.push(toolInput.content);
+    }
+    if (typeof toolInput.new_string === 'string') {
+        texts.push(toolInput.new_string);
+    }
+    if (Array.isArray(toolInput.edits)) {
+        for (const edit of toolInput.edits) {
+            if (edit && typeof edit.new_string === 'string') {
+                texts.push(edit.new_string);
+            }
+        }
+    }
+    return texts;
+}
+
+async function main() {
+    let payload;
+    try {
+        payload = JSON.parse(await readStdin());
+    } catch {
+        // Could not parse the hook payload, do not block.
+        process.exit(0);
+    }
+
+    const toolInput = payload.tool_input || {};
+    const filePath = toolInput.file_path || '';
+
+    if (!filePath.includes(STORAGE_SQLITE_PATH)) {
+        process.exit(0);
+    }
+
+    const offends = collectTexts(toolInput).some(text => CONSOLE_DIR_REGEX.test(text));
+    if (!offends) {
+        process.exit(0);
+    }
+
+    const output = {
+        hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason:
+                'Do not use console.dir inside src/plugins/storage-sqlite. ' +
+                'console.dir is undefined in production React Native / Hermes runtimes and throws ' +
+                'TypeError: undefined is not a function, masking the real error (see issue #8635). ' +
+                'Use console.log(JSON.stringify(...)) or errorToPlainJson(...) instead.'
+        }
+    };
+    process.stdout.write(JSON.stringify(output));
+    process.exit(0);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,15 @@
                         "command": "npx block-no-verify@1.1.2"
                     }
                 ]
+            },
+            {
+                "matcher": "Write|Edit|MultiEdit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node .claude/hooks/no-console-dir-storage-sqlite.mjs"
+                    }
+                ]
             }
         ],
         "PostToolUse": [

--- a/orga/changelog/fix-storage-sqlite-console-dir-hermes.md
+++ b/orga/changelog/fix-storage-sqlite-console-dir-hermes.md
@@ -1,0 +1,1 @@
+- FIX storage-sqlite: removed `console.dir` calls which are `undefined` in production React Native / Hermes runtimes and threw `TypeError: undefined is not a function` inside `openSqliteTransaction`, masking the real SQLite error and bypassing the `BEGIN;` retry loop. [#8635](https://github.com/pubkey/rxdb/issues/8635)

--- a/src/plugins/storage-sqlite/sqlite-basics-helpers.ts
+++ b/src/plugins/storage-sqlite/sqlite-basics-helpers.ts
@@ -3,7 +3,8 @@ import {
     PROMISE_RESOLVE_VOID,
     getFromMapOrCreate,
     randomToken,
-    promiseWait
+    promiseWait,
+    errorToPlainJson
 } from '../../index.ts';
 import type {
     Sqlite3Type,
@@ -27,7 +28,7 @@ export function getSQLiteBasicsNode(
                 queryWithParams: SQLiteQueryWithParams
             ) {
                 if (!Array.isArray(queryWithParams.params)) {
-                    console.dir(queryWithParams);
+                    console.log(JSON.stringify(queryWithParams));
                     throw new Error('no params array given for query: ' + queryWithParams.query);
                 }
                 await execSqlSQLiteNode(
@@ -155,8 +156,8 @@ export function execSqlSQLiteNode(
                     if (debug) {
                         console.log('---- ERROR RUNNING SQL:');
                         console.log(queryWithParams.query);
-                        console.dir(queryWithParams.params);
-                        console.dir(err);
+                        console.log(JSON.stringify(queryWithParams.params));
+                        console.log(JSON.stringify(errorToPlainJson(err)));
                         console.log('----');
                     }
                     rej(err);
@@ -164,10 +165,10 @@ export function execSqlSQLiteNode(
                     if (debug) {
                         console.log('execSql() result: ' + database.eventNames());
                         console.log(queryWithParams.query);
-                        console.dir(result);
+                        console.log(JSON.stringify(result));
                         console.log('execSql() result:');
                         console.log(queryWithParams.query);
-                        console.dir(queryWithParams.params);
+                        console.log(JSON.stringify(queryWithParams.params));
                         console.log('execSql() result -------------------------');
                     }
                     res(result);

--- a/src/plugins/storage-sqlite/sqlite-helpers.ts
+++ b/src/plugins/storage-sqlite/sqlite-helpers.ts
@@ -208,7 +208,6 @@ export async function openSqliteTransaction(
             console.log('open transaction error (will retry):');
             const errorAsJson = errorToPlainJson(err);
             console.log(errorAsJson);
-            console.dir(err);
             if (
                 err.message && (
                     err.message.includes('Database is closed') ||


### PR DESCRIPTION
## Problem

Fixes #8635

`console.dir` is `undefined` in production React Native / Hermes runtimes (RN's console polyfill only restores `dir` under `__DEV__`). Inside `openSqliteTransaction` (`sqlite-helpers.ts`), the `BEGIN;` retry catch handler called `console.dir(err)` before the retry/rethrow decision. In a release build this made the catch handler itself throw `TypeError: undefined is not a function`, which:

1. Replaced the real SQLite error (`"Database is closed"`, `"API misuse"`, transient locks) with an opaque `TypeError`.
2. Ran before the retry/terminal branch, so transient errors were never retried and terminal errors were never rethrown with their real message.

## Changes

- Removed the `console.dir(err)` from the `openSqliteTransaction` retry handler. The error is still logged via `errorToPlainJson(err)`.
- Replaced the remaining `console.dir(...)` calls in `storage-sqlite` (debug paths in `sqlite-basics-helpers.ts`) with `console.log(JSON.stringify(...))` / `errorToPlainJson(...)`, which work in every runtime.
- Added a Claude Code `PreToolUse` hook (`.claude/hooks/no-console-dir-storage-sqlite.mjs`, wired in `.claude/settings.json`) that blocks any future Write/Edit/MultiEdit introducing `console.dir` into `src/plugins/storage-sqlite`.
- Added a changelog entry.

## Verification

- `npm run build`: passes
- `npm run lint`: passes
- `npm run check-types`: passes
- Hook tested: denies `console.dir` edits to storage-sqlite, allows other folders and non-`console.dir` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTi57sdTHYk7FroC5V1EcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTi57sdTHYk7FroC5V1EcF)_