### PR TITLE
improve(storage-sqlite): trial limit excludes deleted docs, bump to 500, warn near limit

### DIFF
--- a/docs-src/docs/rx-storage-sqlite.md
+++ b/docs-src/docs/rx-storage-sqlite.md
@@ -27,7 +27,7 @@ The SQLite storage is a bit slower compared to other Node.js based storages like
 
 There are two versions of the SQLite storage available for RxDB:
 
-- The **trial version** which comes directly shipped with RxDB Core. It contains an SQLite storage that allows you to try out RxDB on devices that support SQLite, like React Native or Electron. While the trial version does pass the full RxDB storage test-suite, it is not made for production. It is not using indexes, has no [attachment support](./rx-attachment.md), is limited to store 300 documents and fetches the whole storage state to run queries in memory. **Use it for evaluation and prototypes only!**
+- The **trial version** which comes directly shipped with RxDB Core. It contains an SQLite storage that allows you to try out RxDB on devices that support SQLite, like React Native or Electron. While the trial version does pass the full RxDB storage test-suite, it is not made for production. It is not using indexes, has no [attachment support](./rx-attachment.md), is limited to store 500 non-deleted documents and fetches the whole storage state to run queries in memory. **Use it for evaluation and prototypes only!**
 
 - The **[RxDB Premium 👑](/premium/) version** which contains the full production-ready SQLite storage. It contains a full load of performance optimizations and full query support. To use the SQLite storage you have to import `getRxStorageSQLite` from the [RxDB Premium 👑](/premium/) package and then add the correct `sqliteBasics` adapter depending on which sqlite module you want to use. This can then be used as storage when creating the [RxDatabase](./rx-database.md). In the following you can see some examples for some of the most common SQLite packages.
 

--- a/orga/changelog/improve-sqlite-trial-document-limit.md
+++ b/orga/changelog/improve-sqlite-trial-document-limit.md
@@ -1,0 +1,1 @@
+- IMPROVE trial SQLite storage: raise the document limit from 300 to 500, stop counting deleted (tombstone) documents towards the limit, and log a loud warning on each write once usage reaches ~80% of the document or operation limit. See https://rxdb.info/rx-storage-sqlite.html

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -1205,8 +1205,8 @@ export const ERROR_MESSAGES = {
         docs: 'https://rxdb.info/rx-storage-sqlite.html?console=errors&code=SQL1'
     },
     SQL2: {
-        message: 'The trial version of the SQLite storage is limited to contain 300 documents',
-        cause: 'You reached the document limit of the trial version.',
+        message: 'The trial version of the SQLite storage is limited to contain 500 non-deleted documents',
+        cause: 'You reached the document limit of the trial version. Deleted documents do not count towards this limit.',
         fix: 'Upgrade to the full version.',
         docs: 'https://rxdb.info/rx-storage-sqlite.html?console=errors&code=SQL2'
     },

--- a/src/plugins/storage-sqlite/index.ts
+++ b/src/plugins/storage-sqlite/index.ts
@@ -50,7 +50,7 @@ export function getRxStorageSQLiteTrial(
                 '-------------- RxDB SQLite Trial Version in Use -------------------------------',
                 'You are using the trial version of the SQLite RxStorage from RxDB https://rxdb.info/rx-storage-sqlite.html?console=sqlite ',
                 'While this is a great option to try out RxDB itself, notice that you should never use the trial version in production. It is way slower compared to the "real" SQLite storage',
-                'and it has several limitations like not using indexes and being limited to store a maximum of 300 documents.',
+                'and it has several limitations like not using indexes and being limited to store a maximum of 500 documents.',
                 'For production environments, use the premium SQLite RxStorage:',
                 ' https://rxdb.info/premium/?console=sqlite ',
                 'If you already purchased premium access, ensure that you have imported the correct sqlite storage from the premium plugins.',

--- a/src/plugins/storage-sqlite/sqlite-storage-instance.ts
+++ b/src/plugins/storage-sqlite/sqlite-storage-instance.ts
@@ -46,6 +46,21 @@ import { newRxError } from '../../rx-error.ts';
 let shownNonPremiumLog = false;
 let instanceId = 0;
 
+/**
+ * Limits of the free trial SQLite storage.
+ * Reaching them throws an error, see the error codes SQL2 and SQL3.
+ * Deleted documents are kept as tombstones for the replication but do
+ * NOT count towards the document limit.
+ * Use the premium SQLite storage to remove these limits:
+ * @link https://rxdb.info/premium/
+ */
+export const TRIAL_SQLITE_DOCUMENT_LIMIT = 500;
+export const TRIAL_SQLITE_OPERATION_LIMIT = 500;
+/**
+ * Ratio of the limits at which a loud warning is logged on each write.
+ */
+const TRIAL_SQLITE_WARN_RATIO = 0.8;
+
 export class RxStorageInstanceSQLite<RxDocType> implements RxStorageInstance<
     RxDocType,
     SQLiteInternals,
@@ -98,7 +113,7 @@ export class RxStorageInstanceSQLite<RxDocType> implements RxStorageInstance<
         }
 
         this.opCount = this.opCount + 1;
-        if (this.opCount > 500) {
+        if (this.opCount > TRIAL_SQLITE_OPERATION_LIMIT) {
             throw newRxError('SQL3');
         }
 
@@ -120,15 +135,16 @@ export class RxStorageInstanceSQLite<RxDocType> implements RxStorageInstance<
         const writePromises: Promise<any>[] = [];
         let categorized: CategorizeBulkWriteRowsOutput<RxDocType> = {} as any;
 
+        const isPremium = await hasPremiumFlag();
         if (
             !shownNonPremiumLog &&
-            !(await hasPremiumFlag())
+            !isPremium
         ) {
             console.warn(
                 [
                     '-------------- RxDB SQLite Trial Storage ---------------------------------',
                     'You are using the free *trial* SQLite-based RxStorage implementation: https://rxdb.info/rx-storage-sqlite.html?console=sqlite-trial',
-                    'This storage is intended only for evaluation purposes and comes with strict limitations (no indexes, no attachments, and a ~300-document cap).',
+                    'This storage is intended only for evaluation purposes and comes with strict limitations (no indexes, no attachments, and a ~500-document cap).',
                     'For production use and optimal performance, we strongly recommend upgrading to the premium SQLite storage.',
                     'Premium version: https://rxdb.info/premium/?console=sqlite',
                     'If you already have premium access, you can disable this message by calling setPremiumFlag() from rxdb-premium/plugins/shared.',
@@ -175,7 +191,55 @@ export class RxStorageInstanceSQLite<RxDocType> implements RxStorageInstance<
                 );
                 ret.error = categorized.errors;
 
-                if ((result.length + categorized.bulkInsertDocs.length) > 300) {
+                /**
+                 * Deleted documents are kept as tombstones for the replication
+                 * but must NOT count towards the trial document limit.
+                 * Therefore we count the resulting amount of non-deleted documents.
+                 */
+                let liveDocCount = 0;
+                docsInDb.forEach(doc => {
+                    if (!doc._deleted) {
+                        liveDocCount = liveDocCount + 1;
+                    }
+                });
+                categorized.bulkInsertDocs.forEach(row => {
+                    if (!row.document._deleted) {
+                        liveDocCount = liveDocCount + 1;
+                    }
+                });
+                categorized.bulkUpdateDocs.forEach(row => {
+                    const previous = docsInDb.get(row.document[this.primaryPath]);
+                    const wasLive = !!previous && !previous._deleted;
+                    const isLive = !row.document._deleted;
+                    if (wasLive && !isLive) {
+                        liveDocCount = liveDocCount - 1;
+                    } else if (!wasLive && isLive) {
+                        liveDocCount = liveDocCount + 1;
+                    }
+                });
+
+                if (
+                    !isPremium &&
+                    (
+                        liveDocCount >= Math.floor(TRIAL_SQLITE_DOCUMENT_LIMIT * TRIAL_SQLITE_WARN_RATIO) ||
+                        this.opCount >= Math.floor(TRIAL_SQLITE_OPERATION_LIMIT * TRIAL_SQLITE_WARN_RATIO)
+                    )
+                ) {
+                    console.warn(
+                        [
+                            '-------------- RxDB SQLite Trial Storage - Limit Almost Reached ----------------',
+                            'You are close to the limits of the free *trial* SQLite RxStorage.',
+                            'Current usage: ' + liveDocCount + ' / ' + TRIAL_SQLITE_DOCUMENT_LIMIT + ' documents and ' +
+                            this.opCount + ' / ' + TRIAL_SQLITE_OPERATION_LIMIT + ' operations.',
+                            'When a limit is reached, your read and write operations will start to throw errors.',
+                            'Upgrade to the premium SQLite storage to remove these limits and get full performance:',
+                            'https://rxdb.info/premium/?console=sqlite-trial-limit',
+                            '--------------------------------------------------------------------------------'
+                        ].join('\n')
+                    );
+                }
+
+                if (liveDocCount > TRIAL_SQLITE_DOCUMENT_LIMIT) {
                     throw newRxError('SQL2');
                 }
 


### PR DESCRIPTION
## What

Three improvements to the free trial SQLite storage limits:

1. **Deleted documents no longer count towards the limit.** The limit check previously counted every row in the table, including soft-deleted tombstones (kept for replication). This meant deleting data never freed up space. The check now counts only the resulting number of non-deleted documents.
2. **Document limit raised from 300 to 500.** This matches the existing 500-operation limit (`SQL3`). Because each inserted document consumes one operation, a doc limit higher than 500 was unreachable in practice. Both limits are now exposed as named constants (`TRIAL_SQLITE_DOCUMENT_LIMIT`, `TRIAL_SQLITE_OPERATION_LIMIT`).
3. **Loud warning near the limit.** On each write, once usage reaches ~80% of the document or operation limit, a warning is logged showing current usage (e.g. `400 / 500 documents and 405 / 500 operations`) with a link to the premium page.

## Why

The previous behavior was confusing: a user could hit the cap, delete documents to make room, and still be blocked because tombstones counted. There was also no early warning before writes started throwing `SQL2` / `SQL3` errors.

## How it was verified

A direct script against the trial storage confirmed across sessions:
- insert 400 live docs, delete 300 (300 tombstones), then insert 400 more live docs (500 live total) succeeds, proving tombstones are not counted.
- inserting a 501st live document throws `SQL2`.
- the ~80% warning fires with correct usage numbers.

`npm run build` and `npm run check-types` pass.

## Changes
- `src/plugins/storage-sqlite/sqlite-storage-instance.ts` - live-doc counting, named constants, near-limit warning.
- `src/plugins/storage-sqlite/index.ts` - updated trial-in-use log text.
- `src/plugins/dev-mode/error-messages.ts` - updated `SQL2` message/cause.
- `docs-src/docs/rx-storage-sqlite.md` - updated limit description.
- `orga/changelog/improve-sqlite-trial-document-limit.md` - changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4b4v4itK4uWaBGbpcwQsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4b4v4itK4uWaBGbpcwQsd)_