### PR TITLE
IMPROVE query planner: use index bounds for $in operator

### DIFF
--- a/docs-src/docs/nosql-performance-tips.md
+++ b/docs-src/docs/nosql-performance-tips.md
@@ -91,6 +91,8 @@ const enumQuery = {
 }
 ```
 
+For `$in` queries on an indexed field, the RxDB query planner limits the scanned index space to the range between the smallest and the largest of the given values. Adding a restrictive operator next to an `$in` is only useful when you know a tighter bound than the min/max of the values.
+
 ## Set a specific index
 
 Sometime the query planner of the database itself has no chance in picking the best index of the possible given indexes.

--- a/orga/changelog/improve-query-planner-in-operator-index-bounds.md
+++ b/orga/changelog/improve-query-planner-in-operator-index-bounds.md
@@ -1,0 +1,1 @@
+- IMPROVE query planner: `$in` queries on indexed fields now limit the scanned index range to the min/max of the given values instead of doing a full scan. This makes `$in` queries with multiple values use the index in all RxStorage implementations that use the RxDB query planner. [#8631](https://github.com/pubkey/rxdb/issues/8631)

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -106,6 +106,11 @@ export function getQueryPlan<RxDocType>(
                         const operatorValue = matcher[operator];
                         const partialOpts = getMatcherQueryOpts(operator, operatorValue);
                         matcherOpts = Object.assign(matcherOpts, partialOpts);
+                    } else if (operator === '$in') {
+                        const partialOpts = getInQueryRangeOpts(matcher[operator]);
+                        if (partialOpts) {
+                            matcherOpts = Object.assign(matcherOpts, partialOpts);
+                        }
                     }
                 });
             }
@@ -333,6 +338,54 @@ export function isSelectorSatisfiedByIndex(
     }
 
     return true;
+}
+
+/**
+ * $in can use an index by scanning the range between the
+ * smallest and the largest of the given values.
+ * That range can contain non-matching documents, so the
+ * selector is never satisfied by the index alone and the
+ * query matcher must still filter the results.
+ * Only homogeneous arrays of strings or finite numbers are
+ * used because min/max is not defined across mixed types.
+ * @link https://github.com/pubkey/rxdb/issues/8631
+ */
+export function getInQueryRangeOpts(
+    operatorValue: any
+): Partial<RxQueryPlanerOpts> | undefined {
+    if (
+        !Array.isArray(operatorValue) ||
+        operatorValue.length === 0
+    ) {
+        return undefined;
+    }
+    const valueType = typeof operatorValue[0];
+    if (valueType !== 'string' && valueType !== 'number') {
+        return undefined;
+    }
+    let min = operatorValue[0];
+    let max = operatorValue[0];
+    for (let i = 0; i < operatorValue.length; i++) {
+        const value = operatorValue[i];
+        if (
+            typeof value !== valueType ||
+            (valueType === 'number' && !isFinite(value))
+        ) {
+            return undefined;
+        }
+        if (value < min) {
+            min = value;
+        }
+        if (value > max) {
+            max = value;
+        }
+    }
+    return {
+        startKey: min,
+        endKey: max,
+        inclusiveStart: true,
+        inclusiveEnd: true
+    };
 }
 
 export function getMatcherQueryOpts(

--- a/test/unit/query-planner.test.ts
+++ b/test/unit/query-planner.test.ts
@@ -458,6 +458,127 @@ describeParallel('query-planner.test.js', () => {
             assert.strictEqual(queryPlan.endKeys[1], INDEX_MAX);
             assert.ok(queryPlan.inclusiveStart);
         });
+        it('should use the min/max of $in values as the scan range', () => {
+            const schema = getHumanSchemaWithIndexes([['firstName']]);
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {
+                        firstName: {
+                            $in: ['carol', 'alice', 'bob']
+                        },
+                        _deleted: false
+                    }
+                }
+            );
+            const queryPlan = getQueryPlan(
+                schema,
+                query
+            );
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'firstName', 'passportId']);
+            assert.strictEqual(queryPlan.startKeys[1], 'alice');
+            assert.strictEqual(queryPlan.endKeys[1], 'carol');
+            assert.ok(queryPlan.inclusiveStart);
+            assert.ok(queryPlan.inclusiveEnd);
+            /**
+             * The scanned range can contain documents whose value
+             * lies between the $in values without being one of them,
+             * so the selector must never count as satisfied by the index.
+             */
+            assert.strictEqual(queryPlan.selectorSatisfiedByIndex, false);
+        });
+        it('should use the min/max of numeric $in values as the scan range', () => {
+            const schema = getHumanSchemaWithIndexes([['age']]);
+            const query = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {
+                        age: {
+                            $in: [30, 10, 20]
+                        },
+                        _deleted: false
+                    }
+                }
+            );
+            const queryPlan = getQueryPlan(
+                schema,
+                query
+            );
+            assert.deepStrictEqual(queryPlan.index, ['_deleted', 'age', 'passportId']);
+            assert.strictEqual(queryPlan.startKeys[1], 10);
+            assert.strictEqual(queryPlan.endKeys[1], 30);
+            assert.strictEqual(queryPlan.selectorSatisfiedByIndex, false);
+        });
+        it('should keep the full scan range for mixed-type or empty $in values', () => {
+            const schema = getHumanSchemaWithIndexes([['firstName']]);
+            const mixedQuery = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {
+                        firstName: {
+                            $in: ['alice', 5]
+                        } as any,
+                        _deleted: false
+                    }
+                }
+            );
+            const mixedPlan = getQueryPlan(schema, mixedQuery);
+            assert.strictEqual(mixedPlan.startKeys[1], INDEX_MIN);
+            assert.strictEqual(mixedPlan.endKeys[1], INDEX_MAX);
+
+            const emptyQuery = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {
+                        firstName: {
+                            $in: []
+                        },
+                        _deleted: false
+                    }
+                }
+            );
+            const emptyPlan = getQueryPlan(schema, emptyQuery);
+            assert.strictEqual(emptyPlan.startKeys[1], INDEX_MIN);
+            assert.strictEqual(emptyPlan.endKeys[1], INDEX_MAX);
+        });
+        it('#8631 should rate a $in bounded plan higher than a full scan so the index is used', () => {
+            const schema = getHumanSchemaWithIndexes([['firstName', 'age']]);
+            const queryWithIn = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {
+                        firstName: {
+                            $in: ['aaron', 'jack', 'carol']
+                        },
+                        age: {
+                            $lt: 5
+                        }
+                    },
+                    index: ['firstName', 'age']
+                }
+            );
+            const planWithIn = getQueryPlan(schema, queryWithIn);
+
+            const queryNoSelector = normalizeMangoQuery<RxDocumentData<HumanDocumentType>>(
+                schema,
+                {
+                    selector: {},
+                    index: ['firstName', 'age']
+                }
+            );
+            const planNoSelector = getQueryPlan(schema, queryNoSelector);
+
+            const ratingWithIn = rateQueryPlan(schema, queryWithIn, planWithIn);
+            const ratingNoSelector = rateQueryPlan(schema, queryNoSelector, planNoSelector);
+
+            assert.strictEqual(planWithIn.startKeys[0], 'aaron');
+            assert.strictEqual(planWithIn.endKeys[0], 'jack');
+            assert.ok(
+                ratingWithIn > ratingNoSelector,
+                'query plan with $in bounds should be rated higher than a full scan. ' +
+                'Got ratingWithIn=' + ratingWithIn + ', ratingNoSelector=' + ratingNoSelector
+            );
+        });
         it('should have the correct start- and end keys when inclusiveStart and inclusiveEnd are false', () => {
             const schema = getHumanSchemaWithIndexes([['age']]);
             const query = normalizeMangoQuery<HumanDocumentType>(

--- a/test/unit/rx-storage-query-correctness.test.ts
+++ b/test/unit/rx-storage-query-correctness.test.ts
@@ -710,6 +710,89 @@ describeParallel('rx-storage-query-correctness.test.ts', () => {
         ]
     });
     /**
+     * @link https://github.com/pubkey/rxdb/issues/8631
+     * The query planner uses the min/max of the $in values
+     * as scan range on the index. Documents whose value lies
+     * inside that range without being one of the $in values
+     * must still be filtered out.
+     */
+    testCorrectQueries<HumanDocumentType>({
+        testTitle: '$in with index use',
+        data: [
+            schemaObjects.humanData('aa', 3, 'aaron'),
+            schemaObjects.humanData('bb', 10, 'aaron'),
+            schemaObjects.humanData('cc', 4, 'carol'),
+            schemaObjects.humanData('dd', 2, 'dave'),
+            schemaObjects.humanData('ee', 1, 'jack'),
+            schemaObjects.humanData('ff', 30, 'zoe')
+        ],
+        schema: withIndexes(human, [
+            ['firstName', 'age']
+        ]),
+        queries: [
+            {
+                info: '$in combined with range operator and desc sort',
+                query: {
+                    selector: {
+                        firstName: {
+                            $in: ['aaron', 'jack', 'carol']
+                        },
+                        age: {
+                            $lt: 5
+                        }
+                    },
+                    sort: [
+                        { age: 'desc' },
+                        { passportId: 'asc' }
+                    ],
+                    index: ['firstName', 'age'],
+                    limit: 50
+                },
+                selectorSatisfiedByIndex: false,
+                expectedResultDocIds: [
+                    'cc',
+                    'aa',
+                    'ee'
+                ]
+            },
+            {
+                info: '$in values that span the whole index range',
+                query: {
+                    selector: {
+                        firstName: {
+                            $in: ['aaron', 'zoe']
+                        }
+                    },
+                    sort: [{ passportId: 'asc' }],
+                    index: ['firstName', 'age']
+                },
+                selectorSatisfiedByIndex: false,
+                expectedResultDocIds: [
+                    'aa',
+                    'bb',
+                    'ff'
+                ]
+            },
+            {
+                info: '$in with mixed value types must not use the min/max bounds',
+                query: {
+                    selector: {
+                        firstName: {
+                            $in: ['aaron', 42]
+                        } as any
+                    },
+                    sort: [{ passportId: 'asc' }],
+                    index: ['firstName', 'age']
+                },
+                selectorSatisfiedByIndex: false,
+                expectedResultDocIds: [
+                    'aa',
+                    'bb'
+                ]
+            }
+        ]
+    });
+    /**
      * $in must not only work on strings but also on
      * arrays.
      */


### PR DESCRIPTION
## This PR contains:

- AN IMPROVEMENT to the query planner (with tests, docs and changelog entry)

## Describe the problem you have without this PR

Fixes #8631

`$in` queries on indexed fields do a full index scan. The query planner only handles `$eq`/`$gt`/`$gte`/`$lt`/`$lte`, so a field constrained with `$in` contributes an unbounded `INDEX_MIN..INDEX_MAX` range to the query plan. The plan gets no quality points for that field and the storage has to scan the whole index, which times out on large datasets (see #8631, > 1 million documents). Users currently work around this by splitting an `$in` into one query per value and merging the results.

With this PR, `getQueryPlan()` limits the scanned index range to the smallest and the largest of the `$in` values (inclusive on both ends). The scanned range can still contain documents whose value lies between the `$in` values without being one of them, so `selectorSatisfiedByIndex` stays `false` and the query matcher keeps filtering the results. The bounds are only applied for homogeneous arrays of strings or finite numbers, because min/max is not defined across mixed types; anything else keeps the previous unbounded behavior.

This benefits all RxStorage implementations that build their scan ranges from the RxDB query plan (memory, dexie, localstorage, denokv, foundationdb, and the premium storages that reuse the plan).

Example from the issue, index `['name', 'age']`:

```ts
collection.find({
  selector: {
    name: { $in: ['aaron', 'jack', 'carol'] },
    age: { $lt: 5 },
  },
  sort: [{ age: 'desc' }],
  limit: 50,
  index: ['name', 'age'],
}).exec();
```

Previously the plan scanned the full index. Now it scans `['aaron', MIN] .. ['jack', 5)`.

## Todos
- [x] Tests (query plan unit tests and query correctness tests, verified with memory and dexie storages)
- [x] Documentation (`nosql-performance-tips.md` note about `$in` and restrictive operators)
- [x] Typings (no type changes needed, `RxQueryPlanKey` already covers the bound values)
- [x] Changelog (`orga/changelog/improve-query-planner-in-operator-index-bounds.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNiaGsNGkUGMTYJf3h4Hgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNiaGsNGkUGMTYJf3h4Hgf)_