### PR TITLE
fix(docs): add alt attributes to footer thumbs-up/down vote icons

### DIFF
--- a/docs-src/src/components/docs-footer.tsx
+++ b/docs-src/src/components/docs-footer.tsx
@@ -77,10 +77,10 @@ export function DocsFooter(props: Props) {
             <li style={styles.li}>
                 Was this page helpful?
                 <div style={styles.vote}>
-                    <img src="/img/thumbs-up-white.svg" loading="lazy" width="14" height="14" onClick={() => vote('up')} />
+                    <img src="/img/thumbs-up-white.svg" alt="Thumbs up" loading="lazy" width="14" height="14" onClick={() => vote('up')} />
                 </div>
                 <div style={{ ...styles.vote, ...styles.down }}>
-                    <img src="/img/thumbs-up-white.svg" loading="lazy" width="14" height="14" onClick={() => vote('down')} />
+                    <img src="/img/thumbs-up-white.svg" alt="Thumbs down" loading="lazy" width="14" height="14" onClick={() => vote('down')} />
                 </div>
             </li> : <li style={styles.li}>Thank you for your vote! <div style={styles.heart}>&#x2665;</div></li>
         }

--- a/orga/changelog/fix-docs-footer-thumbs-alt-attributes.md
+++ b/orga/changelog/fix-docs-footer-thumbs-alt-attributes.md
@@ -1,0 +1,1 @@
+- FIX Add accessible `alt` text to the "Was this page helpful?" thumbs-up and thumbs-down icons in the docs footer that an accessibility audit flagged as missing the `alt` attribute.


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS (accessibility)
- A BUGFIX

## Describe the problem you have without this PR
An accessibility audit flagged the "Was this page helpful?" vote icons in the docs footer (`docs-src/src/components/docs-footer.tsx`) as image elements missing the `alt` attribute (``'&lt;img src="/img/thumbs-up-white.svg" loading="lazy" width="14" height="14"&gt;'``). Screen readers had no text alternative for these interactive icons.

This PR adds descriptive `alt` text (`"Thumbs up"` / `"Thumbs down"`) to both vote images, matching the pattern already used by the adjacent Discord icon.

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014rmgMDNqANvASF4GcwLEQH)_