### PR TITLE
feat(docs): add customizable sem.bulletpoints for landingpage hero

### DIFF
--- a/docs-src/src/components/hero-section/T4_hero_b.tsx
+++ b/docs-src/src/components/hero-section/T4_hero_b.tsx
@@ -55,18 +55,24 @@ export function HeroSection_B(props: {
                         paddingBottom: 0,
                         maxWidth: 360
                     }}>
-                        <>
-                            Build apps that work <b onClick={() => props.scrollToSection('offline')}>offline</b>
-                        </>
-                        <>
-                            Sync with <b onClick={() => props.scrollToSection('replication')}>any Backend</b>
-                        </>
-                        <>
-                            Observable <b onClick={() => props.scrollToSection('realtime')}>Realtime Queries</b>
-                        </>
-                        <>
-                            All JavaScript <b onClick={() => props.scrollToSection('runtimes')}>Runtimes</b> Supported
-                        </>
+                        {
+                            props.sem && props.sem.bulletpoints
+                                ? props.sem.bulletpoints
+                                : [
+                                    <>
+                                        Build apps that work <b onClick={() => props.scrollToSection('offline')}>offline</b>
+                                    </>,
+                                    <>
+                                        Sync with <b onClick={() => props.scrollToSection('replication')}>any Backend</b>
+                                    </>,
+                                    <>
+                                        Observable <b onClick={() => props.scrollToSection('realtime')}>Realtime Queries</b>
+                                    </>,
+                                    <>
+                                        All JavaScript <b onClick={() => props.scrollToSection('runtimes')}>Runtimes</b> Supported
+                                    </>
+                                ]
+                        }
                     </CheckedList>
                 </div>
 

--- a/docs-src/src/pages/index.tsx
+++ b/docs-src/src/pages/index.tsx
@@ -201,6 +201,13 @@ export type SemPage = {
   text?: any;
   appName?: AppName;
   /**
+   * Custom bulletpoints shown in the hero sections checklist.
+   * Allows the SEM pages to a/b test different value propositions
+   * like "Build apps that work offline".
+   * When not set, the default bulletpoints are used.
+   */
+  bulletpoints?: React.JSX.Element[];
+  /**
    * Additional blocks to be shown
    */
   blocks?: React.JSX.Element[];

--- a/orga/changelog/sem-custom-bulletpoints.md
+++ b/orga/changelog/sem-custom-bulletpoints.md
@@ -1,0 +1,1 @@
+- Add an optional `sem.bulletpoints` field to the landingpage `SemPage` config so SEM pages can customly define and a/b test the hero section bulletpoints like "Build apps that work offline". When not set, the default bulletpoints are used. See https://github.com/pubkey/rxdb


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS
- A NEW FEATURE
- IMPROVED typings

## Describe the problem you have without this PR

The landingpage hero section bulletpoints (`Build apps that work offline`, `Sync with any Backend`, etc.) were hardcoded in `T4_hero_b.tsx`. There was no way for the SEM (search engine marketing) pages to override them, so they could not a/b test different value propositions per landingpage.

This PR adds an optional `bulletpoints` field to the `SemPage` config. When a SEM page sets `sem.bulletpoints`, those are rendered in the hero section `CheckedList`. When it is not set, the existing default bulletpoints are used, so behavior for all current pages is unchanged.

Example usage on a SEM page:

```tsx
export default function Page() {
    return Home({
        sem: {
            id: 'gads',
            metaTitle: 'The local Database for Browsers',
            appName: 'Browser',
            title: <>The easiest way to <b>store</b> and <b>sync</b> Data in a Browser</>,
            bulletpoints: [
                <>Build apps that work <b>offline</b></>,
                <>Sync with <b>any Backend</b></>,
            ]
        }
    });
}
```

`browser-database.tsx` was intentionally left untouched as requested.

## Changes
- `docs-src/src/pages/index.tsx`: add optional `bulletpoints?: React.JSX.Element[]` to the `SemPage` type.
- `docs-src/src/components/hero-section/T4_hero_b.tsx`: render `sem.bulletpoints` when provided, otherwise the default bulletpoints.
- `orga/changelog/sem-custom-bulletpoints.md`: changelog entry.

## Todos
- [x] Typings
- [x] Documentation
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tnq5h1bi3YhnuHJYuN3LzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tnq5h1bi3YhnuHJYuN3LzX)_