### PR TITLE
FIX: render sem.text in hero section so a/b tested text variations show up

### DIFF
--- a/docs-src/src/components/hero-section/T4_hero_b.tsx
+++ b/docs-src/src/components/hero-section/T4_hero_b.tsx
@@ -46,8 +46,14 @@ export function HeroSection_B(props: {
                         marginTop: 0,
                         marginBottom: 0
                     }} className='centered-mobile-p'>
-                        RxDB is a NoSQL database for JavaScript that runs directly in your app. With a <a href="/articles/local-first-future.html" target="_blank">local-first</a> design,
-                        it delivers zero-latency queries even offline, and syncs seamlessly with any backend.
+                        {
+                            props.sem && props.sem.text
+                                ? props.sem.text
+                                : <>
+                                    RxDB is a NoSQL database for JavaScript that runs directly in your app. With a <a href="/articles/local-first-future.html" target="_blank">local-first</a> design,
+                                    it delivers zero-latency queries even offline, and syncs seamlessly with any backend.
+                                </>
+                        }
                     </p>
                     <CheckedList className='centered-mobile padding-right-20-0' style={{
                         paddingTop: 35,

--- a/orga/changelog/sem-hero-text-variation.md
+++ b/orga/changelog/sem-hero-text-variation.md
@@ -1,0 +1,1 @@
+FIX: The hero section now renders the `text` of a SEM page so that the a/b tested text variations of the `sem` landingpages are shown instead of always displaying the hardcoded default text.


### PR DESCRIPTION
## This PR contains:
- A BUGFIX

## Describe the problem you have without this PR
The SEM landingpages (`gaidxdb1`, `gaidxdb2`, `gaidxdb3`) pass `text: texts[variation]` into `Home()` to a/b test three text variations, but the hero paragraph in `HeroSection_B` (`docs-src/src/components/hero-section/T4_hero_b.tsx`) was hardcoded and never read `props.sem.text`. As a result, every visitor saw the same default text regardless of the assigned variation, while `title` and `bulletpoints` varied correctly.

This PR makes the hero paragraph render `props.sem.text` when it is set, falling back to the existing default text otherwise, matching how `title` and `bulletpoints` are already handled in the same component.

## Todos
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDVXXnLmnifbkG5jKUqjgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDVXXnLmnifbkG5jKUqjgG)_