### PR TITLE
SEM landingpage must not produce a changelog entry

### DIFF
--- a/.claude/skills/create-sem-page/SKILL.md
+++ b/.claude/skills/create-sem-page/SKILL.md
@@ -48,9 +48,9 @@ Optional:
    `docs-src/src/pages/sem/<slug>.tsx`. If it does, ask before overwriting.
 2. Create `docs-src/src/pages/sem/<slug>.tsx` from the template below, filling
    in the collected values. Keep all 3 arrays the same length (3 entries).
-3. Add a changelog entry file under `orga/changelog/` (see the Changelog Rule in
-   `CLAUDE.md`), e.g. `orga/changelog/sem-<slug>-page.md` with a one line
-   description and a link to the issue or PR if available.
+3. Do NOT add a changelog entry. A SEM landingpage is neither a testcase nor a
+   FIX, so the Changelog Rule in `CLAUDE.md` does not apply. Adding one here is
+   wrong.
 4. If dependencies are installed, run `npm run check-types` and `npm run lint`
    inside the repo to verify the new page compiles. If `node_modules` is not
    installed these will fail for unrelated reasons, so it is fine to skip them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ npm run check-types
 ## Changelog Rule
 - Whenever you add a testcase or implement a FIX, add a changelog entry file under `orga/changelog/`.
 - Prefer including a link to the root issue or pull request in that changelog line.
+- Do NOT add a changelog entry for changes that are neither a testcase nor a FIX. For example, adding a SEM landingpage under `docs-src/src/pages/sem/` must not produce a changelog entry.
 
 ## Documentation Style
 - SHOULD use clear, simple language.


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS (internal skill + `CLAUDE.md` instructions)

## Describe the problem you have without this PR

The `create-sem-page` skill instructed adding a changelog entry under `orga/changelog/` for every new SEM landingpage (step 3). This is wrong: the Changelog Rule in `CLAUDE.md` only applies when you add a testcase or implement a FIX. A SEM landingpage is neither, so "Added SEM landingpage" must not produce a changelog entry.

This PR:
- Removes the changelog step from `.claude/skills/create-sem-page/SKILL.md` and replaces it with an explicit instruction not to add a changelog entry.
- Makes the exclusion explicit in the Changelog Rule in `CLAUDE.md`, using the SEM landingpage as the example.

No source code behavior changes, so no tests or typings are affected.

## Todos
- [ ] Tests (not applicable, docs/instructions only)
- [x] Documentation
- [ ] Typings (not applicable)
- [x] Changelog (intentionally none: this change is neither a testcase nor a FIX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBrBnXoEtwwBoDUPwZh2Sj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBrBnXoEtwwBoDUPwZh2Sj)_