### PR TITLE
fix(doc-cache): prevent out-of-order multiInstance events from diverging the cache

### DIFF
--- a/orga/changelog/fix-doc-cache-multiinstance-out-of-order.md
+++ b/orga/changelog/fix-doc-cache-multiinstance-out-of-order.md
@@ -1,0 +1,1 @@
+- FIX `DocumentCache` no longer downgrades the cached latest document state when an older change event arrives out of order in multiInstance mode. This prevents two instances from diverging and fixes a flaky `upsertLocal()` concurrency test. Fixes #8609

--- a/src/doc-cache.ts
+++ b/src/doc-cache.ts
@@ -7,6 +7,7 @@ import type {
 } from './types/index.d.ts';
 import {
     getFromMapOrThrow,
+    getHeightOfRevision,
     overwriteGetterForCaching,
     requestIdlePromiseNoQueue
 } from './plugins/utils/index.ts';
@@ -121,7 +122,24 @@ export class DocumentCache<RxDocType, OrmMethods> {
                         if (!documentData) {
                             documentData = event.previousDocumentData as any;
                         }
-                        cacheItem[1] = documentData;
+                        /**
+                         * In multiInstance mode the changeStream merges events
+                         * from the own writes together with the events from other
+                         * instances that arrive over the BroadcastChannel.
+                         * These events can arrive out of order, so an older document
+                         * state might be received after a newer one was already processed.
+                         * We must not downgrade the cached latest document state in that case,
+                         * otherwise two instances can end up with diverging "latest" states
+                         * that never converge.
+                         * @link https://github.com/pubkey/rxdb/issues/8609
+                         */
+                        const currentLatest = cacheItem[1];
+                        if (
+                            !currentLatest ||
+                            !isOlderDocumentState(documentData._rev, currentLatest._rev)
+                        ) {
+                            cacheItem[1] = documentData;
+                        }
                     }
                 }
             });
@@ -182,6 +200,26 @@ export class DocumentCache<RxDocType, OrmMethods> {
             return cacheItem[1];
         }
     }
+}
+
+/**
+ * Determines if the document state of checkRev is older than the one of currentRev.
+ * Compares by revision height first and falls back to a deterministic
+ * comparison of the full revision string so that all instances agree
+ * on the same winner when the heights are equal.
+ * Equal revisions are not considered older so that the cached reference
+ * still gets refreshed, which keeps the previous behavior intact.
+ */
+function isOlderDocumentState(checkRev: string, currentRev: string): boolean {
+    if (checkRev === currentRev) {
+        return false;
+    }
+    const checkHeight = getHeightOfRevision(checkRev);
+    const currentHeight = getHeightOfRevision(currentRev);
+    if (checkHeight !== currentHeight) {
+        return checkHeight < currentHeight;
+    }
+    return checkRev < currentRev;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './overwritable.ts';
 export * from './rx-collection.ts';
 export * from './rx-collection-helper.ts';
 export * from './rx-document.ts';
+export * from './doc-cache.ts';
 export * from './rx-change-event.ts';
 export * from './rx-document-prototype-merge.ts';
 export * from './rx-query.ts';

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -9,6 +9,7 @@ import './unit/util.test.ts';
 import './unit/vector-distance.test.ts';
 import './unit/custom-index.test.ts';
 import './unit/query-planner.test.ts';
+import './unit/doc-cache.test.ts';
 
 
 import './unit/internal-indexes.test.ts';

--- a/test/unit/doc-cache.test.ts
+++ b/test/unit/doc-cache.test.ts
@@ -3,7 +3,7 @@ import { Subject } from 'rxjs';
 import {
     DocumentCache,
     mapDocumentsDataToCacheDocs
-} from '../../src/doc-cache.ts';
+} from '../../plugins/core/index.mjs';
 import type {
     RxDocumentData,
     RxStorageChangeEvent
@@ -210,6 +210,35 @@ describeParallel('doc-cache.test.ts', () => {
                 cache.processTasks();
                 const latest = cache.getLatestDocumentData('doc1');
                 assert.strictEqual(latest.name, 'FallbackName');
+            });
+            it('should not downgrade latestDoc when an older change event arrives out of order', () => {
+                /**
+                 * In multiInstance mode the changeStream merges the own writes
+                 * with the events from other instances that arrive over the
+                 * BroadcastChannel. Those events can arrive out of order, so an
+                 * older document state might be received after a newer one.
+                 * The cache must keep the newest state so that two instances
+                 * converge instead of diverging forever.
+                 * @link https://github.com/pubkey/rxdb/issues/8609
+                 */
+                const { cache, changes$ } = createDocumentCache();
+                const docDataOld = createFakeDocData('doc1', EXAMPLE_REVISION_1, 1, 'Alice', 30);
+                const docDataNew = createFakeDocData('doc1', EXAMPLE_REVISION_2, 2, 'Bob', 31);
+                cache.getCachedRxDocuments([docDataNew]);
+
+                // older event arrives after the newer state is already cached
+                changes$.next([{
+                    documentId: 'doc1',
+                    documentData: docDataOld,
+                    previousDocumentData: undefined,
+                    operation: 'INSERT',
+                    isLocal: false
+                } as any]);
+
+                cache.processTasks();
+                const latest = cache.getLatestDocumentData('doc1');
+                assert.strictEqual(latest.name, 'Bob');
+                assert.strictEqual(latest._rev, EXAMPLE_REVISION_2);
             });
             it('should ignore change events for documents not in cache', () => {
                 const { cache, changes$ } = createDocumentCache();


### PR DESCRIPTION
## Problem

The local-documents test `should properly handle 409 conflicts and rerun the write when concurrently upserted from another instance` randomly fails on some storages with a 10s timeout:

```
1) local-documents.test.ts
     .upsertLocal()
       positive
         should properly handle 409 conflicts and rerun the write when concurrently upserted from another instance:
   Error: Timeout of 10000ms exceeded.
```

## Root cause

In multiInstance mode, `RxStorageInstance.changeStream()` merges the instance's own write events together with the events from other instances that arrive over the `BroadcastChannel`. Those two sources can arrive out of order.

The `DocumentCache` updates its cached "latest" document state for every change event without comparing revisions:

```ts
cacheItem[1] = documentData;
```

When two instances upsert the same id concurrently, one wins the insert (revision height 1) and the other resolves the 409 and writes an update (revision height 2). The instances then exchange events. If the older height-1 event arrives at an instance that already holds the height-2 state, the cache gets downgraded. Because no further events follow, the two instances settle on opposite values and never converge, so `waitUntil(...)` times out.

This does not reproduce on the memory storage because it delivers events in order, which is why the failure only shows up on storages with async event delivery.

## Fix

`DocumentCache` now keeps the newest known revision. It only refreshes `cacheItem[1]` when the incoming revision is equal or newer, compared by revision height first and by the full revision string as a deterministic tie-break. Single-instance behavior is unchanged because events there always arrive with strictly increasing revision height.

## Tests

- Added a deterministic regression test in `doc-cache.test.ts` that feeds an older change event after a newer state is cached and asserts the cache keeps the newest state.
- `doc-cache.test.ts` was previously orphaned (never imported into the unit suite and importing from `src` directly, which does not resolve in the transpiled test build). It is now wired into `test/unit.test.ts`, and `DocumentCache` is exported from the main entry point so the test imports it from the build like the other tests.

All related suites pass locally on the memory storage: `doc-cache` (23), `local-documents` (33), `cross-instance` (10), `rx-document` (63), `rx-collection` (139).

Fixes #8609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk3vB95T1hfjZU1DxnvXnB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk3vB95T1hfjZU1DxnvXnB)_