### PR TITLE
fix(docs): disallow crawling of published .md files in robots.txt

### DIFF
--- a/docs-src/static/robots.txt
+++ b/docs-src/static/robots.txt
@@ -1,4 +1,9 @@
 User-agent: *
 Allow: /
 
+# Disallow crawling of the raw .md files that are published for the llms.txt
+# (generateMarkdownFiles in docusaurus-plugin-llms) so the markdown sources
+# do not show up as duplicate content in search engines.
+Disallow: /*.md$
+
 Sitemap: https://rxdb.info/sitemap.xml

--- a/orga/changelog/robots-txt-disallow-md.md
+++ b/orga/changelog/robots-txt-disallow-md.md
@@ -1,0 +1,1 @@
+- Disallow crawling of the published `.md` files (generated for the llms.txt via `generateMarkdownFiles`) in `robots.txt` so the raw markdown sources do not appear as duplicate content in search engines. See https://github.com/pubkey/rxdb


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS

## Describe the problem you have without this PR

The `docusaurus-plugin-llms` plugin is configured with `generateMarkdownFiles: true`, so it publishes a raw `.md` copy of every documentation page next to the `llms.txt` files (for example `https://rxdb.info/rx-database.md`). These markdown files mirror the HTML pages, so search engines can index them as duplicate content of the regular docs pages.

This PR updates `docs-src/static/robots.txt` to disallow crawling of any URL ending in `.md`:

```
Disallow: /*.md$
```

The `.txt` files used for the actual llms.txt feature (`llms.txt`, `llms-full.txt`, `llms-api.txt`, etc.) are not affected, since the rule only matches the `.md` extension.

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaNxgJiDkejQEpBZm8xMha)_