### PR TITLE
docs: replace Cookiebot with a client-side consent banner (EU-only)

### DIFF
--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -8,6 +8,7 @@ import type { Config } from '@docusaurus/types';
 import rehypePrettyCode from 'rehype-pretty-code';
 import type { Options as RehypePrettyCodeOptions, Theme } from 'rehype-pretty-code';
 import { createCssVariablesTheme, ThemeRegistrationAny } from 'shiki';
+import { EU_EEA_REGION_CODES } from './src/theme/eu-consent';
 
 const rehypePrettyCodeOptions: RehypePrettyCodeOptions = {
     theme: createCssVariablesTheme({
@@ -26,10 +27,34 @@ const config: Config = {
     tagline: 'Realtime JavaScript Database',
     favicon: '/files/logo/logo.svg',
     headTags: [
+        /**
+         * Google Consent Mode v2 default. For EU/EEA (and UK) regions the
+         * analytics and ad storage is denied until the visitor accepts in the
+         * client-side consent banner (see src/theme/consent-manager.ts).
+         * Google detects the region server-side from the IP, so this stays
+         * accurate independent of the timezone heuristic used to decide
+         * whether the banner is shown. The commands are queued on dataLayer
+         * before the async gtag/GTM libraries boot, so the default applies to
+         * the very first hit.
+         */
+        {
+            tagName: 'script',
+            innerHTML: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('consent', 'default', {
+                    ad_storage: 'denied',
+                    ad_user_data: 'denied',
+                    ad_personalization: 'denied',
+                    analytics_storage: 'denied',
+                    wait_for_update: 500,
+                    region: ${JSON.stringify(EU_EEA_REGION_CODES)}
+                });
+                gtag('set', 'ads_data_redaction', true);
+            `.replace(/\s+/g, ' ').trim(),
+        },
         { tagName: 'meta', attributes: { name: 'theme-color', content: '#ed168f' } },
         { tagName: 'link', attributes: { rel: 'apple-touch-icon', href: '/img/apple-touch-icon.png', sizes: '180x180' } },
-        { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://consentcdn.cookiebot.com/' } },
-        { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://consent.cookiebot.com/' } },
         { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://region1.analytics.google.com/' } },
         { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://www.redditstatic.com/' } },
         { tagName: 'link', attributes: { rel: 'preconnect', href: 'https://pixel-config.reddit.com/' } },
@@ -304,21 +329,6 @@ Topic-specific documentation files:
         },
     ],
     scripts: [
-        // {
-        //   id: 'CookieDeclaration',
-        //   src: 'https://consent.cookiebot.com/c429ebbd-6e92-4150-b700-ca186e06bc7c/cd.js',
-        //   type: 'text/javascript'
-        // }
-
-        // already included via google tag manager
-        // {
-        //   id: 'Cookiebot',
-        //   src: 'https://consent.cookiebot.com/uc.js?cbid=c429ebbd-6e92-4150-b700-ca186e06bc7c',
-        //   'data-cbid': 'c429ebbd-6e92-4150-b700-ca186e06bc7c',
-        //   'data-blockingmode': 'auto',
-        //   type: 'text/javascript',
-        //   async: true
-        // },
         /*
          * Pipedrive embedded chat.
          * Disabled because people should fill out the premium form

--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -39,6 +39,7 @@ const config: Config = {
          */
         {
             tagName: 'script',
+            attributes: { type: 'text/javascript' },
             innerHTML: `
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -31,7 +31,8 @@
     "shiki": "3.19.0",
     "to-vfile": "6.1.0",
     "unified": "9.0.0",
-    "unist-util-is": "4.0.2"
+    "unist-util-is": "4.0.2",
+    "vanilla-cookieconsent": "3.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",

--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -1,6 +1,24 @@
 import { useEffect } from 'react';
 import { getTestGroupEventPrefix } from './a-b-tests';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import { isLikelyEuUser } from '../theme/eu-consent';
+
+/**
+ * Gates all tracking. EU/EEA visitors start blocked and are only unlocked
+ * by setTrackingConsent(true) once they accept via the consent banner.
+ * Everyone else is allowed from the first event, matching the previous
+ * behavior. During SSR we stay blocked (no events fire there anyway).
+ */
+let trackingConsentGranted = ExecutionEnvironment.canUseDOM
+    ? !isLikelyEuUser()
+    : false;
+
+/**
+ * Called by the consent manager once the visitor made a choice.
+ */
+export function setTrackingConsent(granted: boolean): void {
+    trackingConsentGranted = granted;
+}
 
 
 export type RedditEventType =
@@ -122,6 +140,13 @@ export function triggerTrackingEvent(
     redditSearchTerm?: string
 ) {
     if (!ExecutionEnvironment.canUseDOM) {
+        return;
+    }
+    /**
+     * Do not send anything to analytics, ad or conversion services until the
+     * visitor allowed it. For non-EU visitors this is granted by default.
+     */
+    if (!trackingConsentGranted) {
         return;
     }
     const prefix = 'event_count_';

--- a/docs-src/src/css/custom.css
+++ b/docs-src/src/css/custom.css
@@ -2784,17 +2784,71 @@ footer a:visited {
 /**
  * Theming for the client-side cookie consent banner
  * (vanilla-cookieconsent, see src/theme/consent-manager.ts).
- * Maps the library CSS variables to the RxDB brand color.
+ *
+ * The website is a dark theme, but the library ships a light default. Its
+ * stylesheet is injected at runtime (after custom.css), so we use the higher
+ * specificity selector "html #cc-main" to make sure these values win the
+ * cascade regardless of stylesheet order, and map everything to the RxDB
+ * dark palette / brand color.
  */
-#cc-main {
-    --cc-btn-primary-bg: var(--color-top);
-    --cc-btn-primary-border-color: var(--color-top);
-    --cc-btn-primary-hover-bg: var(--color-middle);
-    --cc-btn-primary-hover-border-color: var(--color-middle);
-    --cc-toggle-on-bg: var(--color-top);
-    --cc-toggle-on-knob-bg: #fff;
-    --cc-link-color: var(--color-top);
+html #cc-main {
     --cc-font-family: var(--ifm-font-family-base);
+    --cc-modal-border-radius: 12px;
+    --cc-btn-border-radius: 8px;
+
+    /* surfaces + text */
+    --cc-bg: var(--bg-color, #20293c);
+    --cc-primary-color: #ffffff;
+    --cc-secondary-color: #c7ccd6;
+    --cc-separator-border-color: rgba(255, 255, 255, 0.1);
+
+    /* primary button = brand color */
+    --cc-btn-primary-bg: var(--color-top, #ed168f);
+    --cc-btn-primary-color: #ffffff;
+    --cc-btn-primary-border-color: var(--color-top, #ed168f);
+    --cc-btn-primary-hover-bg: var(--color-middle, #b2218b);
+    --cc-btn-primary-hover-color: #ffffff;
+    --cc-btn-primary-hover-border-color: var(--color-middle, #b2218b);
+
+    /* secondary button = recessed dark surface */
+    --cc-btn-secondary-bg: var(--bg-color-dark, #0d0f18);
+    --cc-btn-secondary-color: #ffffff;
+    --cc-btn-secondary-border-color: rgba(255, 255, 255, 0.16);
+    --cc-btn-secondary-hover-bg: var(--bg-color-code, #282330);
+    --cc-btn-secondary-hover-color: #ffffff;
+    --cc-btn-secondary-hover-border-color: rgba(255, 255, 255, 0.28);
+
+    /* toggles */
+    --cc-toggle-on-bg: var(--color-top, #ed168f);
+    --cc-toggle-off-bg: #565f78;
+    --cc-toggle-on-knob-bg: #ffffff;
+    --cc-toggle-off-knob-bg: #ffffff;
+    --cc-toggle-enabled-block-bg: var(--color-top, #ed168f);
+    --cc-toggle-readonly-bg: #39415a;
+    --cc-toggle-readonly-knob-bg: #c7ccd6;
+    --cc-toggle-readonly-knob-icon-color: var(--bg-color, #20293c);
+
+    /* preferences category blocks */
+    --cc-cookie-category-block-bg: var(--bg-color-dark, #0d0f18);
+    --cc-cookie-category-block-border: rgba(255, 255, 255, 0.08);
+    --cc-cookie-category-block-hover-bg: var(--bg-color-code, #282330);
+    --cc-cookie-category-block-hover-border: rgba(255, 255, 255, 0.16);
+    --cc-cookie-category-expanded-block-bg: var(--bg-color-code, #282330);
+    --cc-cookie-category-expanded-block-hover-bg: #333044;
+
+    /* misc */
+    --cc-overlay-bg: rgba(0, 0, 0, 0.65);
+    --cc-webkit-scrollbar-bg: #39415a;
+    --cc-webkit-scrollbar-bg-hover: #565f78;
+    --cc-footer-bg: var(--bg-color-dark, #0d0f18);
+    --cc-footer-color: #c7ccd6;
+    --cc-footer-border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Links inside the banner follow the brand color. */
+html #cc-main a,
+html #cc-main .cc__link {
+    color: var(--color-top, #ed168f);
 }
 
 

--- a/docs-src/src/css/custom.css
+++ b/docs-src/src/css/custom.css
@@ -2782,62 +2782,19 @@ footer a:visited {
 }
 
 /**
- * Change stuff in cookie banner
+ * Theming for the client-side cookie consent banner
+ * (vanilla-cookieconsent, see src/theme/consent-manager.ts).
+ * Maps the library CSS variables to the RxDB brand color.
  */
-#CybotCookiebotDialogHeader {
-    display: none !important;
-}
-
-#CybotCookiebotDialog {
-    padding: 12px !important;
-    font-family: var(--ifm-font-family-monospace) !important;
-}
-
-.CybotCookiebotDialogBodyBottomWrapper {
-    margin-top: 0.5em !important;
-}
-
-#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll {
-    background-color: var(--color-top) !important;
-}
-
-#CybotCookiebotDialogBodyLevelButtonCustomize {
-    border-color: var(--color-top) !important;
-}
-
-#CybotCookiebotDialogPoweredByText {
-    display: none !important;
-}
-
-#__docusaurus {
-    position: relative;
-}
-
-/**
- * Change stuff in cookie banner
- */
-#CybotCookiebotDialogHeader {
-    display: none !important;
-}
-
-#CybotCookiebotDialog {
-    padding: 12px !important;
-}
-
-.CybotCookiebotDialogBodyBottomWrapper {
-    margin-top: 0.5em !important;
-}
-
-#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll {
-    background-color: var(--color-top) !important;
-}
-
-#CybotCookiebotDialogBodyLevelButtonCustomize {
-    border-color: var(--color-top) !important;
-}
-
-#CybotCookiebotDialogPoweredByText {
-    display: none !important;
+#cc-main {
+    --cc-btn-primary-bg: var(--color-top);
+    --cc-btn-primary-border-color: var(--color-top);
+    --cc-btn-primary-hover-bg: var(--color-middle);
+    --cc-btn-primary-hover-border-color: var(--color-middle);
+    --cc-toggle-on-bg: var(--color-top);
+    --cc-toggle-on-knob-bg: #fff;
+    --cc-link-color: var(--color-top);
+    --cc-font-family: var(--ifm-font-family-base);
 }
 
 

--- a/docs-src/src/pages/privacy.tsx
+++ b/docs-src/src/pages/privacy.tsx
@@ -87,6 +87,20 @@ export default function Privacy() {
                             Analyse- und Marketing-Dienste Cookies setzen. Cookies und Local-Storage-Einträge
                             können Sie jederzeit über die Einstellungen Ihres Browsers löschen.
                         </p>
+                        <p>
+                            Besuchern aus der EU/dem EWR wird beim ersten Aufruf ein Einwilligungsbanner
+                            angezeigt. Analyse- und Marketing-Dienste werden erst nach Ihrer Einwilligung
+                            geladen. Ihre Auswahl können Sie jederzeit ändern oder widerrufen:{' '}
+                            <a
+                                href="#"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    (window as any).rxdbShowConsentPreferences?.();
+                                }}
+                            >
+                                Cookie-Einstellungen &ouml;ffnen
+                            </a>.
+                        </p>
 
                         <h3>4. Analyse und Reichweitenmessung</h3>
                         <p>
@@ -269,6 +283,20 @@ export default function Privacy() {
                             happens locally in your browser. In addition, the analytics and marketing
                             services listed below may set cookies. You can delete cookies and local storage
                             entries at any time via your browser settings.
+                        </p>
+                        <p>
+                            Visitors from the EU/EEA are shown a consent banner on their first visit.
+                            Analytics and marketing services are only loaded after you consent. You can
+                            change or withdraw your choice at any time:{' '}
+                            <a
+                                href="#"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    (window as any).rxdbShowConsentPreferences?.();
+                                }}
+                            >
+                                Open cookie settings
+                            </a>.
                         </p>
 
                         <h3>4. Analytics and reach measurement</h3>

--- a/docs-src/src/theme/Root.tsx
+++ b/docs-src/src/theme/Root.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { AD_CLICK_STORAGE_ID, onCopy, triggerTrackingEvent } from '../components/trigger-event';
+import { AD_CLICK_STORAGE_ID, onCopy, setTrackingConsent, triggerTrackingEvent } from '../components/trigger-event';
+import { isLikelyEuUser } from './eu-consent';
+import { type ConsentState, initEuConsentBanner, updateGoogleConsent } from './consent-manager';
 import { randomNumber } from '../../../plugins/utils';
 import { IconClose } from '../components/icons/close';
 import { Button } from '../components/button';
@@ -115,6 +117,44 @@ const callToActions: CallToActionItem[] = [
 const NOTIFICATION_SPLIT_TEST_VERSION = 'B';
 const POPUP_DISABLED_IF_CLOSED_TIME = 1000 * 60 * 10; // 10 minutes
 
+/**
+ * Guards so the tracker suite and the marketing pixels are each started only
+ * once, even when the visitor changes the consent multiple times.
+ */
+let trackerSuiteStarted = false;
+let marketingPixelsLoaded = false;
+
+/**
+ * Applies a consent decision: updates Google Consent Mode, unlocks the
+ * in-app tracking guard and starts the trackers that match the granted
+ * categories. Called for every consent change and, for non-EU visitors,
+ * once with everything granted.
+ */
+function applyConsent(state: ConsentState): void {
+    updateGoogleConsent(state);
+
+    const anyTracking = state.analytics || state.marketing;
+    setTrackingConsent(anyTracking);
+
+    if (anyTracking && !trackerSuiteStarted) {
+        trackerSuiteStarted = true;
+        setTimeout(() => {
+            startAnalytics();
+            trackReturnAfter3to14Days();
+            trackCopy();
+            trackUrlChanges();
+            addCallToActionButton();
+            triggerClickEventWhenFromCode();
+            triggerClickEventWhenFromDiscord();
+        }, 0);
+    }
+
+    if (state.marketing && !marketingPixelsLoaded) {
+        marketingPixelsLoaded = true;
+        loadMarketingPixels();
+    }
+}
+
 // Default implementation, that you can customize
 export default function Root({ children }) {
     const [showPopup, setShowPopup] = useState<{
@@ -127,15 +167,20 @@ export default function Root({ children }) {
     useEffect(() => {
         // addCommunityChatButton();
         storeAdClickId();
-        setTimeout(() => {
-            startAnalytics();
-            trackReturnAfter3to14Days();
-            trackCopy();
-            trackUrlChanges();
-            addCallToActionButton();
-            triggerClickEventWhenFromCode();
-            triggerClickEventWhenFromDiscord();
-        }, 0);
+
+        /**
+         * EU/EEA visitors only get trackers after they accepted them in the
+         * consent banner. Everyone else keeps the previous behavior where
+         * everything starts right away.
+         */
+        if (isLikelyEuUser()) {
+            initEuConsentBanner(applyConsent).catch(err => {
+                console.log('# Error while starting the consent banner:');
+                console.dir(err);
+            });
+        } else {
+            applyConsent({ analytics: true, marketing: true });
+        }
 
         const showTime = location.pathname.includes('.html') ? 30 : 60;
         // const showTime = 1;
@@ -399,6 +444,62 @@ function addCommunityChatButton() {
 
 
 
+/**
+ * Loads the marketing pixels that are not aware of Google Consent Mode.
+ * Only called after the visitor granted the "marketing" category (or for
+ * non-EU visitors, where marketing is granted by default).
+ */
+function loadMarketingPixels() {
+    // reddit pixel TODO move into google tag manager
+    // @ts-ignore eslint-disable-next-line
+    (function (w, d) {
+        if (!(w as any).rdt) {
+            // @ts-ignore
+            const rdt: any = (w as any).rdt = function () {
+                // @ts-ignore
+                if (rdt.sendEvent) {
+                    rdt.sendEvent.apply(rdt, arguments);
+                } else {
+                    rdt.callQueue.push(arguments);
+                }
+            };
+            rdt.callQueue = [];
+            const t = d.createElement('script');
+            t.src = 'https://www.redditstatic.com/ads/pixel.js';
+            t.async = true;
+            const s: any = d.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(t, s);
+        }
+
+        // Initialize pixel and track page visit
+        (w as any).rdt('init', 'a2_irjdz88999o9');
+        (w as any).rdt('track', 'PageVisit');
+    })(window, document);
+    // /reddit pixel
+
+
+
+    // pipedrive chat
+    (window as any).pipedriveLeadboosterConfig = {
+        base: 'leadbooster-chat.pipedrive.com', companyId: 11404711, playbookUuid:
+            '16a8caba-6b26-4bb1-a1fa-434c4171d542', version: 2
+    }; (function () {
+        const w = window; if ((w as any).LeadBooster) {
+            console.warn('LeadBooster already exists');
+        } else {
+            (w as any).LeadBooster = {
+                q: [], on: function (n, h) {
+                    this.q.push({ t: 'o', n: n, h: h });
+                }, trigger: function (n) {
+                    this.q.push({ t: 't', n: n });
+                },
+            };
+        }
+    })();
+    // /pipedrive chat
+}
+
+
 function startAnalytics() {
     console.log('load analytics code');
 
@@ -484,57 +585,6 @@ function startAnalytics() {
     // const bc = new BroadcastChannel(DEV_MODE_EVENT_ID);
     // bc.onmessage = () => checkDevModeEvent();
     // /track dev_mode_tracking_iframe event
-
-
-    // reddit pixel TODO move into google tag manager
-    // @ts-ignore eslint-disable-next-line
-    (function (w, d) {
-        if (!(w as any).rdt) {
-            // @ts-ignore
-            const rdt: any = (w as any).rdt = function () {
-                // @ts-ignore
-                if (rdt.sendEvent) {
-                    rdt.sendEvent.apply(rdt, arguments);
-                } else {
-                    rdt.callQueue.push(arguments);
-                }
-            };
-            rdt.callQueue = [];
-            const t = d.createElement('script');
-            t.src = 'https://www.redditstatic.com/ads/pixel.js';
-            t.async = true;
-            const s: any = d.getElementsByTagName('script')[0];
-            s.parentNode.insertBefore(t, s);
-        }
-
-        // Initialize pixel and track page visit
-        (w as any).rdt('init', 'a2_irjdz88999o9');
-        (w as any).rdt('track', 'PageVisit');
-    })(window, document);
-    // /reddit pixel
-
-
-
-    // pipedrive chat
-    (window as any).pipedriveLeadboosterConfig = {
-        base: 'leadbooster-chat.pipedrive.com', companyId: 11404711, playbookUuid:
-            '16a8caba-6b26-4bb1-a1fa-434c4171d542', version: 2
-    }; (function () {
-        const w = window; if ((w as any).LeadBooster) {
-            console.warn('LeadBooster already exists');
-        } else {
-            (w as any).LeadBooster = {
-                q: [], on: function (n, h) {
-                    this.q.push({ t: 'o', n: n, h: h });
-                }, trigger: function (n) {
-                    this.q.push({ t: 't', n: n });
-                },
-            };
-        }
-    })();
-    // /pipedrive chat
-
-
 
 
 

--- a/docs-src/src/theme/consent-manager.ts
+++ b/docs-src/src/theme/consent-manager.ts
@@ -83,7 +83,7 @@ export async function initEuConsentBanner(
                     consentModal: {
                         title: 'We use cookies',
                         description:
-                            'We use cookies for analytics and advertising. You decide what we load.',
+                            'RxDB uses cookies for analytics and advertising. You decide what loads.',
                         acceptAllBtn: 'Accept all',
                         acceptNecessaryBtn: 'Reject all',
                         showPreferencesBtn: 'Manage preferences',

--- a/docs-src/src/theme/consent-manager.ts
+++ b/docs-src/src/theme/consent-manager.ts
@@ -1,0 +1,134 @@
+/**
+ * Client-side consent management, replaces the hosted Cookiebot CMP.
+ *
+ * - The banner UI comes from the fully client-side npm package
+ *   `vanilla-cookieconsent` (no external server, no cookie scanning service).
+ * - Google Analytics / Google Tag Manager are gated through Google Consent
+ *   Mode v2. The "denied" default for EU/EEA regions is set in an inline
+ *   script in docusaurus.config.ts; here we only send the "update" once the
+ *   visitor made a choice.
+ * - Trackers that are not Consent-Mode aware (Reddit pixel, Pipedrive, the
+ *   conversion worker and the gtag events) are gated in application code via
+ *   `setTrackingConsent()` in trigger-event.tsx and the marketing callback.
+ */
+
+export type ConsentState = {
+    analytics: boolean;
+    marketing: boolean;
+};
+
+/**
+ * Sends the Google Consent Mode v2 update signal. This unlocks (or keeps
+ * denied) the storage that GA4 and Google Ads use, both for the gtag script
+ * and for tags managed inside the GTM container.
+ */
+export function updateGoogleConsent(state: ConsentState): void {
+    const gtag = (window as any).gtag;
+    if (typeof gtag !== 'function') {
+        return;
+    }
+    gtag('consent', 'update', {
+        analytics_storage: state.analytics ? 'granted' : 'denied',
+        ad_storage: state.marketing ? 'granted' : 'denied',
+        ad_user_data: state.marketing ? 'granted' : 'denied',
+        ad_personalization: state.marketing ? 'granted' : 'denied',
+    });
+}
+
+/**
+ * Starts the consent banner for EU/EEA visitors and wires the callbacks.
+ * `onApply` is invoked with the current consent state on first consent,
+ * on every change and once on load if a choice was stored before.
+ *
+ * The library is imported dynamically so it stays out of the main bundle
+ * and never runs during server-side rendering.
+ */
+export async function initEuConsentBanner(
+    onApply: (state: ConsentState) => void,
+): Promise<void> {
+    const CookieConsent = await import('vanilla-cookieconsent');
+    // The library ships its own stylesheet, theming is added in custom.css.
+    await import('vanilla-cookieconsent/dist/cookieconsent.css');
+
+    const readState = (): ConsentState => ({
+        analytics: CookieConsent.acceptedCategory('analytics'),
+        marketing: CookieConsent.acceptedCategory('marketing'),
+    });
+
+    await CookieConsent.run({
+        guiOptions: {
+            consentModal: {
+                layout: 'box',
+                position: 'bottom left',
+            },
+            preferencesModal: {
+                layout: 'box',
+            },
+        },
+        categories: {
+            necessary: {
+                enabled: true,
+                readOnly: true,
+            },
+            analytics: {},
+            marketing: {},
+        },
+        onFirstConsent: () => onApply(readState()),
+        onConsent: () => onApply(readState()),
+        onChange: () => onApply(readState()),
+        language: {
+            default: 'en',
+            translations: {
+                en: {
+                    consentModal: {
+                        title: 'We use cookies',
+                        description:
+                            'RxDB uses cookies to measure and improve the website and to support our advertising. Everything the database itself does stays on your device. You decide what we may load.',
+                        acceptAllBtn: 'Accept all',
+                        acceptNecessaryBtn: 'Reject all',
+                        showPreferencesBtn: 'Manage preferences',
+                    },
+                    preferencesModal: {
+                        title: 'Cookie preferences',
+                        acceptAllBtn: 'Accept all',
+                        acceptNecessaryBtn: 'Reject all',
+                        savePreferencesBtn: 'Save preferences',
+                        closeIconLabel: 'Close',
+                        sections: [
+                            {
+                                title: 'Strictly necessary',
+                                description:
+                                    'Required for the website to function. These cannot be turned off.',
+                                linkedCategory: 'necessary',
+                            },
+                            {
+                                title: 'Analytics',
+                                description:
+                                    'Google Analytics 4 and Google Tag Manager, used to understand how the website is used so we can improve it.',
+                                linkedCategory: 'analytics',
+                            },
+                            {
+                                title: 'Marketing',
+                                description:
+                                    'Reddit Pixel, Pipedrive and Google Ads conversion measurement, used to measure and improve our advertising.',
+                                linkedCategory: 'marketing',
+                            },
+                            {
+                                title: 'More information',
+                                description:
+                                    'For details, see our <a href="/privacy">privacy policy</a>.',
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    });
+
+    /**
+     * Let the privacy page (and anyone else) reopen the settings so a given
+     * consent can be withdrawn at any time (Art. 7(3) GDPR).
+     */
+    (window as any).rxdbShowConsentPreferences = () =>
+        CookieConsent.showPreferences();
+}

--- a/docs-src/src/theme/consent-manager.ts
+++ b/docs-src/src/theme/consent-manager.ts
@@ -83,7 +83,7 @@ export async function initEuConsentBanner(
                     consentModal: {
                         title: 'We use cookies',
                         description:
-                            'RxDB uses cookies to measure and improve the website and to support our advertising. Everything the database itself does stays on your device. You decide what we may load.',
+                            'We use cookies for analytics and advertising. You decide what we load.',
                         acceptAllBtn: 'Accept all',
                         acceptNecessaryBtn: 'Reject all',
                         showPreferencesBtn: 'Manage preferences',

--- a/docs-src/src/theme/eu-consent.ts
+++ b/docs-src/src/theme/eu-consent.ts
@@ -1,0 +1,96 @@
+/**
+ * Client-side, request-free detection of visitors that are likely located
+ * in the EU/EEA (plus the UK). Used to decide whether the cookie consent
+ * banner has to be shown at all.
+ *
+ * There is no reliable way to read the visitor IP on a static site
+ * (rxdb.info is hosted on GitHub Pages, so there is no edge geo header).
+ * The browser timezone is the only geo signal that is available without a
+ * network request and without sending any personal data to a third party.
+ * It is a heuristic (a VPN or a traveler defeats it), so we err on the safe
+ * side and show the banner whenever detection fails.
+ */
+
+/**
+ * ISO 3166-1 alpha-2 codes of the EU + EEA countries (and the UK for
+ * UK-GDPR). Passed to Google Consent Mode as the `region` so that Google
+ * applies the "denied" default only to these regions, using the accurate
+ * server-side IP lookup at its own edge.
+ */
+export const EU_EEA_REGION_CODES: string[] = [
+    // EU 27
+    'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR',
+    'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK',
+    'SI', 'ES', 'SE',
+    // EEA (non-EU)
+    'IS', 'LI', 'NO',
+    // United Kingdom (UK-GDPR)
+    'GB',
+];
+
+/**
+ * IANA timezones that map to an EU/EEA (or UK) country. Used to decide
+ * whether the banner is shown in the browser.
+ */
+const EU_EEA_TIMEZONES: Set<string> = new Set([
+    // EU 27
+    'Europe/Vienna',        // AT
+    'Europe/Brussels',      // BE
+    'Europe/Sofia',         // BG
+    'Europe/Zagreb',        // HR
+    'Asia/Famagusta',       // CY
+    'Asia/Nicosia',         // CY
+    'Europe/Prague',        // CZ
+    'Europe/Copenhagen',    // DK
+    'Europe/Tallinn',       // EE
+    'Europe/Helsinki',      // FI
+    'Europe/Paris',         // FR
+    'Europe/Berlin',        // DE
+    'Europe/Busingen',      // DE
+    'Europe/Athens',        // GR
+    'Europe/Budapest',      // HU
+    'Europe/Dublin',        // IE
+    'Europe/Rome',          // IT
+    'Europe/Riga',          // LV
+    'Europe/Vilnius',       // LT
+    'Europe/Luxembourg',    // LU
+    'Europe/Malta',         // MT
+    'Europe/Amsterdam',     // NL
+    'Europe/Warsaw',        // PL
+    'Europe/Lisbon',        // PT
+    'Atlantic/Azores',      // PT
+    'Atlantic/Madeira',     // PT
+    'Europe/Bucharest',     // RO
+    'Europe/Bratislava',    // SK
+    'Europe/Ljubljana',     // SI
+    'Europe/Madrid',        // ES
+    'Atlantic/Canary',      // ES
+    'Europe/Stockholm',     // SE
+    // EEA (non-EU)
+    'Europe/Oslo',          // NO
+    'Atlantic/Reykjavik',   // IS
+    'Europe/Vaduz',         // LI
+    // United Kingdom (UK-GDPR)
+    'Europe/London',        // GB
+]);
+
+/**
+ * Returns true when the visitor is likely located in the EU/EEA (or UK),
+ * based purely on the browser timezone. Returns true (show the banner) when
+ * detection is not possible, so we never accidentally track an EU visitor
+ * without consent.
+ */
+export function isLikelyEuUser(): boolean {
+    try {
+        if (typeof Intl === 'undefined' || !Intl.DateTimeFormat) {
+            return true;
+        }
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (!timezone) {
+            return true;
+        }
+        return EU_EEA_TIMEZONES.has(timezone);
+    } catch (err) {
+        return true;
+    }
+}


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS (docs website consent handling)
- A NEW FEATURE (client-side, EU-only cookie consent)

Replaces the hosted Cookiebot CMP on the docs website with the fully client-side npm package [`vanilla-cookieconsent`](https://www.npmjs.com/package/vanilla-cookieconsent) and gates the existing trackers behind consent.

## Describe the problem you have without this PR
The docs site relied on Cookiebot, a hosted third-party Consent Management Platform (external requests to `consent.cookiebot.com`, cloud cookie scanning, paid). The goal was to move to a client-side-only solution from npm, and to only show the banner to EU users.

### What changed
- **Banner (client-side only):** `vanilla-cookieconsent` runs entirely in the browser (no external CMP server). It is imported dynamically so it stays out of the main bundle and only loads for visitors who get the banner.
- **EU-only display:** the banner is shown only to likely EU/EEA (and UK) visitors, detected from the browser timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`). This needs no network request and sends no personal data. rxdb.info is on GitHub Pages, so there is no edge geo header available; the timezone heuristic errs on the safe side (shows the banner) when detection fails. See `docs-src/src/theme/eu-consent.ts`.
- **Google Analytics / GTM gating:** Google Consent Mode v2 defaults (`denied`, `region`-scoped to EU/EEA/UK) are injected as the first head tag in `docusaurus.config.ts`. The commands are queued on `dataLayer` before the async gtag/GTM libraries boot, so the denied default applies to the first hit for EU regions. Region is detected accurately server-side by Google from the IP, independent of the timezone heuristic. On consent, a `gtag('consent','update', ...)` is sent.
- **Non-Consent-Mode trackers gated:** the Reddit pixel and Pipedrive were split out of `startAnalytics()` into `loadMarketingPixels()` and only load after the `marketing` category is granted. All `triggerTrackingEvent` calls (Reddit, gtag events, conversion worker) are gated by a `setTrackingConsent()` flag that defaults to blocked for EU visitors and granted for everyone else, matching the previous behavior for non-EU users.
- **Cleanup:** removed Cookiebot preconnects, the commented Cookiebot script entries, and the `#CybotCookiebot*` CSS overrides. Added brand-colored theming for the new banner.
- **Privacy page:** added a short note (DE + EN) that EU/EEA visitors see a consent banner and can reopen/withdraw their choice via an "open cookie settings" link.

### Files
- `docs-src/src/theme/eu-consent.ts` (new): timezone-based EU detection + region code list.
- `docs-src/src/theme/consent-manager.ts` (new): `vanilla-cookieconsent` setup + Consent Mode update.
- `docs-src/src/theme/Root.tsx`: consent orchestration; split marketing pixels out of `startAnalytics()`.
- `docs-src/src/components/trigger-event.tsx`: consent guard for all tracking events.
- `docs-src/docusaurus.config.ts`: Consent Mode default head tag; removed Cookiebot remnants.
- `docs-src/src/css/custom.css`: replaced Cybot styles with banner theming.
- `docs-src/src/pages/privacy.tsx`: consent banner note + reopen link.
- `docs-src/package.json`: added `vanilla-cookieconsent`.

## Todos
- [ ] Tests
- [x] Documentation
- [x] Typings
- [ ] Changelog

### Verification note
This branch was prepared in an environment without the docs `node_modules`, so `npm run docs:build` / `docs:serve` was not run here. Please run the docs site locally to visually confirm the banner and, once deployed, verify the Consent Mode signal in GA's DebugView. Everything else (tracker gating, EU detection, config wiring) is covered by the code changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnuj2ikuRMC56mwKmYqwY)_