### PR TITLE
docs: use a single SVG favicon instead of duplicate icon tags

### DIFF
--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -24,7 +24,7 @@ const rehypePrettyCodeOptions: RehypePrettyCodeOptions = {
 const config: Config = {
     title: 'RxDB - JavaScript Database',
     tagline: 'Realtime JavaScript Database',
-    favicon: '/img/favicon.png',
+    favicon: '/files/logo/logo.svg',
     headTags: [
         { tagName: 'meta', attributes: { name: 'theme-color', content: '#ed168f' } },
         { tagName: 'link', attributes: { rel: 'apple-touch-icon', href: '/img/apple-touch-icon.png', sizes: '180x180' } },

--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -25,10 +25,8 @@ const config: Config = {
     title: 'RxDB - JavaScript Database',
     tagline: 'Realtime JavaScript Database',
     favicon: '/img/favicon.png',
-    // Add multiple sizes + Apple touch icon (+ optional SVG)
     headTags: [
         { tagName: 'meta', attributes: { name: 'theme-color', content: '#ed168f' } },
-        { tagName: 'link', attributes: { rel: 'icon', type: 'image/svg+xml', href: '/files/logo/logo.svg' } },
         { tagName: 'link', attributes: { rel: 'apple-touch-icon', href: '/img/apple-touch-icon.png', sizes: '180x180' } },
         { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://consentcdn.cookiebot.com/' } },
         { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://consent.cookiebot.com/' } },


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS (Docusaurus config fix, no source code changes)

## Describe the problem you have without this PR
Google SERPs do not display the site favicon for rxdb.info. The rendered HTML head contains two conflicting `<link rel="icon">` tags:

1. The Docusaurus `favicon` config pointing to `/img/favicon.png`
2. A custom injected tag in `headTags`: `<link rel="icon" type="image/svg+xml" href="/files/logo/logo.svg">`

The duplicate tags confuse Google's favicon picker.

This PR removes the custom injected SVG icon tag from `headTags` and points the Docusaurus `favicon` property to `/files/logo/logo.svg`, so the head contains exactly one icon declaration using the scalable SVG logo. Google supports SVG favicons; the 48px multiple size rule only applies to raster formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RT2LCYXELVkFTuWtYmFShn