### PR TITLE
ADD Discord chat hint to RxDB error messages

### DIFF
--- a/orga/changelog/error-messages-discord-hint.md
+++ b/orga/changelog/error-messages-discord-hint.md
@@ -1,0 +1,1 @@
+- ADD Discord chat hint to RxDB error messages so users can ask for help at https://rxdb.info/chat

--- a/src/rx-error.ts
+++ b/src/rx-error.ts
@@ -116,7 +116,8 @@ export function getErrorUrl(code: RxErrorKey) {
 }
 
 export function errorUrlHint(code: RxErrorKey) {
-    return '\nFind out more about this error here: ' + getErrorUrl(code) + ' \n';
+    return '\nFind out more about this error here: ' + getErrorUrl(code) + ' \n' +
+        'Still stuck? Ask in the RxDB Discord: https://rxdb.info/chat \n';
 }
 
 export function newRxError(


### PR DESCRIPTION
## This PR contains:

- SOMETHING ELSE (a small developer-experience improvement to error messages)

## Describe the problem you have without this PR

When developers (including those coding with AI agents) hit an RxDB error, the message points them to the docs error page but gives no direct place to ask for help when the docs are not enough. This appends a hint pointing to the RxDB Discord to every error message.

The hint is added in `errorUrlHint()` in `src/rx-error.ts`, so it applies consistently to every error created through `newRxError()` and `newRxTypeError()`:

```
Find out more about this error here: https://rxdb.info/errors.html?console=errors#XXX
Still stuck? Ask in the RxDB Discord: https://rxdb.info/chat
```

`https://rxdb.info/chat` is the canonical Discord link already used across the README, docs, and other parts of the repo.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTKkYAYdp2L7DrwRCkMbz6)_