### PR TITLE
ADD conflict$ observable to RxReplicationState

### DIFF
--- a/docs-src/docs/replication.md
+++ b/docs-src/docs/replication.md
@@ -464,6 +464,10 @@ myRxReplicationState.canceled$.subscribe(bool => console.dir(bool));
 
 // emits true when a replication cycle is running, false when not.
 myRxReplicationState.active$.subscribe(bool => console.dir(bool));
+
+// emits each conflict that was reported by the remote in the response of the push handler,
+// together with the output of the conflictHandler that resolved it.
+myRxReplicationState.conflict$.subscribe(conflict => console.dir(conflict));
 ```
 
 ### awaitInitialReplication()

--- a/docs-src/docs/replication.md
+++ b/docs-src/docs/replication.md
@@ -465,8 +465,9 @@ myRxReplicationState.canceled$.subscribe(bool => console.dir(bool));
 // emits true when a replication cycle is running, false when not.
 myRxReplicationState.active$.subscribe(bool => console.dir(bool));
 
-// emits each conflict that was reported by the remote in the response of the push handler,
-// together with the output of the conflictHandler that resolved it.
+// emits each conflict that was reported by the remote in the response
+// of the push handler, together with the output of the conflictHandler
+// that resolved it.
 myRxReplicationState.conflict$.subscribe(conflict => console.dir(conflict));
 ```
 

--- a/orga/changelog/add-replication-conflict-observable.md
+++ b/orga/changelog/add-replication-conflict-observable.md
@@ -1,1 +1,1 @@
-- ADD `replicationState.conflict$` observable that emits each conflict that was reported by the remote in the response of the push handler, together with the output of the conflictHandler that resolved it. (https://github.com/pubkey/rxdb/pull/8743)
+- ADD `replicationState.conflict$` observable that emits each conflict that was reported by the remote in the response of the push handler, together with the output of the conflictHandler that resolved it. (https://github.com/pubkey/rxdb/pull/8742)

--- a/orga/changelog/add-replication-conflict-observable.md
+++ b/orga/changelog/add-replication-conflict-observable.md
@@ -1,0 +1,1 @@
+- ADD `replicationState.conflict$` observable that emits each conflict that was reported by the remote in the response of the push handler, together with the output of the conflictHandler that resolved it. (https://github.com/pubkey/rxdb/pull/8743)

--- a/src/plugins/replication/index.ts
+++ b/src/plugins/replication/index.ts
@@ -25,6 +25,7 @@ import type {
     RxError,
     RxDocument,
     RxJsonSchema,
+    RxReplicationConflict,
     RxReplicationPullStreamItem,
     RxReplicationWriteToMasterRow,
     RxStorageInstance,
@@ -84,7 +85,8 @@ export class RxReplicationState<RxDocType, CheckpointType> {
         sent: new Subject<WithDeleted<RxDocType>>(), // all documents that are sent to the endpoint
         error: new Subject<RxError | RxTypeError>(), // all errors that are received from the endpoint, emits new Error() objects
         canceled: new BehaviorSubject<boolean>(false), // true when the replication was canceled
-        active: new BehaviorSubject<boolean>(false) // true when something is running, false when not
+        active: new BehaviorSubject<boolean>(false), // true when something is running, false when not
+        conflict: new Subject<RxReplicationConflict<RxDocType>>() // all conflicts that are reported by the remote on pushes, together with the conflictHandler output
     };
 
     readonly received$: Observable<RxDocumentData<RxDocType>> = this.subjects.received.asObservable();
@@ -92,6 +94,7 @@ export class RxReplicationState<RxDocType, CheckpointType> {
     readonly error$: Observable<RxError | RxTypeError> = this.subjects.error.asObservable();
     readonly canceled$: Observable<any> = this.subjects.canceled.asObservable();
     readonly active$: Observable<boolean> = this.subjects.active.asObservable();
+    readonly conflict$: Observable<RxReplicationConflict<RxDocType>> = this.subjects.conflict.asObservable();
 
     wasStarted: boolean = false;
 
@@ -409,6 +412,10 @@ export class RxReplicationState<RxDocType, CheckpointType> {
                 .subscribe((writeToMasterRow: RxReplicationWriteToMasterRow<RxDocType>) => {
                     this.subjects.sent.next(writeToMasterRow.newDocumentState);
                 }),
+            this.internalReplicationState.events.resolvedConflicts
+                .subscribe((conflict: RxReplicationConflict<RxDocType>) => {
+                    this.subjects.conflict.next(conflict);
+                }),
             combineLatest([
                 this.internalReplicationState.events.active.down,
                 this.internalReplicationState.events.active.up
@@ -691,6 +698,7 @@ export class RxReplicationState<RxDocType, CheckpointType> {
         this.subjects.error.complete();
         this.subjects.received.complete();
         this.subjects.sent.complete();
+        this.subjects.conflict.complete();
 
         /**
          * Remove from the REPLICATION_STATE_BY_COLLECTION registry

--- a/src/types/conflict-handling.d.ts
+++ b/src/types/conflict-handling.d.ts
@@ -31,6 +31,16 @@ export type RxConflictHandlerOld<RxDocType> = (
 ) => Promise<RxConflictHandlerOutput<RxDocType>>;
 
 
+/**
+ * A conflict that was reported by the remote in the response
+ * of the push handler, together with the output of the
+ * conflictHandler that resolved it.
+ */
+export type RxReplicationConflict<RxDocType> = {
+    input: RxConflictHandlerInput<RxDocType>;
+    output: WithDeleted<RxDocType>;
+};
+
 export type RxConflictHandler<RxDocType> = {
     /**
      * This must be non-async

--- a/src/types/replication-protocol.d.ts
+++ b/src/types/replication-protocol.d.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import type {
     RxConflictHandler,
-    RxConflictHandlerInput
+    RxReplicationConflict
 } from './conflict-handling.d.ts';
 import type { RxError, RxTypeError } from './rx-error.d.ts';
 import type {
@@ -187,10 +187,12 @@ export type RxStorageInstanceReplicationState<RxDocType> = {
             up: Subject<RxReplicationWriteToMasterRow<RxDocType>>;
             down: Subject<BulkWriteRow<RxDocType>>;
         };
-        resolvedConflicts: Subject<{
-            input: RxConflictHandlerInput<RxDocType>;
-            output: WithDeleted<RxDocType>;
-        }>;
+        /**
+         * Streams all conflicts that were reported by the remote
+         * on masterWrite() calls together with the output
+         * of the conflictHandler that resolved them.
+         */
+        resolvedConflicts: Subject<RxReplicationConflict<RxDocType>>;
         /**
          * Contains the cancel state.
          * Emit true here to cancel the replication.

--- a/test/unit/replication.test.ts
+++ b/test/unit/replication.test.ts
@@ -61,6 +61,7 @@ import {
 
 import type {
     ReplicationPullHandlerResult,
+    RxReplicationConflict,
     RxReplicationWriteToMasterRow,
     RxStorage,
     RxStorageDefaultCheckpoint,
@@ -707,6 +708,47 @@ describe('replication.test.ts', () => {
                 values[values.length - 1],
                 false
             );
+
+            localCollection.database.close();
+            remoteCollection.database.close();
+        });
+        it('should emit conflicts reported by the remote on conflict$ together with the conflictHandler output', async () => {
+            const localCollection = await humansCollection.createHumanWithTimestamp(0, randomToken(10), false);
+            const remoteCollection = await humansCollection.createHumanWithTimestamp(0, randomToken(10), false);
+
+            // insert a document with the same id on both sides so that the push creates a conflict
+            await Promise.all([localCollection, remoteCollection].map((c, i) => c.insert({
+                id: 'conflicting-doc',
+                name: 'name-' + i,
+                updatedAt: 1001,
+                age: i
+            })));
+
+            const replicationState = replicateRxCollection({
+                collection: localCollection,
+                replicationIdentifier: REPLICATION_IDENTIFIER_TEST,
+                live: true,
+                pull: {
+                    handler: getPullHandler(remoteCollection)
+                },
+                push: {
+                    handler: getPushHandler(remoteCollection)
+                }
+            });
+            ensureReplicationHasNoErrors(replicationState);
+
+            const emitted: RxReplicationConflict<TestDocType>[] = [];
+            replicationState.conflict$.subscribe(c => emitted.push(c));
+
+            await replicationState.awaitInitialReplication();
+            await waitUntil(() => emitted.length > 0);
+
+            const conflict = emitted[0];
+            // the input contains the conflicting document states
+            assert.strictEqual(conflict.input.newDocumentState.age, 0, 'newDocumentState must be the local state that was pushed');
+            assert.strictEqual(conflict.input.realMasterState.age, 1, 'realMasterState must be the remote state that was reported as conflict');
+            // the default conflict handler resolves conflicts by using the realMasterState
+            assert.strictEqual(conflict.output.age, 1, 'output must be the resolved document state from the conflictHandler');
 
             localCollection.database.close();
             remoteCollection.database.close();


### PR DESCRIPTION
## This PR contains:
- A NEW FEATURE
- IMPROVED DOCS
- IMPROVED TESTS
- IMPROVED typings

## Describe the problem you have without this PR

There is no way to observe replication conflicts. When the remote reports a conflict in the response of the push handler, the `conflictHandler` resolves it silently. Applications cannot react to conflicts, for example to log them, show a notification or track how often they happen.

This PR adds a `conflict$` observable to the `RxReplicationState`:

```ts
// emits each conflict that was reported by the remote in the response of the push handler,
// together with the output of the conflictHandler that resolved it.
myRxReplicationState.conflict$.subscribe(conflict => console.dir(conflict));
```

Each emission is a `RxReplicationConflict<RxDocType>` with:
- `input`: the `RxConflictHandlerInput` (`newDocumentState`, `assumedMasterState`, `realMasterState`) that was given to the `conflictHandler`
- `output`: the resolved document state returned by the `conflictHandler`

Implementation: the replication protocol already emitted this data on the internal `events.resolvedConflicts` subject, it is now forwarded to a public `conflict$` observable on the `RxReplicationState`, so all replication plugins (GraphQL, CouchDB, Firestore, etc.) inherit it.

## Todos
- [x] Tests
- [x] Documentation
- [x] Typings
- [x] Changelog


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBLWkytZTRyzpoKV4oFKKH)_