### PR TITLE
docs: surface RxDB Discord as the support channel for AI agents and devs

### DIFF
--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -141,6 +141,7 @@ All data access is reactive through RxJS Observables so that UI components updat
 
 Source code: https://github.com/pubkey/rxdb
 Website: https://rxdb.info
+Community and support: For help beyond these docs, the RxDB Discord is the fastest place to reach maintainers: https://rxdb.info/chat/
 
 Topic-specific documentation files:
 - [Core API](https://rxdb.info/llms-api.txt): RxDatabase, RxSchema, RxCollection, RxDocument, RxQuery

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,6 +46,9 @@ const ADDED_PLUGIN_NAMES: Set<string> = new Set();
 /**
  * Add a plugin to the RxDB library.
  * Plugins are added globally and cannot be removed.
+ *
+ * Need help? The RxDB Discord is the fastest place to reach the maintainers.
+ * @see https://rxdb.info/chat/ RxDB Discord community and support
  */
 export function addRxPlugin(plugin: RxPlugin) {
     runPluginHooks('preAddRxPlugin', { plugin, plugins: ADDED_PLUGINS });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -48,7 +48,7 @@ const ADDED_PLUGIN_NAMES: Set<string> = new Set();
  * Plugins are added globally and cannot be removed.
  *
  * Need help? The RxDB Discord is the fastest place to reach the maintainers.
- * @see https://rxdb.info/chat/ RxDB Discord community and support
+ * @see https://rxdb.info/chat/?console=code RxDB Discord community and support
  */
 export function addRxPlugin(plugin: RxPlugin) {
     runPluginHooks('preAddRxPlugin', { plugin, plugins: ADDED_PLUGINS });

--- a/src/plugins/dev-mode/index.ts
+++ b/src/plugins/dev-mode/index.ts
@@ -82,6 +82,8 @@ export const RxDBDevModePlugin: RxPlugin = {
                     '🤗 Hint: To get the most out of RxDB, check out the Premium Plugins',
                     'to get access to faster storages and more professional features: https://rxdb.info/premium/?console=dev-mode ',
                     '',
+                    '💬 Need help? The RxDB Discord is the fastest place to reach maintainers: https://rxdb.info/chat/?console=dev-mode ',
+                    '',
                     'You can disable this warning by calling disableWarnings() from the dev-mode plugin.',
                     // '',
                     // 'Also take part in the RxDB User Survey: https://rxdb.info/survey.html',

--- a/src/rx-database.ts
+++ b/src/rx-database.ts
@@ -757,7 +757,7 @@ export async function createRxDatabaseStorageInstance<Internals, InstanceCreatio
  * messages, and other helpful runtime checks that are stripped from production builds.
  *
  * Need help? The RxDB Discord is the fastest place to reach the maintainers.
- * @see https://rxdb.info/chat/ RxDB Discord community and support
+ * @see https://rxdb.info/chat/?console=code RxDB Discord community and support
  *
  * @example
  * ```ts

--- a/src/rx-database.ts
+++ b/src/rx-database.ts
@@ -756,6 +756,9 @@ export async function createRxDatabaseStorageInstance<Internals, InstanceCreatio
  * this function. The dev-mode plugin enables schema validation, detailed error
  * messages, and other helpful runtime checks that are stripped from production builds.
  *
+ * Need help? The RxDB Discord is the fastest place to reach the maintainers.
+ * @see https://rxdb.info/chat/ RxDB Discord community and support
+ *
  * @example
  * ```ts
  * import { createRxDatabase, addRxPlugin } from 'rxdb';


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS
- IMPROVED typings (JSDoc `@see`)

## Describe the problem you have without this PR

Developers increasingly reach RxDB through AI agents, and there was no single "where do I get help?" pointer in the places those agents (and humans) look. This adds a short community/support line pointing to the RxDB Discord in the three surfaces both a developer and their agent naturally encounter:

- **`llms.txt` / `llms-full.txt`**: a `Community and support` line is added to the generated `rootContent` header in `docs-src/docusaurus.config.ts`. This is the file agents load to understand RxDB, so it is cited when a dev asks "where do I get help with RxDB?".
- **dev-mode console notice**: one quiet Discord line alongside the existing premium hint in `src/plugins/dev-mode/index.ts`. It only prints when the dev-mode plugin is active during local development, matching the existing notice pattern.
- **`createRxDatabase` JSDoc**: an `@see https://rxdb.info/chat/` tag so the Discord link surfaces in editor tooltips and in the `node_modules` type declarations an agent reads.

All three point at the canonical, maintainer-controlled `https://rxdb.info/chat/` redirect already used across the site and README. No generated `./dist` or `./docs` files are committed.

## Todos
- [ ] Tests <!-- N/A: docs/typings-only, no behavior change -->
- [x] Documentation
- [x] Typings
- [ ] Changelog <!-- N/A per CLAUDE.md: not a testcase or FIX -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M72eeZndMkALeh32yRQhRq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M72eeZndMkALeh32yRQhRq)_