### PR TITLE
docs: expire stale ad click ids before sending conversions to the worker

### DIFF
--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -36,6 +36,15 @@ const CONVERSION_WORKER_URL = 'https://rxdb-events.daniel-meyer-e90.workers.dev'
  */
 export const AD_CLICK_STORAGE_ID = 'click_id';
 
+/**
+ * Google Ads' maximum click-through conversion window is 90 days. A stored
+ * click id older than that can never be imported ("this click is too old"),
+ * and attributing a later (often organic) visit to a months-old ad click would
+ * be wrong anyway. So we ignore — and clear — stale ids instead of uploading
+ * conversions against them forever.
+ */
+const AD_CLICK_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
 function getStoredAdClickId(): { k: string; v: string; t: number; } | null {
     try {
         const raw = localStorage.getItem(AD_CLICK_STORAGE_ID);
@@ -44,6 +53,10 @@ function getStoredAdClickId(): { k: string; v: string; t: number; } | null {
         }
         const parsed = JSON.parse(raw);
         if (!parsed || !parsed.v) {
+            return null;
+        }
+        if (typeof parsed.t !== 'number' || Date.now() - parsed.t > AD_CLICK_MAX_AGE_MS) {
+            localStorage.removeItem(AD_CLICK_STORAGE_ID);
             return null;
         }
         return parsed;

--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -40,7 +40,7 @@ export const AD_CLICK_STORAGE_ID = 'click_id';
  * Google Ads' maximum click-through conversion window is 90 days. A stored
  * click id older than that can never be imported ("this click is too old"),
  * and attributing a later (often organic) visit to a months-old ad click would
- * be wrong anyway. So we ignore — and clear — stale ids instead of uploading
+ * be wrong anyway. So we ignore (and clear) stale ids instead of uploading
  * conversions against them forever.
  */
 const AD_CLICK_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## This PR contains:

A BUGFIX (docs site conversion tracking — `docs-src`).

## Describe the problem you have without this PR

`storeAdClickId()` (`docs-src/src/theme/Root.tsx`) saves the `gclid`/`gbraid`/`wbraid` from the landing URL into `localStorage` under `click_id`, and `getStoredAdClickId()` (`docs-src/src/components/trigger-event.tsx`) reads it back for **every** tracking event to attribute conversions sent to the offline-conversion worker.

The stored id **never expired**. So once a visitor arrives from an ad, `getStoredAdClickId()` keeps returning that same click id indefinitely — on every later visit, including organic return visits weeks or months later. Every one of those events is then posted to `/api/google-ads` attributed to the old click. Two concrete problems:

- Google Ads rejects the upload with **"This click is too old"** once the click is past the conversion window (observed on the live offline-conversion upload).
- Even inside the window, crediting a much-later visit to a long-past ad click is **mis-attribution** — the worker keeps uploading conversions against a click the visit had nothing to do with.

## The fix

Ignore — and clear — a stored click id once it is older than **90 days** (Google Ads' maximum click-through conversion window). After that a click can never be legitimately imported anyway, so `getStoredAdClickId()` returns `null` and removes the stale entry. The client then only ever calls the worker with a click id that can still be attributed. Also hardens against a missing/invalid timestamp.

Behaviour is unchanged for normal (fresh) ad clicks; only stale ids are dropped.

## Todos
- [ ] Tests — the change lives in `docs-src` (Docusaurus site tracking code), which has no unit-test harness in this repo (the `test/` suite covers the library, not the docs site). The fix is a small, self-contained localStorage-age guard; happy to add a test if you point me at where docs-site logic should be tested.
- [x] Documentation — inline comment explains the 90-day window and why.
- [x] Typings — unchanged (same return type).
- [ ] Changelog — N/A (docs-site tracking, not the published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018HtuEgSWKF1H2RYjupj8hF)_