### PR TITLE
fix(docs): remove duplicate alternatives/ prefix from article slugs

### DIFF
--- a/docs-src/docs/articles/alternatives/aws-amplify-datastore-alternative.md
+++ b/docs-src/docs/articles/alternatives/aws-amplify-datastore-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as an AWS Amplify DataStore Alternative - Backend-Agnostic, Offline-First
-slug: alternatives/aws-amplify-datastore-alternative.html
+slug: aws-amplify-datastore-alternative.html
 description: Compare RxDB and AWS Amplify DataStore for offline-first JavaScript applications. Learn why RxDB is a strong alternative with pluggable backends, flexible storage, reactive queries, and no vendor lock-in.
 image: /headers/alternatives/aws-amplify-datastore-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/couchbase-alternative.md
+++ b/docs-src/docs/articles/alternatives/couchbase-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a Couchbase Alternative - Local-First, Backend-Agnostic, and Framework-Ready
-slug: alternatives/couchbase-alternative.html
+slug: couchbase-alternative.html
 description: Compare RxDB and Couchbase for JavaScript applications. Learn why RxDB is a practical alternative to Couchbase and Couchbase Lite for offline-first web, mobile, and desktop apps without the enterprise infrastructure overhead.
 image: /headers/alternatives/couchbase-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/couchdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/couchdb-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a CouchDB Alternative - Client-Side, Offline-First, Reactive Queries
-slug: alternatives/couchdb-alternative.html
+slug: couchdb-alternative.html
 description: Compare RxDB and CouchDB for local-first JavaScript applications. Learn why CouchDB is a server-side database, how RxDB provides client-side offline-first storage with reactive queries, and how the two can work together through the RxDB CouchDB replication plugin.
 image: /headers/alternatives/couchdb-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/horizon-alternative.md
+++ b/docs-src/docs/articles/alternatives/horizon-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a Horizon Alternative - Offline-First, Client-Side Reactive Database
-slug: alternatives/horizon-alternative.html
+slug: horizon-alternative.html
 description: Compare RxDB and Horizon (RethinkDB's client library) for realtime JavaScript applications. Learn why RxDB is a strong alternative with true offline-first support, client-side reactive queries, flexible backends, and active long-term maintenance.
 image: /headers/alternatives/horizon-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/meteor-alternative.md
+++ b/docs-src/docs/articles/alternatives/meteor-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a Meteor Alternative - Offline-First Without Framework Lock-In
-slug: alternatives/meteor-alternative.html
+slug: meteor-alternative.html
 description: Compare RxDB and Meteor for local-first JavaScript applications. Learn why RxDB is a strong alternative for offline-first, reactive, framework-agnostic database needs.
 image: /files/alternatives/meteor_text.svg
 ---

--- a/docs-src/docs/articles/alternatives/minimongo-alternative.md
+++ b/docs-src/docs/articles/alternatives/minimongo-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a Minimongo Alternative - Persistent, Observable, Offline-First
-slug: alternatives/minimongo-alternative.html
+slug: minimongo-alternative.html
 description: Compare RxDB and Minimongo for client-side JavaScript databases. Learn why RxDB is a better alternative for offline-first apps with persistent storage, reactive queries, conflict handling, and multi-tab support.
 image: /headers/alternatives/minimongo-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/pouchdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/pouchdb-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a PouchDB Alternative - Reactive, Fast, and Backend-Agnostic
-slug: alternatives/pouchdb-alternative.html
+slug: pouchdb-alternative.html
 description: Compare RxDB and PouchDB for offline-first JavaScript applications. Learn why RxDB is a modern alternative to PouchDB with reactive queries, pluggable storage engines, flexible replication, and no revision-tree overhead.
 image: /headers/alternatives/pouchdb-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/rethinkdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/rethinkdb-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a RethinkDB Alternative - Offline-First, Client-Side Reactive Database
-slug: alternatives/rethinkdb-alternative.html
+slug: rethinkdb-alternative.html
 description: Compare RxDB and RethinkDB for realtime JavaScript applications. Learn why RxDB is a strong alternative with true offline-first support, client-side reactive queries, flexible backends, and active long-term maintenance.
 image: /headers/alternatives/rethinkdb-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/supabase-alternative.md
+++ b/docs-src/docs/articles/alternatives/supabase-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a Supabase Alternative - Offline-First, Local Storage, Reactive Queries
-slug: alternatives/supabase-alternative.html
+slug: supabase-alternative.html
 description: Compare RxDB and Supabase for local-first JavaScript applications. Learn why Supabase lacks offline support, how the RxDB Supabase replication plugin bridges that gap, and when to choose RxDB as a client-side database paired with a Supabase backend.
 image: /headers/alternatives/supabase-alternative.jpg
 ---

--- a/docs-src/docs/articles/alternatives/watermelondb-alternative.md
+++ b/docs-src/docs/articles/alternatives/watermelondb-alternative.md
@@ -1,6 +1,6 @@
 ---
 title: RxDB as a WatermelonDB Alternative - Cross-Platform, Observable, Offline-First
-slug: alternatives/watermelondb-alternative.html
+slug: watermelondb-alternative.html
 description: Compare RxDB and WatermelonDB for offline-first JavaScript and React Native applications. Learn why RxDB is a strong alternative with built-in replication, flexible storage, and framework-agnostic reactive queries.
 image: /headers/alternatives/watermelondb-alternative.jpg
 ---

--- a/orga/changelog/fix-alternatives-slug-duplicate-path.md
+++ b/orga/changelog/fix-alternatives-slug-duplicate-path.md
@@ -1,0 +1,1 @@
+FIX broken links on the [alternatives](https://rxdb.info/alternatives.html) page. Ten alternative article pages had a redundant `alternatives/` prefix in their `slug` frontmatter, which Docusaurus resolves relative to the file directory and produced doubled URLs like `/articles/alternatives/alternatives/aws-amplify-datastore-alternative.html`.


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (a bugfix to documentation routing)

## Describe the problem you have without this PR

The [alternatives](https://rxdb.info/alternatives.html) overview page linked to broken, doubled URLs such as:

```
https://rxdb.info/articles/alternatives/alternatives/aws-amplify-datastore-alternative.html
```

instead of the intended:

```
https://rxdb.info/articles/alternatives/aws-amplify-datastore-alternative.html
```

### Cause

Ten article pages under `docs-src/docs/articles/alternatives/` declared a `slug` frontmatter value with a redundant `alternatives/` prefix, for example:

```yaml
slug: alternatives/aws-amplify-datastore-alternative.html
```

Docusaurus resolves a `slug` that does not start with `/` **relative to the document's own directory**. Because these files already live in `/articles/alternatives/`, the extra `alternatives/` prefix got concatenated onto that directory path, producing the doubled URL segment.

### Fix

Removed the redundant `alternatives/` prefix so each slug matches the convention already used by the other ~18 files in the same directory (e.g. `slug: aws-amplify-datastore-alternative.html`).

Affected files:

- aws-amplify-datastore-alternative.md
- couchbase-alternative.md
- couchdb-alternative.md
- horizon-alternative.md
- meteor-alternative.md
- minimongo-alternative.md
- pouchdb-alternative.md
- rethinkdb-alternative.md
- supabase-alternative.md
- watermelondb-alternative.md

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkVZycPdK2iTn7sCuk4TNh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkVZycPdK2iTn7sCuk4TNh)_