### PR TITLE
fix(docs): remove "| RxDB - JavaScript Database" suffix from SEO titles

### DIFF
--- a/docs-src/src/theme/PageMetadata/index.tsx
+++ b/docs-src/src/theme/PageMetadata/index.tsx
@@ -1,0 +1,50 @@
+import React, { type ReactNode } from 'react';
+import Head from '@docusaurus/Head';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type { Props } from '@theme/PageMetadata';
+
+/**
+ * Swizzled version of the default Docusaurus PageMetadata.
+ *
+ * The only difference to the original is the page title:
+ * Docusaurus appends the site title (`| RxDB - JavaScript Database`)
+ * to every page title. This removes that suffix so the SEO title
+ * is just the page title itself.
+ * @link https://github.com/pubkey/rxdb
+ */
+export default function PageMetadata({
+    title,
+    description,
+    keywords,
+    image,
+    children,
+}: Props): ReactNode {
+    const { siteConfig } = useDocusaurusContext();
+    // Use the raw page title without the appended site title suffix.
+    // Fall back to the site title for pages that do not set a title.
+    const pageTitle = title && title.trim().length > 0 ? title.trim() : siteConfig.title;
+    const pageImage = useBaseUrl(image, { absolute: true });
+
+    return (
+        <Head>
+            {pageTitle && <title>{pageTitle}</title>}
+            {pageTitle && <meta property="og:title" content={pageTitle} />}
+
+            {description && <meta name="description" content={description} />}
+            {description && <meta property="og:description" content={description} />}
+
+            {keywords && (
+                <meta
+                    name="keywords"
+                    content={Array.isArray(keywords) ? keywords.join(',') : keywords}
+                />
+            )}
+
+            {image && <meta property="og:image" content={pageImage} />}
+            {image && <meta name="twitter:image" content={pageImage} />}
+
+            {children}
+        </Head>
+    );
+}

--- a/orga/changelog/fix-seo-title-site-suffix.md
+++ b/orga/changelog/fix-seo-title-site-suffix.md
@@ -1,0 +1,1 @@
+Removed the appended `| RxDB - JavaScript Database` site-title suffix from SEO page titles by swizzling the `PageMetadata` theme component, so the `<title>` and `og:title` now contain only the page title. See https://github.com/pubkey/rxdb


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS

## Describe the problem you have without this PR

Every documentation page's SEO `<title>` (and `og:title`) currently ends with the appended site title, e.g. `Why Local-First Software Is the Future and its Limitations | RxDB - JavaScript Database`. Docusaurus appends `{titleDelimiter} {siteTitle}` to every page title by default, which makes the titles longer and pushes the meaningful part further from the start.

This PR removes that `| RxDB - JavaScript Database` suffix so the SEO title is just the page title itself.

### How

Swizzled the `@theme/PageMetadata` component (`docs-src/src/theme/PageMetadata/index.tsx`). It mirrors the default Docusaurus implementation but uses the raw page title instead of running it through the site-title formatter. Pages without an explicit title still fall back to the site title.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBqpWmJUAUcE3fDNsjEpfg)_