### PR TITLE
Add SEM landingpages gaidxdb1, gaidxdb2 and gaidxdb3

### DIFF
--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaidxdb1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaidxdb1';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}<b>IndexedDB</b> Without the <b>Pain</b></>,
+    <>{/* variation 2 */}<b>Instant Queries</b> on <b>IndexedDB</b></>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    <>RxDB gives you a clean NoSQL API on top of IndexedDB. No transaction boilerplate, no callback chains — just schemas, queries and observables that keep your UI in sync with your data.</>,
+    <>RxDB runs directly inside your app and answers queries with zero network latency. Your data lives in IndexedDB, stays available offline and updates your UI the moment it changes.</>
+];
+
+const bulletpoints = [
+    [
+        <>Build apps that work offline</>,
+        <>Sync with any Backend</>,
+        <>Observable Realtime Queries</>,
+        <>All JavaScript Runtimes Supported</>
+    ],
+    [
+        <>No IndexedDB boilerplate</>,
+        <>Reactive queries out of the box</>,
+        <>JSON schemas and migrations</>,
+        <>Free and open source</>
+    ],
+    [
+        <>Zero-latency local reads</>,
+        <>Works fully offline</>,
+        <>Optimized IndexedDB storage</>,
+        <>Observable realtime queries</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB — IndexedDB Without the Pain',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaidxdb2.tsx
+++ b/docs-src/src/pages/sem/gaidxdb2.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaidxdb2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaidxdb2';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Reactive</b> JavaScript Database on <b>IndexedDB</b></>,
+    <>{/* variation 1 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
+    <>{/* variation 2 */}From <b>Prototype</b> to <b>Production</b> on IndexedDB</>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, Angular, Vue or Svelte components on every data change, with your data stored in IndexedDB.</>,
+    <>RxDB&apos;s core is free and open source. Replication works over HTTP, WebSocket or GraphQL against your own servers — no proprietary cloud, no per-read pricing, no lock-in.</>,
+    <>RxDB adds what raw IndexedDB is missing for real products: schema validation, data migrations, encryption, compression and multi-tab handling — with a query API that scales with your app.</>
+];
+
+const bulletpoints = [
+    [
+        <>First-class TypeScript support</>,
+        <>Bindings for major frameworks</>,
+        <>JSON schema validation</>,
+        <>Sync with any backend</>
+    ],
+    [
+        <>Free, open-source core</>,
+        <>Self-hostable replication</>,
+        <>Runs on IndexedDB, OPFS or SQLite</>,
+        <>No vendor lock-in</>
+    ],
+    [
+        <>Schema and data migrations</>,
+        <>Encryption and compression</>,
+        <>Multi-tab leader election</>,
+        <>Pluggable storage adapters</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB — The Reactive JavaScript Database on IndexedDB',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaidxdb3.tsx
+++ b/docs-src/src/pages/sem/gaidxdb3.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaidxdb3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaidxdb3';
+
+const titles = [
+    <>{/* variation 0 */}Fix IndexedDB <b>Limits</b>, <b>Speed</b> and <b>Sync</b></>,
+    <>{/* variation 1 */}<b>IndexedDB</b> That <b>Syncs</b> With Your Backend</>,
+    <>{/* variation 2 */}Browser Storage You Can <b>Rely On</b></>
+];
+
+const texts = [
+    <>Quota errors, slow bulk writes, data evicted by the browser? RxDB manages storage carefully, keeps queries fast with caching and indexes, and protects your data by syncing it to your server.</>,
+    <>IndexedDB keeps data on one device — RxDB replicates it. Sync browser data to any backend over HTTP, WebSocket or GraphQL, with conflict handling and offline queueing built in.</>,
+    <>RxDB coordinates writes across tabs, validates every document against your schema and migrates data between app versions — so browser storage stops being the scary part of your stack.</>
+];
+
+const bulletpoints = [
+    [
+        <>Handles storage quotas gracefully</>,
+        <>Fast queries via caching and indexes</>,
+        <>Data survives via server sync</>,
+        <>Works offline by default</>
+    ],
+    [
+        <>Realtime two-way replication</>,
+        <>Conflict resolution included</>,
+        <>Offline writes sync later</>,
+        <>Your servers, your data</>
+    ],
+    [
+        <>Multi-tab write coordination</>,
+        <>Schema validation on every write</>,
+        <>Versioned data migrations</>,
+        <>Open source and auditable</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB — Fix IndexedDB Limits, Speed and Sync',
+            appName: 'Browser',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/orga/changelog/sem-gaidxdb-pages.md
+++ b/orga/changelog/sem-gaidxdb-pages.md
@@ -1,0 +1,1 @@
+- ADD SEM landingpages `/sem/gaidxdb1.html`, `/sem/gaidxdb2.html` and `/sem/gaidxdb3.html`, each a/b testing 3 variations of the hero title, description and bulletpoints.


### PR DESCRIPTION
## This PR contains:
- Three new SEM landingpages under `docs-src/src/pages/sem/`:
  - `/sem/gaidxdb1.html` (meta title: "RxDB — IndexedDB Without the Pain")
  - `/sem/gaidxdb2.html` (meta title: "RxDB — The Reactive JavaScript Database on IndexedDB")
  - `/sem/gaidxdb3.html` (meta title: "RxDB — Fix IndexedDB Limits, Speed and Sync")

## Describe the problem you have without this PR
There are no SEM landingpages for these IndexedDB-focused ad campaigns. Each new page a/b tests 3 variations of the hero title, description and bulletpoints via `getSemVariation()`, so conversions can be attributed to the variation that the visitor was assigned. The assigned variation is kept stable per visitor via localStorage, and variation 0 is rendered on the server and first client render to avoid hydration mismatches.

## Todos
- [x] Changelog (`orga/changelog/sem-gaidxdb-pages.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ad8LRrFFvfmkCDxNW3oczd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad8LRrFFvfmkCDxNW3oczd)_