### PR TITLE
FIX dev-mode error diagnostics, fieldname regex and object utils

### DIFF
--- a/orga/changelog/fix-dev-mode-error-diagnostics-and-fieldname-regex.md
+++ b/orga/changelog/fix-dev-mode-error-diagnostics-and-fieldname-regex.md
@@ -1,0 +1,1 @@
+- FIX dev-mode: `COL13` and `COL16` errors now report the type of the invalid value instead of a constant wrong type, and the field name check no longer accepts square brackets in field names because they cannot be used as javascript variables.

--- a/orga/changelog/fix-utils-object-falsy-and-null-handling.md
+++ b/orga/changelog/fix-utils-object-falsy-and-null-handling.md
@@ -1,0 +1,1 @@
+- FIX utils: `getFromObjectOrThrow()` no longer throws on existing falsy values like `0`, `''` or `false`, and `flattenObject()` no longer drops keys whose value is `null`.

--- a/src/plugins/dev-mode/check-migration-strategies.ts
+++ b/src/plugins/dev-mode/check-migration-strategies.ts
@@ -44,7 +44,7 @@ export function checkMigrationStrategies(
         .forEach(strategy => {
             throw newRxTypeError('COL13', {
                 version: strategy.v,
-                type: typeof strategy,
+                type: typeof strategy.s,
                 schema
             });
         });

--- a/src/plugins/dev-mode/check-orm.ts
+++ b/src/plugins/dev-mode/check-orm.ts
@@ -53,7 +53,7 @@ export function checkOrmMethods(
             if (typeof v !== 'function') {
                 throw newRxTypeError('COL16', {
                     name: k,
-                    type: typeof k
+                    type: typeof v
                 });
             }
 

--- a/src/plugins/dev-mode/check-schema.ts
+++ b/src/plugins/dev-mode/check-schema.ts
@@ -41,7 +41,7 @@ export function checkFieldNameRegex(fieldName: string) {
         });
     }
 
-    const regexStr = '^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$';
+    const regexStr = '^[a-zA-Z](?:[a-zA-Z0-9_]*[a-zA-Z0-9])?$';
     const regex = new RegExp(regexStr);
     if (
         /**

--- a/src/plugins/utils/utils-object.ts
+++ b/src/plugins/utils/utils-object.ts
@@ -141,7 +141,7 @@ export function getFromObjectOrThrow<V>(
     key: string
 ): V {
     const val = obj[key];
-    if (!val) {
+    if (typeof val === 'undefined') {
         throw new Error('missing value from object ' + key);
     }
     return val;
@@ -156,7 +156,7 @@ export function flattenObject(ob: any) {
 
     for (const i in ob) {
         if (!Object.prototype.hasOwnProperty.call(ob, i)) continue;
-        if ((typeof ob[i]) === 'object') {
+        if (typeof ob[i] === 'object' && ob[i] !== null) {
             const flatObject = flattenObject(ob[i]);
             for (const x in flatObject) {
                 if (!Object.prototype.hasOwnProperty.call(flatObject, x)) continue;

--- a/test/unit/migration-schema.test.ts
+++ b/test/unit/migration-schema.test.ts
@@ -192,6 +192,32 @@ describe('migration-schema.test.ts', function () {
                 );
                 db.close();
             });
+            it('should report the type of the non-function strategy value', async () => {
+                const db = await createRxDatabase({
+                    name: randomToken(10),
+                    storage: config.storage.getStorage(),
+                });
+                let thrown: any;
+                try {
+                    await db.addCollections({
+                        foobar: {
+                            schema: schemas.simpleHumanV3,
+                            autoMigrate: false,
+                            migrationStrategies: {
+                                1: () => { },
+                                2: 'notAFunction',
+                                3: () => { }
+                            }
+                        }
+                    } as any);
+                } catch (err) {
+                    thrown = err;
+                }
+                assert.ok(thrown);
+                assert.strictEqual(thrown.code, 'COL13');
+                assert.strictEqual(thrown.parameters.type, 'string');
+                db.close();
+            });
             it('throw when strategy missing', async () => {
                 const db = await createRxDatabase({
                     name: randomToken(10),

--- a/test/unit/orm.test.ts
+++ b/test/unit/orm.test.ts
@@ -60,6 +60,29 @@ describeParallel('orm.test.js', () => {
                     );
                     db.close();
                 });
+                it('crash when static is no function and report the type of the value', async () => {
+                    const db = await createRxDatabase({
+                        name: randomToken(10),
+                        storage: config.storage.getStorage(),
+                    });
+                    let thrown: any;
+                    try {
+                        await db.addCollections({
+                            humans: {
+                                schema: schemas.human,
+                                statics: {
+                                    foobar: 123
+                                } as any
+                            }
+                        });
+                    } catch (err) {
+                        thrown = err;
+                    }
+                    assert.ok(thrown);
+                    assert.strictEqual(thrown.code, 'COL16');
+                    assert.strictEqual(thrown.parameters.type, 'number');
+                    db.close();
+                });
                 it('crash when name not allowed (name reserved)', async () => {
                     const db = await createRxDatabase({
                         name: randomToken(10),

--- a/test/unit/rx-schema.test.ts
+++ b/test/unit/rx-schema.test.ts
@@ -441,6 +441,40 @@ describeParallel('rx-schema.test.ts', () => {
                         }
                     }), 'RxError', 'SC1');
                 });
+                it('should not allow square brackets in fieldnames', async () => {
+                    await assertThrows(() => checkSchema({
+                        title: 'schema',
+                        version: 0,
+                        primaryKey: 'id',
+                        description: 'square bracket in fieldname',
+                        type: 'object',
+                        properties: {
+                            id: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            'foo[bar': {
+                                type: 'string'
+                            }
+                        }
+                    }), 'RxError', 'SC1');
+                    await assertThrows(() => checkSchema({
+                        title: 'schema',
+                        version: 0,
+                        primaryKey: 'id',
+                        description: 'closing square bracket in fieldname',
+                        type: 'object',
+                        properties: {
+                            id: {
+                                type: 'string',
+                                maxLength: 100
+                            },
+                            'foo]bar': {
+                                type: 'string'
+                            }
+                        }
+                    }), 'RxError', 'SC1');
+                });
                 it('should not allow RxDocument-properties as top-fieldnames (own)', () => {
                     assert.throws(() => checkSchema({
                         title: 'schema',

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -28,7 +28,9 @@ import {
     trimDots,
     parseRevision,
     getHeightOfRevision,
-    createRevision
+    createRevision,
+    flattenObject,
+    getFromObjectOrThrow
 } from '../../plugins/core/index.mjs';
 import config from './config.ts';
 
@@ -119,6 +121,34 @@ describe('util.test.js', () => {
             const result = trimDots(str);
             assert.strictEqual(result, str);
             assert.ok(result === str);
+        });
+    });
+    describe('.flattenObject()', () => {
+        it('should flatten nested objects', () => {
+            assert.deepStrictEqual(
+                flattenObject({ a: { b: 1 }, c: 2 }),
+                { 'a.b': 1, c: 2 }
+            );
+        });
+        it('should keep keys with null values', () => {
+            assert.deepStrictEqual(
+                flattenObject({ a: null, b: 1 }),
+                { a: null, b: 1 }
+            );
+            assert.deepStrictEqual(
+                flattenObject({ a: { b: null } }),
+                { 'a.b': null }
+            );
+        });
+    });
+    describe('.getFromObjectOrThrow()', () => {
+        it('should return falsy values that exist in the object', () => {
+            assert.strictEqual(getFromObjectOrThrow({ a: 0 }, 'a'), 0);
+            assert.strictEqual(getFromObjectOrThrow({ a: '' }, 'a'), '');
+            assert.strictEqual(getFromObjectOrThrow({ a: false }, 'a'), false);
+        });
+        it('should throw for missing keys', () => {
+            assert.throws(() => getFromObjectOrThrow({ a: 1 }, 'b'));
         });
     });
     describe('.recursiveDeepCopy()', () => {


### PR DESCRIPTION
## This PR contains:

A BUGFIX (five small correctness fixes in dev-mode checks and object utils, each covered by a new test)

## Describe the problem you have without this PR

Several dev-mode diagnostics report wrong information and two object utils mishandle falsy/null values:

- `COL16` (given static method is not a function) reports `typeof k`, the method name, so `type` is always `'string'` no matter what invalid value was passed. It now reports the type of the value (`src/plugins/dev-mode/check-orm.ts`).
- `COL13` (migrationStrategy must be a function) reports `typeof strategy`, the internal `{v, s}` wrapper object, so `type` is always `'object'`. It now reports the type of the invalid strategy value (`src/plugins/dev-mode/check-migration-strategies.ts`).
- `checkFieldNameRegex` used `^[a-zA-Z](?:[[a-zA-Z0-9_]*]?[a-zA-Z0-9])?$`. The doubled `[` makes the bracket a literal member of the character class and the following `]?` an optional literal, so field names like `foo[bar` passed validation even though the check exists to guarantee that field names can be used as javascript variables. The regex is now `^[a-zA-Z](?:[a-zA-Z0-9_]*[a-zA-Z0-9])?$`, which accepts exactly the same names as before except those containing square brackets (`src/plugins/dev-mode/check-schema.ts`).
- `getFromObjectOrThrow()` used `if (!val)` and therefore threw "missing value" for existing falsy values like `0`, `''` or `false`. It now checks for `undefined`, matching the sibling `getFromMapOrThrow()` (`src/plugins/utils/utils-object.ts`).
- `flattenObject()` recursed into `null` values because `typeof null === 'object'`, which made keys with `null` values disappear from the output. `flattenObject({a: null, b: 1})` returned `{b: 1}`; it now returns `{a: null, b: 1}` (`src/plugins/utils/utils-object.ts`).

Verified locally with `npm run build`, `npm run test:fast:memory` (1070 passing; the single `replication-webrtc` failure is a pre-existing environment issue where the `node-datachannel` native module cannot be built and it fails identically on the base commit), the new migration test against the dexie storage, `npm run lint` and `npm run check-types`.

## Todos
- [x] Tests
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wvjVFuftfpug6oRH3RD9m

---
_Generated by [Claude Code](https://claude.ai/code/session_018wvjVFuftfpug6oRH3RD9m)_