### PR TITLE
Add SEM landingpages gaawsds1, gaawsds2 and gaawsds3

### DIFF
--- a/docs-src/src/pages/sem/gaawsds1.tsx
+++ b/docs-src/src/pages/sem/gaawsds1.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaawsds1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaawsds1';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}The <b>Migration Path</b> When Your Sync Gets <b>Deprecated</b></>,
+    <>{/* variation 2 */}<b>Migrate Once</b>, Never Get <b>Sunset</b> Again</>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    <>Your offline sync engine is being sunset, but your app still needs local data and realtime sync. RxDB is open source and actively developed: store data on the device, query it instantly and replicate to the backend you already run.</>,
+    <>RxDB runs inside your app and syncs to infrastructure you control. No vendor can deprecate your data layer: the core is open source, backend-agnostic and runs in browsers, mobile apps and desktop.</>
+];
+
+const bulletpoints = [
+    [
+        <>Build apps that work offline</>,
+        <>Sync with any Backend</>,
+        <>Observable Realtime Queries</>,
+        <>All JavaScript Runtimes Supported</>
+    ],
+    [
+        <>Actively developed, no sunset risk</>,
+        <>Keep your existing GraphQL backend</>,
+        <>Works offline by default</>,
+        <>Free and open source</>
+    ],
+    [
+        <>You own the stack, no lock-in</>,
+        <>Backend-agnostic replication</>,
+        <>Browser, mobile and desktop</>,
+        <>Apache-2.0 licensed core</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Migrate Off Deprecated Offline Sync',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaawsds2.tsx
+++ b/docs-src/src/pages/sem/gaawsds2.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaawsds2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaawsds2';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Reactive</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}A <b>Local Database</b> That Syncs With Your <b>GraphQL</b> API</>,
+    <>{/* variation 2 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, React Native, Angular or Vue components on every data change, online or offline.</>,
+    <>RxDB replicates over GraphQL, HTTP or WebSocket, so you keep the backend you already run. Offline writes queue locally and sync with conflict handling when the connection returns.</>,
+    <>RxDB's core is free and open source. Replication works against your own servers: no proprietary cloud, no metered realtime billing, no vendor deciding when your data layer dies.</>
+];
+
+const bulletpoints = [
+    [
+        <>First-class TypeScript support</>,
+        <>Bindings for major frameworks</>,
+        <>JSON schema validation</>,
+        <>Works in every JS runtime</>
+    ],
+    [
+        <>GraphQL replication built in</>,
+        <>Keep your existing backend</>,
+        <>Offline queue and conflict handling</>,
+        <>Realtime two-way sync</>
+    ],
+    [
+        <>Free, open-source core</>,
+        <>Self-hostable replication</>,
+        <>Runs on IndexedDB, OPFS or SQLite</>,
+        <>No vendor lock-in</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Open-Source Local-First Database for JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaawsds3.tsx
+++ b/docs-src/src/pages/sem/gaawsds3.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaawsds3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaawsds3';
+
+const titles = [
+    <>{/* variation 0 */}<b>Offline Sync</b> You Can Actually <b>Debug</b></>,
+    <>{/* variation 1 */}<b>Realtime Sync</b> Without the <b>Metered Bill</b></>,
+    <>{/* variation 2 */}Your Offline Sync <b>Retires in 2027</b>. RxDB <b>Won't</b>.</>
+];
+
+const texts = [
+    <>Data that silently stops syncing is not a fact of life. RxDB's replication is open source and runs in your code: you can inspect it, log it and test it, with conflict resolution you define.</>,
+    <>Per-connection and per-update pricing punishes successful apps. RxDB syncs to infrastructure you already pay for, so realtime updates and always-on devices stop showing up on your cloud invoice.</>,
+    <>If your app's sync layer has an end-of-life date, the migration is coming either way. RxDB keeps the local-first model you already use: write locally, observe queries, sync in the background, even to your existing GraphQL backend.</>
+];
+
+const bulletpoints = [
+    [
+        <>Open, inspectable sync protocol</>,
+        <>Conflict resolution you control</>,
+        <>Offline writes never get lost</>,
+        <>Works the same on every platform</>
+    ],
+    [
+        <>No per-update billing</>,
+        <>No per-connection billing</>,
+        <>Self-host on your own servers</>,
+        <>Free, open-source core</>
+    ],
+    [
+        <>Same local-first programming model</>,
+        <>Keep your GraphQL backend</>,
+        <>Actively developed and maintained</>,
+        <>Migrate on your schedule, not theirs</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Reliable Offline Sync You Control',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/orga/changelog/sem-gaawsds1-page.md
+++ b/orga/changelog/sem-gaawsds1-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaawsds1` (a/b testing 3 title/description/bulletpoint variations for migrating off deprecated offline sync) at `/sem/gaawsds1.html`.

--- a/orga/changelog/sem-gaawsds2-page.md
+++ b/orga/changelog/sem-gaawsds2-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaawsds2` (a/b testing 3 title/description/bulletpoint variations for the open-source local-first database) at `/sem/gaawsds2.html`.

--- a/orga/changelog/sem-gaawsds3-page.md
+++ b/orga/changelog/sem-gaawsds3-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaawsds3` (a/b testing 3 title/description/bulletpoint variations for reliable offline sync you control) at `/sem/gaawsds3.html`.


### PR DESCRIPTION
## This PR contains:

- A NEW FEATURE (three SEM/ads landingpages)

## Describe the problem you have without this PR

We want dedicated search engine marketing landingpages that a/b test different messaging around local-first storage and migrating off deprecated/metered offline sync engines. This PR adds three new pages under `docs-src/src/pages/sem/`:

- **`gaawsds1`** (`/sem/gaawsds1.html`) - "Migrate Off Deprecated Offline Sync". Variations focused on the local-first database and the migration path when a sync engine gets sunset.
- **`gaawsds2`** (`/sem/gaawsds2.html`) - "Open-Source Local-First Database for JavaScript". Variations focused on reactivity, GraphQL sync and self-hosting.
- **`gaawsds3`** (`/sem/gaawsds3.html`) - "Reliable Offline Sync You Control". Variations focused on debuggable sync, no metered billing and migrating on your own schedule.

Each page reuses the main `Home` hero via the `sem` prop and a/b tests 3 variations of the title, description and bulletpoints. The variation is chosen randomly per visitor through `getSemVariation`, kept stable via `localStorage`, and attached to tracking events for conversion attribution. This follows the same pattern as the existing `gaidxdb*` pages.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZo6A51MUV2B6BsT8S61An

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZo6A51MUV2B6BsT8S61An)_