### PR TITLE
docs: add SEM landingpages gajsondb1, gajsondb2, gajsondb3

### DIFF
--- a/docs-src/src/pages/sem/gajsondb1.tsx
+++ b/docs-src/src/pages/sem/gajsondb1.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gajsondb1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gajsondb1';
+
+const titles = [
+    <>{/* variation 0 */}The Local-First <b>Database</b> for JavaScript Apps</>,
+    <>{/* variation 1 */}The <b>JSON Database</b> Built for JavaScript</>,
+    <>{/* variation 2 */}Instant Queries on <b>JSON Documents</b></>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    <>RxDB is a NoSQL database that stores your data as plain JSON documents. Query them with a Mongo-like syntax, observe changes in realtime and keep your app state JSON from the UI to storage to your backend.</>,
+    <>RxDB runs inside your app and answers JSON queries with zero network latency. Your documents stay available offline and your UI updates the moment the data changes.</>
+];
+
+const bulletpoints = [
+    [
+        <>Build apps that work offline</>,
+        <>Sync with any Backend</>,
+        <>Observable Realtime Queries</>,
+        <>All JavaScript Runtimes Supported</>
+    ],
+    [
+        <>Plain JSON documents</>,
+        <>Mongo-like query syntax</>,
+        <>Realtime observable queries</>,
+        <>Free and open source</>
+    ],
+    [
+        <>Zero-latency local reads</>,
+        <>Works fully offline</>,
+        <>Indexes for fast JSON queries</>,
+        <>Live UI updates</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: The JSON Database for JavaScript Apps',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gajsondb2.tsx
+++ b/docs-src/src/pages/sem/gajsondb2.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gajsondb2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gajsondb2';
+
+const titles = [
+    <>{/* variation 0 */}The NoSQL <b>JSON Database</b> With Schemas</>,
+    <>{/* variation 1 */}An Open-Source <b>JSON Database</b> You Can Self-Host</>,
+    <>{/* variation 2 */}The Reactive <b>JSON Database</b> for Your Framework</>
+];
+
+const texts = [
+    <>RxDB validates every document against your JSON Schema and ships full TypeScript typings. You get NoSQL flexibility without the anything goes chaos, plus versioned migrations when your data model evolves.</>,
+    <>RxDB's core is free and open source. Replicate JSON documents to your own servers over HTTP, WebSocket or GraphQL: no proprietary cloud, no per-read pricing, no lock-in.</>,
+    <>RxDB's observable queries re-render your React, Angular, Vue or Svelte components whenever a JSON document changes. One database, every JavaScript runtime: browser, Node.js, Electron and mobile.</>
+];
+
+const bulletpoints = [
+    [
+        <>JSON Schema validation</>,
+        <>First-class TypeScript support</>,
+        <>Versioned schema migrations</>,
+        <>NoSQL query engine</>
+    ],
+    [
+        <>Free, open-source core</>,
+        <>Self-hostable replication</>,
+        <>Runs on IndexedDB, OPFS or SQLite</>,
+        <>No vendor lock-in</>
+    ],
+    [
+        <>Bindings for major frameworks</>,
+        <>Observable realtime queries</>,
+        <>Browser, Node.js and mobile</>,
+        <>Sync with any backend</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Open-Source NoSQL JSON Database for JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gajsondb3.tsx
+++ b/docs-src/src/pages/sem/gajsondb3.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gajsondb3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gajsondb3';
+
+const titles = [
+    <>{/* variation 0 */}Outgrown JSON Files? Get a Real <b>JSON Database</b></>,
+    <>{/* variation 1 */}<b>JSON Documents</b> That Sync Across Devices</>,
+    <>{/* variation 2 */}<b>JSON Storage</b> That Scales With Your App</>
+];
+
+const texts = [
+    <>Writing app data to JSON files means rewriting the whole file on every change, looping instead of querying, and corrupted data under concurrent writes. RxDB keeps your data JSON and fixes all of that.</>,
+    <>A JSON file lives on one machine. RxDB replicates JSON documents between your clients and your backend, with offline queueing and conflict handling built in.</>,
+    <>RxDB queries JSON documents through indexes instead of loading everything into memory, and keeps working offline. Grow from a prototype to production without changing your data model.</>
+];
+
+const bulletpoints = [
+    [
+        <>Indexed queries on JSON</>,
+        <>Safe concurrent writes</>,
+        <>Schemas and migrations</>,
+        <>Realtime UI updates</>
+    ],
+    [
+        <>Two-way realtime replication</>,
+        <>Conflict resolution included</>,
+        <>Offline writes sync later</>,
+        <>Your servers, your data</>
+    ],
+    [
+        <>Indexes, not full scans</>,
+        <>Zero-latency local reads</>,
+        <>Works offline by default</>,
+        <>Production-ready open source</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Outgrown JSON Files? Get a Real JSON Database',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/orga/changelog/sem-gajsondb1-page.md
+++ b/orga/changelog/sem-gajsondb1-page.md
@@ -1,0 +1,1 @@
+- Added SEM landingpage `gajsondb1` (JSON database for JavaScript apps) that a/b tests 3 title, description and bulletpoint variations.

--- a/orga/changelog/sem-gajsondb2-page.md
+++ b/orga/changelog/sem-gajsondb2-page.md
@@ -1,0 +1,1 @@
+- Added SEM landingpage `gajsondb2` (open-source NoSQL JSON database) that a/b tests 3 title, description and bulletpoint variations.

--- a/orga/changelog/sem-gajsondb3-page.md
+++ b/orga/changelog/sem-gajsondb3-page.md
@@ -1,0 +1,1 @@
+- Added SEM landingpage `gajsondb3` (real JSON database vs JSON files) that a/b tests 3 title, description and bulletpoint variations.


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (three new SEM landingpages)

## Describe the problem you have without this PR

There were no SEM landingpages targeting the "JSON database for JavaScript" keyword set. This PR adds three of them under `docs-src/src/pages/sem/`:

- **`gajsondb1`** (`/sem/gajsondb1.html`) - general "JSON database for JavaScript apps" angle.
- **`gajsondb2`** (`/sem/gajsondb2.html`) - "open-source NoSQL JSON database with schemas" angle.
- **`gajsondb3`** (`/sem/gajsondb3.html`) - "outgrown JSON files, get a real JSON database" angle.

Each page renders the main `Home` landingpage through the `sem` prop and a/b tests 3 variations of the hero title, description and bulletpoints. A visitor is randomly assigned one variation via `getSemVariation`, the choice is stored in `localStorage` so it stays stable across visits, and the chosen variation index is attached to the tracking events for conversion attribution. The first variation is rendered on the server and first client render to avoid a hydration mismatch, then swapped to the assigned one.

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012aiUYzphkc1DYAMChEEsnm)_