### PR TITLE
docs: add "Best IndexedDB Wrapper" and "IndexedDB Sync" articles

### DIFF
--- a/docs-src/docs/articles/best-indexeddb-wrapper.md
+++ b/docs-src/docs/articles/best-indexeddb-wrapper.md
@@ -1,0 +1,182 @@
+---
+title: Best IndexedDB Wrapper - Compare Dexie, idb, localForage, PouchDB and RxDB
+slug: best-indexeddb-wrapper.html
+description: Compare the best IndexedDB wrappers for JavaScript. Features, performance, and a feature table for Dexie, idb, localForage, PouchDB, LokiJS and RxDB.
+image: /headers/best-indexeddb-wrapper.jpg
+---
+
+import { PerformanceChart } from '@site/src/components/performance-chart';
+import { PERFORMANCE_DATA_BROWSER, PERFORMANCE_METRICS } from '@site/src/components/performance-data';
+
+# Best IndexedDB Wrapper
+
+[IndexedDB](../rx-storage-indexeddb.md) is the standard [browser storage](./browser-storage.md) API for structured data. Every modern browser ships it, it can store megabytes to gigabytes of JSON and binary data, and it works offline. But the native API is low-level and verbose. It relies on event callbacks, forces you to open a transaction for every read and write, and gives you nothing to query with beyond simple key ranges.
+
+That is why almost nobody uses raw IndexedDB directly. Instead you pick an **IndexedDB wrapper**: a library that hides the callbacks, adds promises, and often layers queries, schemas, and reactivity on top.
+
+This page lists the most used IndexedDB wrappers, compares their features and performance, and ends with a feature table so you can pick the right one for your app.
+
+<RxdbLogo alt="JavaScript IndexedDB wrapper" />
+
+## Why You Need a Wrapper
+
+The native IndexedDB API was designed as a building block for library authors, not for application code. Writing directly against it bites back quickly:
+
+- **Callback based**: You handle `onsuccess` and `onerror` on every request, which nests control flow and makes error handling hard.
+- **Manual transactions**: Every operation needs an explicit transaction and object store lookup, which is repetitive boilerplate.
+- **No real queries**: You can only match by key or key range. Anything like "find users older than 18 sorted by name" means iterating a cursor by hand. See [Slow IndexedDB](../slow-indexeddb.md) for why this also hurts performance.
+- **No schema**: IndexedDB stores anything. That sounds flexible until inconsistent documents crash your app at runtime.
+- **No change events**: There is no way to subscribe to data changes, so you build your own event bus to keep the UI in sync.
+
+A wrapper solves some or all of these. The wrappers below sit on a spectrum. On one end are thin promise shims that only remove the callback pain. On the other end are full databases that happen to use IndexedDB as one of several storage backends.
+
+## The IndexedDB Wrappers
+
+### Dexie.js
+
+[Dexie.js](https://dexie.org/) is the most popular minimalist wrapper. It gives you a clean promise based API, a fluent query builder (`db.users.where('age').above(18).toArray()`), and a schema declaration for indexes. It is small, well documented, and battle-tested in production.
+
+Dexie stays close to IndexedDB. It does not add its own document format on top, so writes go almost straight through to the store. It also offers `liveQuery()` for reactive results and a paid add-on for server sync.
+
+**Good for**: apps that want ergonomic IndexedDB access with indexed queries and a small footprint.
+
+**Falls short when**: you need built-in replication, conflict handling, or schema validation beyond index declarations.
+
+### idb
+
+[idb](https://github.com/jakearchibald/idb) by Jake Archibald is the thinnest wrapper of all. It is a tiny promise based mirror of the raw IndexedDB API, under 1 KB. It does not add queries, schemas, or reactivity. It only replaces the callback style with promises and async iterators.
+
+**Good for**: library authors and developers who want full control over IndexedDB with almost no abstraction and no bundle cost.
+
+**Falls short when**: you want queries, indexes as a first-class concept, or any database feature. You still write low-level store and transaction code.
+
+### localForage
+
+[localForage](https://localForage.github.io/localForage/) is a key-value wrapper with automatic fallbacks. It picks IndexedDB when available and falls back to WebSQL or localStorage. The API is `getItem`, `setItem`, `removeItem`, so it feels like localStorage but async and with larger limits.
+
+**Good for**: caching blobs or JSON values by key when you do not need queries.
+
+**Falls short when**: you need to query by anything other than the key. There are no indexes, no filtering, and no sorting. We wrote a dedicated [localForage alternative](./alternatives/localforage-alternative.md) comparison.
+
+### PouchDB
+
+[PouchDB](https://pouchdb.com/) is a full document database that runs in the browser on top of IndexedDB and syncs with [CouchDB](./alternatives/couchdb-alternative.md). It brings a document model, map/reduce views, and a proven replication protocol.
+
+PouchDB is capable but heavy. The revision tree it keeps for conflict handling grows the storage size, and its performance on large datasets in IndexedDB is a known pain point. See the [PouchDB alternative](./alternatives/pouchdb-alternative.md) page for details.
+
+**Good for**: apps that sync with a CouchDB backend and want offline replication out of the box.
+
+**Falls short when**: you care about bundle size and write performance, or you do not use CouchDB on the server.
+
+### JsStore
+
+[JsStore](https://jsstore.net/) wraps IndexedDB with an SQL-like query API and runs the work inside a Web Worker so heavy queries do not block the main thread. You write queries as JSON objects that resemble SQL statements.
+
+**Good for**: teams that prefer an SQL mental model and want queries off the main thread.
+
+**Falls short when**: you want a promise-native document API or a large ecosystem. The community is smaller than Dexie's.
+
+### LokiJS
+
+[LokiJS](https://github.com/techfort/LokiJS) is an in-memory document store with an optional IndexedDB persistence adapter. Because it queries in memory, reads are fast once loaded, but the whole dataset must fit in RAM and gets serialized to IndexedDB in bulk.
+
+LokiJS is no longer actively maintained, which matters for a dependency at the core of your app.
+
+**Good for**: small datasets that fit in memory and need fast in-memory filtering.
+
+**Falls short when**: your data grows past what fits in RAM, or you need an actively maintained library. See the [LokiJS alternative](./alternatives/lokijs-alternative.md) page.
+
+### RxDB
+
+[RxDB](https://rxdb.info/) (Reactive Database) is a local-first, NoSQL database for JavaScript applications. It runs in the browser, Node.js, Electron, React Native, Capacitor, Deno, and Bun. It uses IndexedDB (or faster storages like [OPFS](../rx-storage-opfs.md)) under the hood through its [RxStorage](../rx-storage.md) layer, and adds a full database on top.
+
+RxDB is not only a wrapper. It gives you [JSON Schema](../rx-schema.md) validation, MongoDB-style (Mango) [queries](../rx-query.md) with indexes, [reactive queries](../reactivity.md) that re-emit when data changes, [multi-tab](../rx-storage-indexeddb.md) coordination, schema [migrations](../migration-schema.md), encryption, and a [Sync Engine](../replication.md) for realtime replication with many backends.
+
+The important part for performance is the storage abstraction. RxDB does not lock you to IndexedDB. Switching storages is a configuration change, not a rewrite, so you can start on IndexedDB and move to OPFS when you need more speed.
+
+**Good for**: apps that need a real client-side database with queries, reactivity, and sync, on any JavaScript runtime.
+
+**Falls short when**: you only want to store a handful of key-value flags. For that a thin wrapper like idb or localForage is enough.
+
+## Performance Comparison
+
+Raw IndexedDB is slow, and a thin wrapper cannot make the underlying store faster. It only removes the callback overhead. So for the thin wrappers (idb, Dexie, localForage) the performance is close to native IndexedDB, plus the small cost of the abstraction.
+
+The chart below compares native IndexedDB, Dexie.js, and RxDB storages (IndexedDB-based and the OPFS storage) across common operations. Lower is better.
+
+<PerformanceChart title="Browser Storages" data={PERFORMANCE_DATA_BROWSER} metrics={PERFORMANCE_METRICS} />
+
+Two things stand out. First, Dexie's bulk insert is slower than writing straight to IndexedDB because of the extra work it does per document. Second, the [OPFS storage](../rx-storage-opfs.md) that RxDB can use beats plain IndexedDB by a wide margin on most operations, which is impossible with an IndexedDB-only wrapper. You can reproduce all of these tests in the [RxStorage performance](../rx-storage-performance.md) repo.
+
+The takeaway: if your bottleneck is IndexedDB itself, no wrapper that only wraps IndexedDB will help. You need a library that can swap the storage engine.
+
+## How to Choose
+
+- Pick **idb** when you want the smallest possible promise shim and will write store logic yourself.
+- Pick **Dexie.js** when you want ergonomic indexed queries with a small footprint and no sync.
+- Pick **localForage** when you only store values by key and want localStorage-style code.
+- Pick **PouchDB** when you sync with a CouchDB backend and accept the size and speed cost.
+- Pick **JsStore** when you prefer SQL-style queries running in a Web Worker.
+- Pick **RxDB** when you need a real database: schemas, reactive queries, multi-tab, migrations, and [replication](../replication.md), with the option to run faster storages than IndexedDB.
+
+## FAQ
+
+<details>
+<summary>What is the best IndexedDB wrapper?</summary>
+
+It depends on the job. For a thin promise layer, **[idb](https://github.com/jakearchibald/idb)** is the smallest. For indexed queries with a small footprint, **[Dexie.js](https://dexie.org/)** is the popular choice. For a full client-side database with reactivity and sync, **[RxDB](../rx-database.md)** does more than wrap IndexedDB and can run faster storages like OPFS underneath.
+
+</details>
+
+<details>
+<summary>Is Dexie.js faster than raw IndexedDB?</summary>
+
+No. Dexie sits on top of IndexedDB and adds a small overhead per operation, so bulk writes are slower than writing straight to the store. It buys you a cleaner API and query builder, not more speed. To go faster than IndexedDB you need a different storage engine such as the **[OPFS storage](../rx-storage-opfs.md)**.
+
+</details>
+
+<details>
+<summary>Do I need a wrapper or can I use IndexedDB directly?</summary>
+
+You can use it directly, but the native API is callback based, needs a transaction per operation, and has no real query support. Most teams pick a wrapper to avoid that boilerplate. See the [IndexedDB alternative](./indexeddb-alternative.md) page for a full breakdown of the raw API's problems.
+
+</details>
+
+<details>
+<summary>Which wrapper supports offline sync with a server?</summary>
+
+**PouchDB** syncs with CouchDB, and **[RxDB](../replication.md)** ships a Sync Engine that replicates with many backends including CouchDB, GraphQL, HTTP, Supabase, Firestore, and its own replication server. Thin wrappers like idb, Dexie, and localForage do not include replication.
+
+</details>
+
+<details>
+<summary>Can RxDB replace IndexedDB entirely?</summary>
+
+Yes. RxDB uses IndexedDB as one storage backend but abstracts it behind [RxStorage](../rx-storage.md). You can switch to OPFS, in-memory, SQLite, or other storages without changing your application code, which is why RxDB is not tied to IndexedDB performance.
+
+</details>
+
+## Comparison Table
+
+| Feature | idb | Dexie.js | localForage | PouchDB | LokiJS | RxDB |
+| --- | --- | --- | --- | --- | --- | --- |
+| Data model | Raw stores | Tables + indexes | Key-value | Documents | Documents (in-memory) | Documents in collections |
+| Promise API | ✅ | ✅ | ✅ | ✅ | ⚠️ callback | ✅ |
+| Queries | ❌ | ✅ fluent | ❌ | ✅ map/reduce | ✅ in-memory | ✅ Mango + indexes |
+| Schema validation | ❌ | ⚠️ indexes only | ❌ | ❌ | ❌ | ✅ JSON Schema |
+| Reactivity | ❌ | ⚠️ liveQuery | ❌ | ⚠️ changes feed | ⚠️ events | ✅ observable queries |
+| Multi-tab sync | ❌ | ⚠️ manual | ❌ | ❌ | ❌ | ✅ built in |
+| Replication | ❌ | ⚠️ paid add-on | ❌ | ✅ CouchDB | ❌ | ✅ many backends |
+| Migrations | ❌ | ✅ versioned | ❌ | ⚠️ manual | ❌ | ✅ strategies |
+| Encryption | ❌ | ⚠️ add-on | ❌ | ⚠️ plugin | ❌ | ✅ plugin |
+| Storage backends | IndexedDB | IndexedDB | IndexedDB, WebSQL, localStorage | IndexedDB | IndexedDB, memory, files | IndexedDB, OPFS, SQLite, memory, more |
+| Bundle size | Tiny | Small | Small | Large | Small | Medium |
+| Active development | Low | Active | Low | Moderate | Inactive | Active |
+
+## Follow Up
+
+- Start with the [RxDB Quickstart](../quickstart.md)
+- Read why [IndexedDB is slow](../slow-indexeddb.md) and how to work around it
+- Compare browser storage APIs in [LocalStorage vs. IndexedDB vs. OPFS](./localstorage-indexeddb-cookies-opfs-sqlite-wasm.md)
+- Learn about the [RxStorage](../rx-storage.md) layer and the [OPFS storage](../rx-storage-opfs.md)
+- Check the [RxDB code on GitHub](/code/) and leave a star ⭐

--- a/docs-src/docs/articles/best-indexeddb-wrapper.md
+++ b/docs-src/docs/articles/best-indexeddb-wrapper.md
@@ -36,11 +36,13 @@ A wrapper solves some or all of these. The wrappers below sit on a spectrum. On 
 
 [Dexie.js](https://dexie.org/) is the most popular minimalist wrapper. It gives you a clean promise based API, a fluent query builder (`db.users.where('age').above(18).toArray()`), and a schema declaration for indexes. It is small, well documented, and battle-tested in production.
 
+Keep in mind that Dexie's queries are indexed range queries, not full NoSQL-style queries. The `where()` builder works on fields you declared as indexes, with operators like `above()`, `below()`, `between()`, `anyOf()`, and `startsWith()`. Anything beyond an indexed field falls back to `.filter()`, which runs a linear in-memory scan over the matched rows. There is no Mango-style selector language with `$or`, `$gt` on arbitrary fields, or nested field conditions like RxDB has. So Dexie is ergonomic for index-driven lookups, not for rich ad-hoc queries.
+
 Dexie stays close to IndexedDB. It does not add its own document format on top, so writes go almost straight through to the store. It also offers `liveQuery()` for reactive results and a paid add-on for server sync.
 
-**Good for**: apps that want ergonomic IndexedDB access with indexed queries and a small footprint.
+**Good for**: apps that want ergonomic IndexedDB access with indexed range queries and a small footprint.
 
-**Falls short when**: you need built-in replication, conflict handling, or schema validation beyond index declarations.
+**Falls short when**: you need rich NoSQL queries, built-in replication, conflict handling, or schema validation beyond index declarations.
 
 ### idb
 
@@ -158,20 +160,20 @@ Yes. RxDB uses IndexedDB as one storage backend but abstracts it behind [RxStora
 
 ## Comparison Table
 
-| Feature | idb | Dexie.js | localForage | PouchDB | LokiJS | RxDB |
+| Feature | RxDB | idb | Dexie.js | localForage | PouchDB | LokiJS |
 | --- | --- | --- | --- | --- | --- | --- |
-| Data model | Raw stores | Tables + indexes | Key-value | Documents | Documents (in-memory) | Documents in collections |
-| Promise API | ✅ | ✅ | ✅ | ✅ | ⚠️ callback | ✅ |
-| Queries | ❌ | ✅ fluent | ❌ | ✅ map/reduce | ✅ in-memory | ✅ Mango + indexes |
-| Schema validation | ❌ | ⚠️ indexes only | ❌ | ❌ | ❌ | ✅ JSON Schema |
-| Reactivity | ❌ | ⚠️ liveQuery | ❌ | ⚠️ changes feed | ⚠️ events | ✅ observable queries |
-| Multi-tab sync | ❌ | ⚠️ manual | ❌ | ❌ | ❌ | ✅ built in |
-| Replication | ❌ | ⚠️ paid add-on | ❌ | ✅ CouchDB | ❌ | ✅ many backends |
-| Migrations | ❌ | ✅ versioned | ❌ | ⚠️ manual | ❌ | ✅ strategies |
-| Encryption | ❌ | ⚠️ add-on | ❌ | ⚠️ plugin | ❌ | ✅ plugin |
-| Storage backends | IndexedDB | IndexedDB | IndexedDB, WebSQL, localStorage | IndexedDB | IndexedDB, memory, files | IndexedDB, OPFS, SQLite, memory, more |
-| Bundle size | Tiny | Small | Small | Large | Small | Medium |
-| Active development | Low | Active | Low | Moderate | Inactive | Active |
+| Data model | Documents in collections | Raw stores | Tables + indexes | Key-value | Documents | Documents (in-memory) |
+| Promise API | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ callback |
+| Queries | ✅ Mango + indexes | ❌ | ⚠️ indexed range + `filter()` | ❌ | ✅ map/reduce | ✅ in-memory |
+| Schema validation | ✅ JSON Schema | ❌ | ⚠️ indexes only | ❌ | ❌ | ❌ |
+| Reactivity | ✅ observable queries | ❌ | ⚠️ liveQuery | ❌ | ⚠️ changes feed | ⚠️ events |
+| Multi-tab sync | ✅ built in | ❌ | ⚠️ manual | ❌ | ❌ | ❌ |
+| Replication | ✅ many backends | ❌ | ⚠️ paid add-on | ❌ | ✅ CouchDB | ❌ |
+| Migrations | ✅ strategies | ❌ | ✅ versioned | ❌ | ⚠️ manual | ❌ |
+| Encryption | ✅ plugin | ❌ | ⚠️ add-on | ❌ | ⚠️ plugin | ❌ |
+| Storage backends | IndexedDB, OPFS, SQLite, memory, more | IndexedDB | IndexedDB | IndexedDB, WebSQL, localStorage | IndexedDB | IndexedDB, memory, files |
+| Bundle size | Medium | Tiny | Small | Small | Large | Small |
+| Active development | Active | Low | Active | Low | Moderate | Inactive |
 
 ## Follow Up
 

--- a/docs-src/docs/articles/indexeddb-sync.md
+++ b/docs-src/docs/articles/indexeddb-sync.md
@@ -1,0 +1,170 @@
+---
+title: IndexedDB Sync - Replicate Browser Data Across Tabs, Devices and Servers
+slug: indexeddb-sync.html
+description: Learn how to sync IndexedDB across browser tabs, devices, and a backend server. Compare sync approaches and see how RxDB adds realtime replication.
+image: /headers/indexeddb-sync.jpg
+---
+
+# IndexedDB Sync
+
+[IndexedDB](../rx-storage-indexeddb.md) stores structured data inside a single browser, on a single device, in a single origin. That is the whole design. It has no concept of syncing that data to another tab, another device, or a backend server. As soon as your app needs the same data in more than one place, you have to build **IndexedDB sync** yourself, or use a library that ships it.
+
+This page explains what IndexedDB sync means, why the native API gives you nothing for it, the different levels of sync you might need, and how [RxDB](https://rxdb.info/) adds realtime replication on top of IndexedDB.
+
+<RxdbLogo alt="IndexedDB Sync" />
+
+## What IndexedDB Sync Means
+
+"Sync" is used for three different problems, and it helps to keep them apart:
+
+- **Multi-tab sync**: Two browser tabs of the same origin each open the same IndexedDB database. A write in one tab must become visible in the other tab.
+- **Client-server sync**: The browser holds a local copy in IndexedDB and a backend server holds the source of truth. Changes flow both ways so the client works [offline](../offline-first.md) and catches up when it reconnects.
+- **Peer-to-peer sync**: Two or more clients exchange changes directly, without a central server, over [WebRTC](../replication-webrtc.md) or a relay.
+
+Native IndexedDB solves none of these. It only stores and reads data in one place.
+
+## Why Raw IndexedDB Has No Sync
+
+IndexedDB was designed as a low-level storage building block, not a database engine. It gives you object stores, indexes, and transactions. It does not give you:
+
+- **Change events across tabs**: There is no built-in event when another tab writes to the store. You have to broadcast changes yourself.
+- **A network layer**: IndexedDB never talks to a server. It has no push, no pull, no protocol.
+- **Change tracking**: There is no log of what changed since the last sync. To replicate you need to know which documents are new or updated, and raw IndexedDB does not record that.
+- **Conflict handling**: When the same document is edited in two places while offline, something has to decide the winner. IndexedDB has no notion of document revisions.
+
+So syncing IndexedDB is not a small helper on top of the API. You end up rebuilding change feeds, a revision system, and a replication protocol. That is a database.
+
+## Multi-Tab Sync
+
+The first level of sync happens inside one browser. When a user opens your app in two tabs, both tabs read and write the same IndexedDB database, and a write in one tab should update the UI in the other.
+
+The browser primitive for this is the `BroadcastChannel` API, which sends messages between tabs of the same origin. You can send a message on every write and have other tabs re-read the changed data. Doing this by hand is error-prone, because you also have to avoid running the same background work in every tab at once.
+
+RxDB handles this out of the box. With `multiInstance: true`, writes in one tab are visible to [reactive queries](../reactivity.md) in every other tab, change events propagate over a `BroadcastChannel`, and [leader election](../leader-election.md) picks a single tab to run the server replication so you do not open one connection per tab.
+
+```ts
+import { createRxDatabase } from 'rxdb/plugins/core';
+import { getRxStorageIndexedDB } from 'rxdb-premium/plugins/storage-indexeddb';
+
+const db = await createRxDatabase({
+  name: 'mydb',
+  storage: getRxStorageIndexedDB(),
+  // Coordinate the same database across all tabs of this origin.
+  multiInstance: true
+});
+```
+
+## Client-Server Sync
+
+The second level is syncing the browser's IndexedDB copy with a backend. This is what most people mean by "IndexedDB sync". The client keeps working on the local database, and a replication process moves changes to and from the server.
+
+To do this correctly you need three things that raw IndexedDB lacks:
+
+1. **A checkpoint**: a marker of the last successfully synced state, so a reconnect only sends what changed since then instead of everything.
+2. **Change detection**: a way to list documents modified since that checkpoint. RxDB stores an internal `_meta` field and revision on every document for exactly this.
+3. **Conflict handling**: a rule for when the same document was changed on both sides. RxDB uses per-document revisions and a [conflict handler](../transactions-conflicts-revisions.md) you can customize.
+
+RxDB packages this into its [Sync Engine](../replication.md). The backend does not have to run RxDB. You can replicate against any infrastructure through the general [replication protocol](../replication.md) or one of the ready-made plugins:
+
+- [GraphQL replication](../replication-graphql.md) against a GraphQL endpoint
+- [HTTP replication](../replication-http.md) against a plain REST server on top of PostgreSQL or MongoDB
+- [CouchDB](../replication-couchdb.md), [Firestore](../replication-firestore.md), [Supabase](../replication-supabase.md), [NATS](../replication-nats.md), [WebSocket](../replication-websocket.md), and more
+
+```ts
+import { replicateRxCollection } from 'rxdb/plugins/replication';
+
+const replicationState = replicateRxCollection({
+  collection: db.todos,
+  replicationIdentifier: 'my-todos-http-replication',
+  pull: {
+    async handler(checkpointOrNull, batchSize) {
+      // Ask the server for documents changed since the last checkpoint.
+      const response = await fetch(`/api/pull?since=${/* checkpoint */ ''}`);
+      const data = await response.json();
+      return { documents: data.documents, checkpoint: data.checkpoint };
+    }
+  },
+  push: {
+    async handler(changeRows) {
+      // Send local writes to the server and return conflicts, if any.
+      const response = await fetch('/api/push', {
+        method: 'POST',
+        body: JSON.stringify(changeRows)
+      });
+      return response.json();
+    }
+  }
+});
+```
+
+Because the replication runs on top of the local database, reads and writes stay [zero-latency](./zero-latency-local-first.md). The user never waits for the network. The sync happens in the background and continues where it left off after the client goes offline and back online.
+
+## Peer-to-Peer Sync
+
+The third level skips the central server. Clients exchange changes directly with each other. RxDB supports this with [WebRTC replication](../replication-webrtc.md), where peers connect through a signaling server and then sync documents directly. This suits collaborative apps where a backend is optional or where devices on the same network should sync without the cloud.
+
+## Sync Approaches Compared
+
+There are a few ways to get sync onto IndexedDB. They differ in how much they hand you.
+
+- **Do it yourself**: Use raw IndexedDB or a thin wrapper like [Dexie.js](./best-indexeddb-wrapper.md) and write the change tracking, checkpoint, and protocol by hand. Full control, but you are building and maintaining a replication engine.
+- **A syncing document store**: [PouchDB](./alternatives/pouchdb-alternative.md) syncs IndexedDB with CouchDB. It works well but ties you to the CouchDB protocol and its revision-tree overhead grows the on-disk size.
+- **RxDB**: A local-first database that uses IndexedDB (or faster storages) and ships multi-tab, client-server, and peer-to-peer sync with pluggable backends.
+
+## Feature Comparison
+
+| Sync capability | Raw IndexedDB | Dexie.js | PouchDB | RxDB |
+| --- | --- | --- | --- | --- |
+| Multi-tab change events | ❌ | ⚠️ manual | ⚠️ manual | ✅ built in |
+| Leader election across tabs | ❌ | ❌ | ❌ | ✅ built in |
+| Client-server replication | ❌ | ⚠️ paid add-on | ✅ CouchDB only | ✅ many backends |
+| Offline then catch up | ❌ | ❌ | ✅ | ✅ |
+| Change tracking / checkpoints | ❌ | ❌ | ✅ | ✅ |
+| Conflict handling | ❌ | ❌ | ✅ revision tree | ✅ revisions + custom handler |
+| Peer-to-peer sync | ❌ | ❌ | ⚠️ via CouchDB | ✅ WebRTC |
+| Backend requirement | none | none | CouchDB | any (GraphQL, HTTP, more) |
+
+## FAQ
+
+<details>
+<summary>Can IndexedDB sync across devices on its own?</summary>
+
+No. IndexedDB is scoped to one browser on one device and has no network layer. To sync across devices you need a replication process that moves changes through a server or a peer connection. RxDB provides this with its **[Sync Engine](../replication.md)**.
+
+</details>
+
+<details>
+<summary>How do I sync IndexedDB between browser tabs?</summary>
+
+Use the `BroadcastChannel` API to notify other tabs of writes, or let a database handle it. With RxDB and `multiInstance: true`, writes in one tab reach [reactive queries](../reactivity.md) in every other tab automatically, and [leader election](../leader-election.md) keeps a single tab responsible for the server connection.
+
+</details>
+
+<details>
+<summary>Does IndexedDB sync work offline?</summary>
+
+Yes, when the database tracks changes. The client reads and writes to the local IndexedDB copy while offline, and the replication sends the queued changes once the connection returns. This is the core of the [offline-first](../offline-first.md) approach that RxDB is built for.
+
+</details>
+
+<details>
+<summary>What happens on a conflict when two devices edit the same document?</summary>
+
+The sync layer needs per-document revisions to detect that both sides changed. RxDB attaches a revision to every document and runs a [conflict handler](../transactions-conflicts-revisions.md) that you can customize, so you decide whether the local write, the remote write, or a merge wins.
+
+</details>
+
+<details>
+<summary>Do I need a special backend for IndexedDB sync?</summary>
+
+No. RxDB replicates against any infrastructure. There are plugins for [GraphQL](../replication-graphql.md), plain [HTTP](../replication-http.md), [CouchDB](../replication-couchdb.md), [Firestore](../replication-firestore.md), [Supabase](../replication-supabase.md), and others, and you can implement the [replication protocol](../replication.md) against your own server.
+
+</details>
+
+## Follow Up
+
+- Read how the [RxDB Sync Engine](../replication.md) works
+- Start with the [RxDB Quickstart](../quickstart.md)
+- Learn about [offline-first](../offline-first.md) apps and [zero-latency](./zero-latency-local-first.md) interactions
+- Compare the [best IndexedDB wrappers](./best-indexeddb-wrapper.md)
+- Check the [RxDB code on GitHub](/code/) and leave a star ⭐

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -643,6 +643,7 @@ const sidebars = {
         'articles/reactjs-storage',
         'articles/indexeddb-alternative',
         'articles/best-indexeddb-wrapper',
+        'articles/indexeddb-sync',
         'articles/generic-prompts',
         'articles/electron-sqlite',
         'articles/realm-to-rxdb-migration'

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -642,6 +642,7 @@ const sidebars = {
         'articles/json-based-database',
         'articles/reactjs-storage',
         'articles/indexeddb-alternative',
+        'articles/best-indexeddb-wrapper',
         'articles/generic-prompts',
         'articles/electron-sqlite',
         'articles/realm-to-rxdb-migration'


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS

## Describe the problem you have without this PR

There were no pages that (1) list and compare the common IndexedDB wrappers side by side, and (2) explain how to sync IndexedDB data across tabs, devices, and a server. This PR adds two articles.

**1. `docs-src/docs/articles/best-indexeddb-wrapper.md`**

- Explains why raw IndexedDB needs a wrapper (callbacks, manual transactions, no queries, no schema, no change events).
- Reviews the common wrappers with honest pros/cons: **idb**, **Dexie.js**, **localForage**, **PouchDB**, **JsStore**, **LokiJS**, and **RxDB**. Clarifies that Dexie only offers indexed range queries plus an in-memory `filter()` fallback, not full NoSQL/Mango queries.
- Compares performance with the existing `<PerformanceChart>` component and explains why an IndexedDB-only wrapper cannot beat IndexedDB while RxDB can swap in the OPFS storage.
- Ends with a feature comparison table (RxDB first column).

**2. `docs-src/docs/articles/indexeddb-sync.md`**

- Separates the three meanings of sync: multi-tab, client-server, and peer-to-peer.
- Explains why raw IndexedDB has no sync (no cross-tab events, no network layer, no change tracking, no conflict handling).
- Shows how RxDB handles each level: `multiInstance` + leader election for tabs, the Sync Engine with pluggable backends for client-server, and WebRTC for peer-to-peer, with code samples.
- Ends with a sync feature comparison table.

Both articles are registered in `docs-src/sidebars.js` under the Articles category and link densely to existing docs pages. They follow the documentation style guide (no em dashes, no banned words, US English, author voice).

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [ ] Changelog

<!-- No changelog entry: per the repo rule, changelog entries are only added for testcases or FIXes, not for new docs pages. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXEpMwCrbhdfMsEsrrEB9j