### PR TITLE
docs: capture docs writing style in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,35 @@
 - MUST format FAQ sections using HTML `<details>` and `<summary>` tags. Ensure there is an empty line before and after the inner markdown content so it parses correctly.
 - SHOULD try to use components from the `docs-src/src/components` folder when writing docs.
 
+### Page Structure and Voice (analyzed from existing docs)
+
+The rules above are word-level constraints. The following patterns describe how existing docs pages in `docs-src/docs/` are actually structured and written. New pages SHOULD match them.
+
+**Page structure**
+- Start every page with YAML frontmatter containing `title`, `slug` (ends in `.html`), `description` (one or two SEO-oriented sentences), and `image` (`/headers/<name>.jpg`).
+- Open the body with a plain-language sentence that defines what the thing is and which problem it solves, before going into detail.
+- Use descriptive, benefit-oriented section headings ("Multi-tab usage just works", "Latency is more important than bandwidth") instead of generic labels.
+- End longer pages with a "Next steps" section that links to further docs, the example repositories, the Discord chat, the GitHub repo, and the 👑 Premium package.
+
+**Voice and sentences**
+- Write in second person ("you can", "you have to"). Use "we" for step-by-step tutorials ("here we'll learn", "now we have an RxCollection").
+- Keep sentences short and direct. Mix short statements with medium explanatory ones.
+- Explain a new concept by comparing it to a familiar one ("similar to an SQL table", "works like git").
+- Bold the key term or phrase the first time it matters (`**realtime**`, `**share the state**`).
+
+**Linking and terminology**
+- Link generously. On first mention, link each RxDB concept (RxDatabase, RxCollection, RxDocument, RxStorage, replication) to its own docs page with a relative link like `./rx-collection.md`.
+- Mark premium-only features with the 👑 emoji and link to `/premium/`.
+
+**Code examples**
+- Follow a short explanation with a minimal, runnable code block. Annotate the language (`ts`, `bash`).
+- Keep imports explicit so a reader can copy and run the example.
+
+**Components** (from `docs-src/src/components`)
+- Use `<HeadlineWithIcon h1 icon={...}>` for the page h1 with a matching icon component from `docs-src/src/components/icons`.
+- Use `<Steps>` for sequential tutorials, `<Tabs>` for alternative options (storages, frameworks, replication targets), and `<details>`/`<summary>` for FAQs.
+- Use `<RxdbLogo />` and other existing components instead of raw markup where one fits.
+
 
 
 ## Development Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,32 @@ npm run check-types
 - Review your response and ensure no em dashes.
 - MUST format FAQ sections using HTML `<details>` and `<summary>` tags. Ensure there is an empty line before and after the inner markdown content so it parses correctly.
 - SHOULD try to use components from the `docs-src/src/components` folder when writing docs.
+
+### Page Structure and Voice (analyzed from existing docs)
+
+The rules above are word-level constraints. The following patterns describe how existing docs pages in `docs-src/docs/` are actually structured and written. New pages SHOULD match them.
+
+**Page structure**
+- Start every page with YAML frontmatter containing `title`, `slug` (ends in `.html`), `description` (one or two SEO-oriented sentences), and `image` (`/headers/<name>.jpg`).
+- Open the body with a plain-language sentence that defines what the thing is and which problem it solves, before going into detail.
+- Use descriptive, benefit-oriented section headings ("Multi-tab usage just works", "Latency is more important than bandwidth") instead of generic labels.
+- End longer pages with a "Next steps" section that links to further docs, the example repositories, the Discord chat, the GitHub repo, and the 👑 Premium package.
+
+**Voice and sentences**
+- Write in second person ("you can", "you have to"). Use "we" for step-by-step tutorials ("here we'll learn", "now we have an RxCollection").
+- Keep sentences short and direct. Mix short statements with medium explanatory ones.
+- Explain a new concept by comparing it to a familiar one ("similar to an SQL table", "works like git").
+- Bold the key term or phrase the first time it matters (`**realtime**`, `**share the state**`).
+
+**Linking and terminology**
+- Link generously. On first mention, link each RxDB concept (RxDatabase, RxCollection, RxDocument, RxStorage, replication) to its own docs page with a relative link like `./rx-collection.md`.
+- Mark premium-only features with the 👑 emoji and link to `/premium/`.
+
+**Code examples**
+- Follow a short explanation with a minimal, runnable code block. Annotate the language (`ts`, `bash`).
+- Keep imports explicit so a reader can copy and run the example.
+
+**Components** (from `docs-src/src/components`)
+- Use `<HeadlineWithIcon h1 icon={...}>` for the page h1 with a matching icon component from `docs-src/src/components/icons`.
+- Use `<Steps>` for sequential tutorials, `<Tabs>` for alternative options (storages, frameworks, replication targets), and `<details>`/`<summary>` for FAQs.
+- Use `<RxdbLogo />` and other existing components instead of raw markup where one fits.


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS (agent guidance only, no changes to `docs-src/` content)

## Describe the problem you have without this PR

The existing "Documentation Style" section in `CLAUDE.md` and `AGENTS.md` only listed word-level constraints (words to avoid, em dash rules, FAQ formatting). It did not describe the actual structure and voice used across the pages in `docs-src/docs/`, so an agent writing a new docs page had no guidance on how the pages are really put together.

I read a sample of existing docs pages (`quickstart.md`, `overview.md`, `rx-storage.md`, `offline-first.md`, `replication.md`) and analyzed the recurring patterns. I added a new "Page Structure and Voice" subsection to both files covering:

- **Page structure**: frontmatter fields (`title`, `slug`, `description`, `image`), the plain-language opening sentence, benefit-oriented section headings, and the closing "Next steps" section.
- **Voice and sentences**: second person for instructions, "we" for tutorials, short direct sentences, familiar-concept comparisons, bold for key terms.
- **Linking and terminology**: linking each RxDB concept to its own page on first mention, marking premium features with 👑 and `/premium/`.
- **Code examples**: minimal runnable blocks with explicit imports and language annotations.
- **Components**: `<HeadlineWithIcon>`, `<Steps>`, `<Tabs>`, `<details>`/`<summary>`, `<RxdbLogo />` from `docs-src/src/components`.

## Todos
- [ ] Tests (not applicable, docs/agent-guidance only)
- [x] Documentation
- [ ] Typings (not applicable)
- [ ] Changelog (not applicable, not a testcase or FIX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T37JMkxwqLvPU3PbEmSNtF

---
_Generated by [Claude Code](https://claude.ai/code/session_01T37JMkxwqLvPU3PbEmSNtF)_