### PR TITLE
docs: post conversion events to neutral worker slugs (ad-block safe)

### DIFF
--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -89,21 +89,24 @@ function postToWorker(path: string, payload: any) {
 }
 
 /**
- * Sends every tracking event to the conversion worker:
- * - to /api/google-ads when an ad click id is stored, so Google Ads can
- *   import the event as an offline conversion (which event names count, and
- *   whether they are primary or secondary, is decided in Google Ads by which
- *   conversion actions exist),
- * - to /api/google-analytics when no google-analytics cookie exists (gtag
- *   blocked or never loaded), so the worker forwards the event to the GA4
- *   Measurement Protocol. Users with a _ga cookie already report via gtag;
- *   skipping them here prevents double counting.
+ * Sends every tracking event to the conversion worker. The paths are neutral
+ * slugs (/api/gads, /api/glytics) on purpose: the worker is on a workers.dev
+ * URL, so the path is the only thing an ad blocker can match, and the literal
+ * strings "google-ads"/"google-analytics" are exactly what blocklists look
+ * for, which would drop these beacons for the ad-blocking part of our
+ * audience (the users this worker exists to recover).
+ * - to /api/gads when an ad click id is stored, so Google Ads can import the
+ *   event as an offline conversion,
+ * - to /api/glytics when no google-analytics cookie exists (gtag blocked or
+ *   never loaded), so the worker forwards the event to the GA4 Measurement
+ *   Protocol. Users with a _ga cookie already report via gtag; skipping them
+ *   here prevents double counting.
  */
 function sendToConversionWorker(type: string, value: number) {
     try {
         const adClick = getStoredAdClickId();
         if (adClick) {
-            postToWorker('/api/google-ads', {
+            postToWorker('/api/gads', {
                 type,
                 value,
                 clid: adClick.v,
@@ -111,7 +114,7 @@ function sendToConversionWorker(type: string, value: number) {
             });
         }
         if (!document.cookie.includes('_ga=')) {
-            postToWorker('/api/google-analytics', {
+            postToWorker('/api/glytics', {
                 type,
                 value,
                 cid: getOrMintClientId(),


### PR DESCRIPTION
## This PR contains:

A BUGFIX (docs-site conversion tracking — `docs-src`).

## Describe the problem you have without this PR

The conversion worker runs on a **`workers.dev`** URL (rxdb.info stays on INWX and can't be a first-party Cloudflare route), so the **URL path is the only surface an ad blocker can match**. The client currently posts to:

```
/api/google-ads
/api/google-analytics
```

Those paths contain the literal substrings **`google-ads`** and **`google-analytics`** — exactly what ad-block lists (EasyPrivacy etc.) match, and many rules match a substring **regardless of domain**. So for the ad-blocking part of our developer audience — the very users this worker exists to recover — the beacon can be dropped purely because of the path name. That silently defeats the ad-block-proofing.

## The fix

Post to neutral slugs instead:

| before | after |
|---|---|
| `/api/google-ads` | `/api/gads` |
| `/api/google-analytics` | `/api/glytics` |

No behavior change otherwise — same payloads, same conditions.

⚠️ **Deploy ordering:** the worker must accept the new slugs before this ships. It already does — the worker adds `/api/gads` + `/api/glytics` and keeps the old paths as **aliases** (in the private `rxdb-internals` repo), so there's no window where beacons 404. Just deploy the worker first, then this.

## Todos
- [ ] Tests — `docs-src` (Docusaurus site tracking) has no unit-test harness here (the `test/` suite covers the library). Change is a two-line path rename; worker-side has unit tests for both new slugs and the old aliases.
- [x] Documentation — inline comment explains why the slugs are neutral.
- [x] Typings — unchanged.
- [ ] Changelog — N/A (docs-site tracking, not the published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018HtuEgSWKF1H2RYjupj8hF)_