### PR TITLE
docs: add SEM landingpages for encryption and realtime-sync campaigns

### DIFF
--- a/docs-src/src/pages/sem/gaencdb1.tsx
+++ b/docs-src/src/pages/sem/gaencdb1.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaencdb1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaencdb1';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}The <b>Encrypted</b> Local Database for <b>JavaScript</b></>,
+    <>{/* variation 2 */}Your Data, <b>Encrypted</b> on the <b>Device</b></>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    <>RxDB is a local database for JavaScript apps with AES encryption built in. Your data is encrypted before it is written to disk, stays available offline and syncs to any backend you choose.</>,
+    <>RxDB stores your app's data locally and encrypts sensitive fields before they touch storage. No plaintext at rest, no required cloud, and your app keeps working with zero network latency.</>
+];
+
+const bulletpoints = [
+    [
+        <>Build apps that work offline</>,
+        <>Sync with any Backend</>,
+        <>Observable Realtime Queries</>,
+        <>All JavaScript Runtimes Supported</>
+    ],
+    [
+        <>AES encryption at rest</>,
+        <>Works fully offline</>,
+        <>Sync with any backend</>,
+        <>Free and open source</>
+    ],
+    [
+        <>No plaintext at rest</>,
+        <>Data stays on the device</>,
+        <>Zero-latency local queries</>,
+        <>Open source and auditable</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: The Encrypted Local Database for Your App',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaencdb2.tsx
+++ b/docs-src/src/pages/sem/gaencdb2.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaencdb2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaencdb2';
+
+const titles = [
+    <>{/* variation 0 */}<b>Field-Level Encryption</b> for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}An <b>Encrypted</b> Database You Can <b>Self-Host</b></>,
+    <>{/* variation 2 */}Fast, <b>Encrypted</b> Storage for <b>Production</b> Apps</>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript and TypeScript. Mark properties as encrypted in your JSON schema and RxDB encrypts them transparently, in the browser, React Native, Electron and Node.js.</>,
+    <>RxDB's core and its AES encryption plugin are free and open source. Replicate encrypted data to your own servers over HTTP, WebSocket or GraphQL. No proprietary cloud, no per-read pricing, no lock-in.</>,
+    <>RxDB combines encryption with the features real products need: schema validation, migrations, compression and multi-tab support. The Web Crypto based premium plugin encrypts at native browser speed.</>
+];
+
+const bulletpoints = [
+    [
+        <>Declare encrypted fields in your schema</>,
+        <>Browser, mobile and desktop</>,
+        <>First-class TypeScript support</>,
+        <>JSON schema validation</>
+    ],
+    [
+        <>Free, open-source core</>,
+        <>AES encryption plugin included</>,
+        <>Self-hostable replication</>,
+        <>No vendor lock-in</>
+    ],
+    [
+        <>Native Web Crypto performance</>,
+        <>Schema and data migrations</>,
+        <>Multi-tab out of the box</>,
+        <>Works with any framework</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Field-Level Encryption for JavaScript Apps',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gaencdb3.tsx
+++ b/docs-src/src/pages/sem/gaencdb3.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gaencdb3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'gaencdb3';
+
+const titles = [
+    <>{/* variation 0 */}Browser Storage Is <b>Not Encrypted</b>. RxDB Is.</>,
+    <>{/* variation 1 */}<b>Encrypt</b> Local Data, Keep the <b>Auditors</b> Happy</>,
+    <>{/* variation 2 */}<b>Encrypted</b> Locally, <b>Synced</b> Everywhere</>
+];
+
+const texts = [
+    <>IndexedDB and localStorage keep everything in plaintext, readable by anyone with access to the device. RxDB encrypts sensitive fields with AES before they are written, so stored data stays protected.</>,
+    <>Storing personal or sensitive data on the client? RxDB's field-level encryption keeps it encrypted at rest while your app keeps working offline, and syncs it to servers you control.</>,
+    <>Encryption should not cost you sync. RxDB encrypts fields on the device and still replicates your data in realtime to any backend, with offline queueing and conflict handling built in.</>
+];
+
+const bulletpoints = [
+    [
+        <>Encrypts data before it hits disk</>,
+        <>Password-based AES encryption</>,
+        <>Protects data on shared devices</>,
+        <>Free and open source</>
+    ],
+    [
+        <>Field-level encryption at rest</>,
+        <>Offline access preserved</>,
+        <>Sync to your own backend</>,
+        <>Helps with data-protection rules</>
+    ],
+    [
+        <>Encryption plus realtime sync</>,
+        <>Works offline by default</>,
+        <>Conflict handling included</>,
+        <>Runs on browser and mobile</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Encrypt Local App Data on Web and Mobile',
+            appName: 'Browser',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/garealm1.tsx
+++ b/docs-src/src/pages/sem/garealm1.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "garealm1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'garealm1';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}<b>Sync</b> That No Vendor Can <b>Shut Down</b></>,
+    <>{/* variation 2 */}Keep <b>Offline-First</b>. Replace the <b>Dead Sync</b>.</>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    <>Your managed mobile sync reached end of life. RxDB is open source: the local database and the replication layer run on your infrastructure, so nobody can switch them off again.</>,
+    <>RxDB keeps the model you already built on: a local NoSQL database with live queries plus realtime replication. Move your data layer without rewriting your app's offline logic.</>
+];
+
+const bulletpoints = [
+    [
+        <>Build apps that work offline</>,
+        <>Sync with any Backend</>,
+        <>Observable Realtime Queries</>,
+        <>All JavaScript Runtimes Supported</>
+    ],
+    [
+        <>Open-source local database</>,
+        <>Self-hosted realtime sync</>,
+        <>Actively maintained and funded</>,
+        <>No proprietary cloud required</>
+    ],
+    [
+        <>Local NoSQL with live queries</>,
+        <>Realtime two-way replication</>,
+        <>Offline writes queue and sync</>,
+        <>Runs in React Native and the web</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: The Maintained Local Database With Realtime Sync',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/garealm2.tsx
+++ b/docs-src/src/pages/sem/garealm2.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "garealm2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'garealm2';
+
+const titles = [
+    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    <>{/* variation 1 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
+    <>{/* variation 2 */}Built for <b>Production</b> <b>Offline-First</b> Apps</>
+];
+
+const texts = [
+    <>RxDB is a NoSQL database for JavaScript and TypeScript. It runs in React Native, Capacitor, browsers, Electron and Node.js, with observable queries that update your UI in realtime.</>,
+    <>RxDB's core is free and open source. Replication runs over HTTP, WebSocket or GraphQL against your own backend: no proprietary sync cloud, no per-device pricing, no lock-in.</>,
+    <>RxDB ships what a production migration needs: JSON schema validation, data migrations, conflict resolution, encryption and multi-tab support, proven in years of production use.</>
+];
+
+const bulletpoints = [
+    [
+        <>First-class TypeScript support</>,
+        <>React Native and Expo ready</>,
+        <>Observable realtime queries</>,
+        <>NoSQL JSON documents</>
+    ],
+    [
+        <>Free, open-source core</>,
+        <>Self-hostable replication</>,
+        <>Works with any backend</>,
+        <>No vendor lock-in</>
+    ],
+    [
+        <>Schema validation and migrations</>,
+        <>Conflict resolution built in</>,
+        <>Encryption plugin available</>,
+        <>Battle-tested sync protocol</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: The Local-First JavaScript Database With Sync',
+            appName: 'JavaScript',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/docs-src/src/pages/sem/garealm3.tsx
+++ b/docs-src/src/pages/sem/garealm3.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "garealm3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+const PAGE_ID = 'garealm3';
+
+const titles = [
+    <>{/* variation 0 */}Stranded by a <b>Deprecated</b> Sync Service?</>,
+    <>{/* variation 1 */}Never Get <b>Locked Into</b> a Sync Cloud Again</>,
+    <>{/* variation 2 */}One <b>Database</b> for Web, Mobile and Desktop</>
+];
+
+const texts = [
+    <>When a managed sync service shuts down, the local database keeps working but your realtime sync is gone. RxDB restores it: local NoSQL storage plus replication to a backend you control.</>,
+    <>RxDB is open source and backend-agnostic. Sync over HTTP, WebSocket or GraphQL to infrastructure you own, with no per-device pricing and no proprietary service that can be discontinued.</>,
+    <>Native mobile databases leave the browser behind. RxDB runs the same code in React Native, the web, Electron and Node.js, so one data layer serves every platform you ship to.</>
+];
+
+const bulletpoints = [
+    [
+        <>Realtime two-way sync restored</>,
+        <>Keep working fully offline</>,
+        <>Your backend, your rules</>,
+        <>Clear migration documentation</>
+    ],
+    [
+        <>No proprietary sync cloud</>,
+        <>No per-device pricing</>,
+        <>Open source, auditable code</>,
+        <>Backend-agnostic replication</>
+    ],
+    [
+        <>Full browser support</>,
+        <>React Native and Capacitor</>,
+        <>Electron and Node.js</>,
+        <>One API on every platform</>
+    ]
+];
+
+export default function Page() {
+    /**
+     * Render the first variation on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variation, setVariation] = useState(0);
+    useEffect(() => {
+        setVariation(getSemVariation(PAGE_ID, titles.length));
+    }, []);
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Replace Your Deprecated Mobile Sync Stack',
+            appName: 'React Native',
+            title: titles[variation],
+            text: texts[variation],
+            bulletpoints: bulletpoints[variation]
+        }
+    });
+}

--- a/orga/changelog/sem-gaencdb1-page.md
+++ b/orga/changelog/sem-gaencdb1-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaencdb1` (encrypted local database for JavaScript apps) that a/b tests 3 title, description and bulletpoint variations at `/sem/gaencdb1.html`.

--- a/orga/changelog/sem-gaencdb2-page.md
+++ b/orga/changelog/sem-gaencdb2-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaencdb2` (field-level encryption for JavaScript and TypeScript apps) that a/b tests 3 title, description and bulletpoint variations at `/sem/gaencdb2.html`.

--- a/orga/changelog/sem-gaencdb3-page.md
+++ b/orga/changelog/sem-gaencdb3-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `gaencdb3` (encrypt local app data on web and mobile) that a/b tests 3 title, description and bulletpoint variations at `/sem/gaencdb3.html`.

--- a/orga/changelog/sem-garealm1-page.md
+++ b/orga/changelog/sem-garealm1-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `garealm1` (maintained local database with realtime sync for teams migrating off deprecated mobile sync) that a/b tests 3 title, description and bulletpoint variations at `/sem/garealm1.html`.

--- a/orga/changelog/sem-garealm2-page.md
+++ b/orga/changelog/sem-garealm2-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `garealm2` (local-first JavaScript database with self-hostable sync) that a/b tests 3 title, description and bulletpoint variations at `/sem/garealm2.html`.

--- a/orga/changelog/sem-garealm3-page.md
+++ b/orga/changelog/sem-garealm3-page.md
@@ -1,0 +1,1 @@
+- Add SEM landingpage `garealm3` (replace a deprecated mobile sync stack with self-hosted RxDB replication) that a/b tests 3 title, description and bulletpoint variations at `/sem/garealm3.html`.


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (new SEM/SEO landingpages)

## Describe the problem you have without this PR

We want dedicated ad/SEO landingpages for two campaign angles, each able to a/b test its copy so conversions can be attributed to the winning variation.

This PR adds six new SEM landingpages under `docs-src/src/pages/sem/`. Each page renders the main `Home` layout through the `sem` prop and a/b tests 3 variations of the title, description and bulletpoints. The variation is picked randomly per visitor via `getSemVariation(PAGE_ID, ...)`, stored in `localStorage` so it stays stable across visits, and the chosen index is attached to the tracking event prefix for attribution.

Encryption angle (`/sem/gaencdb1.html`, `gaencdb2`, `gaencdb3`):
- `gaencdb1`: the encrypted local database for JavaScript apps
- `gaencdb2`: field-level encryption for JavaScript and TypeScript
- `gaencdb3`: encrypt local app data on web and mobile

Maintained realtime-sync angle (`/sem/garealm1.html`, `garealm2`, `garealm3`):
- `garealm1`: maintained local database with realtime sync
- `garealm2`: local-first JavaScript database with self-hostable sync
- `garealm3`: replace a deprecated mobile sync stack

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U78MKsdjhp5C8pzXHF8DNe)_