### PR TITLE
docs(premium): use new Pipedrive form URL for custom package

### DIFF
--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -31,13 +31,13 @@ export default function Premium() {
     }, [isBrowser, initDone]);
 
     // for dialog
-    const [openConsulting, setOpenConsulting] = React.useState(false);
-    const handleOpenConsultingDialog = () => {
-        triggerTrackingEvent('consulting_form_open', 0.4);
-        setOpenConsulting(true);
+    const [openCustom, setOpenCustom] = React.useState(false);
+    const handleOpenCustomDialog = () => {
+        triggerTrackingEvent('custom_package_form_open', 0.4);
+        setOpenCustom(true);
     };
-    const handleCloseConsulting = () => {
-        setOpenConsulting(false);
+    const handleCloseCustom = () => {
+        setOpenCustom(false);
     };
 
     const [openPro, setOpenPro] = React.useState(false);
@@ -209,7 +209,7 @@ export default function Premium() {
                                     </ul>
 
                                     <Button onClick={(e) => {
-                                        e.preventDefault(); handleOpenConsultingDialog();
+                                        e.preventDefault(); handleOpenCustomDialog();
                                     }} style={{ width: '100%', marginBottom: 15 }} icon={<IconChevronsRight />}>Contact</Button>
                                     <div style={{ minHeight: 0, display: 'flex', flexDirection: 'column' }}>
                                         <span className="tier-agreement" style={{ visibility: 'hidden' }}>Preview License Agreement</span>
@@ -545,7 +545,7 @@ export default function Premium() {
                         </div>
                     </div>
                     */}
-                    <ConsultingFormDialog open={openConsulting} onClose={handleCloseConsulting} />
+                    <CustomFormDialog open={openCustom} onClose={handleCloseCustom} />
                     <ProFormDialog open={openPro} onClose={handleClosePro} />
                     <ProPlusFormDialog open={openProPlus} onClose={handleCloseProPlus} />
                 </main>
@@ -558,12 +558,12 @@ export default function Premium() {
 // }
 
 
-function ConsultingFormDialog({ onClose, open }) {
+function CustomFormDialog({ onClose, open }) {
     return <IframeFormModal
         onClose={onClose}
         open={open}
-        iframeUrl='https://webforms.pipedrive.com/f/6UUQvwSg3cy0wizvNdC3pmT378WEHYcwv6tdTlPNRl2HtVm0JjBbj5MQjqVj7ePW3F'
-        eventId='consulting_form'
+        iframeUrl='https://webforms.pipedrive.com/f/63f2Y0mNbp1veI9X0QPYMmLKq4xeHmvN4OgxfmUyvIzLDQeAsTOFC3yLEP17TQWGNt'
+        eventId='custom_package_form'
     />;
 }
 


### PR DESCRIPTION
## What

Updates the custom-package contact form on the pricing page (`docs-src/src/pages/premium.tsx`) to use the new Pipedrive webform URL.

The "Enterprise" tier (price "Custom", custom agreements & SLA, custom commercial license) is the custom package on the pricing page. Its "Contact" button previously reused the consulting form. This change:

- Points that tier's form modal at the new Pipedrive URL: `https://webforms.pipedrive.com/f/63f2Y0mNbp1veI9X0QPYMmLKq4xeHmvN4OgxfmUyvIzLDQeAsTOFC3yLEP17TQWGNt`
- Renames the leftover `Consulting*` naming (`ConsultingFormDialog`, state, handlers, tracking event) to `Custom*` so the code reflects its actual purpose.

## Scope

Only affects the pricing page. The consulting page (`consulting.tsx`) has its own separate form instances and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnYdmZMqogqrrBbzrapX42)_