### PR TITLE
docs-src: attribute a/b tests via utm_campaign instead of the invented test-group system

### DIFF
--- a/.claude/skills/create-sem-page/SKILL.md
+++ b/.claude/skills/create-sem-page/SKILL.md
@@ -16,6 +16,15 @@ description text and the bulletpoints. A visitor is randomly assigned one of the
 visits, and the chosen variation index is attached to the tracking events so
 conversions can be attributed to it.
 
+The a/b test is keyed off the **`utm_campaign`** URL parameter: our ad final
+URLs carry the full utm parameter set, `getUtmCampaign()`
+(`docs-src/src/components/trigger-event.tsx`) persists the campaign in
+`localStorage`, and `getSemVariation()` stores the assigned variation index
+under that campaign. All sem pages of one campaign therefore show the same
+variation index, and the tracking events carry a `utm_<campaign>_v<index>`
+prefix. There is no per-page id anymore — the page file itself needs no
+tracking constant.
+
 ## Inputs to collect
 
 Ask the user for these if they are not already provided:
@@ -68,9 +77,9 @@ import { getSemVariation } from '../../components/a-b-tests';
 /**
  * SEM landingpage for "<<slug>>".
  * A/b tests 3 variations of the title, description and bulletpoints.
- * The variation is picked randomly per visitor and kept stable via localStorage.
+ * The variation is picked randomly per visitor, keyed off the utm_campaign
+ * of the ad click and kept stable via localStorage.
  */
-const PAGE_ID = '<<slug>>';
 
 const titles = [
     <>{/* variation 0 */}<<title 0>></>,
@@ -112,7 +121,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({
@@ -132,11 +141,13 @@ export default function Page() {
 ## Notes
 
 - The `id: 'gads'` field is the SEM origin id used across the existing pages;
-  keep it unless the user asks for a different tracking origin. The per page
-  a/b variation is keyed off `PAGE_ID`, not `id`.
-- `getSemVariation(pageId, variationCount)` lives in
+  keep it unless the user asks for a different tracking origin. The a/b
+  variation is keyed off the visitor's stored `utm_campaign`, not `id` and not
+  the slug.
+- `getSemVariation(variationCount)` lives in
   `docs-src/src/components/a-b-tests.tsx`. It returns `0` during server side
-  rendering, and a stored random index in the browser.
+  rendering, and a stored random index (keyed off the visitor's `utm_campaign`,
+  falling back to `organic`) in the browser.
 - Look at existing pages like `docs-src/src/pages/sem/indexeddb-database-2.tsx`
   and `docs-src/src/pages/sem/localstorage-database.tsx` for tone and wording.
 - Keep bulletpoints short (a few words). They render inside a checklist, so

--- a/.claude/skills/create-sem-page/SKILL.md
+++ b/.claude/skills/create-sem-page/SKILL.md
@@ -13,17 +13,23 @@ main landingpage (`docs-src/src/pages/index.tsx` -> `Home`) but swaps the hero
 This skill creates one new page that a/b tests 3 variations of the title, the
 description text and the bulletpoints. A visitor is randomly assigned one of the
 3 variations, the choice is stored in `localStorage` so it stays stable across
-visits, and the chosen variation index is attached to the tracking events so
+visits, and the chosen variation letter is attached to the tracking events so
 conversions can be attributed to it.
+
+Variations are identified by **stable letter keys** (`a`, `b`, `c`, …), never
+by array position: a letter keeps its meaning when variations are added or
+removed later, so stored assignments and GA events stay comparable over time.
+When adding a variation, use the next unused letter; when removing one, retire
+its letter — never re-assign a retired letter to different copy.
 
 The a/b test is keyed off the **`utm_campaign`** URL parameter: our ad final
 URLs carry the full utm parameter set, `getUtmCampaign()`
 (`docs-src/src/components/trigger-event.tsx`) persists the campaign in
-`localStorage`, and `getSemVariation()` stores the assigned variation index
+`localStorage`, and `getSemVariation()` stores the assigned variation letter
 under that campaign. All sem pages of one campaign therefore show the same
-variation index, and the tracking events carry a `utm_<campaign>_v<index>`
-prefix. There is no per-page id anymore — the page file itself needs no
-tracking constant.
+variation letter, and the tracking events carry a `utm_<campaign>_v<letter>`
+prefix (e.g. `utm_indexeddb_va_…`). There is no per-page id anymore — the page
+file itself needs no tracking constant.
 
 ## Inputs to collect
 
@@ -39,8 +45,9 @@ Ask the user for these if they are not already provided:
 4. **3 descriptions** - the hero paragraph text for each variation (JSX).
 5. **3 sets of bulletpoints** - each set is an array of short JSX items shown as
    the hero checklist. Keep the count per set consistent (the default page uses
-   4 bulletpoints). Match variations by index: title[0] pairs with
-   description[0] and bulletpoints[0], and so on.
+   4 bulletpoints). Match by letter: variation `a` gets the first title,
+   description and bulletpoint set (= Option A in the campaign file), `b` the
+   second, `c` the third.
 
 Optional:
 
@@ -81,48 +88,55 @@ import { getSemVariation } from '../../components/a-b-tests';
  * of the ad click and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}<<title 0>></>,
-    <>{/* variation 1 */}<<title 1>></>,
-    <>{/* variation 2 */}<<title 2>></>
-];
-
-const texts = [
-    <><<description 0>></>,
-    <><<description 1>></>,
-    <><<description 2>></>
-];
-
-const bulletpoints = [
-    [
-        <><<bulletpoint 0.1>></>,
-        <><<bulletpoint 0.2>></>,
-        <><<bulletpoint 0.3>></>,
-        <><<bulletpoint 0.4>></>
-    ],
-    [
-        <><<bulletpoint 1.1>></>,
-        <><<bulletpoint 1.2>></>,
-        <><<bulletpoint 1.3>></>,
-        <><<bulletpoint 1.4>></>
-    ],
-    [
-        <><<bulletpoint 2.1>></>,
-        <><<bulletpoint 2.2>></>,
-        <><<bulletpoint 2.3>></>,
-        <><<bulletpoint 2.4>></>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <><<title a>></>,
+        text: <><<description a>></>,
+        bulletpoints: [
+            <><<bulletpoint a.1>></>,
+            <><<bulletpoint a.2>></>,
+            <><<bulletpoint a.3>></>,
+            <><<bulletpoint a.4>></>
+        ]
+    },
+    b: {
+        title: <><<title b>></>,
+        text: <><<description b>></>,
+        bulletpoints: [
+            <><<bulletpoint b.1>></>,
+            <><<bulletpoint b.2>></>,
+            <><<bulletpoint b.3>></>,
+            <><<bulletpoint b.4>></>
+        ]
+    },
+    c: {
+        title: <><<title c>></>,
+        text: <><<description c>></>,
+        bulletpoints: [
+            <><<bulletpoint c.1>></>,
+            <><<bulletpoint c.2>></>,
+            <><<bulletpoint c.3>></>,
+            <><<bulletpoint c.4>></>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
@@ -130,9 +144,9 @@ export default function Page() {
             metaTitle: '<<metaTitle>>',
             // appName: '<<appName>>', // optional, remove if unused
             // iconUrl: '<<iconUrl>>', // optional, remove if unused
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }
@@ -144,10 +158,13 @@ export default function Page() {
   keep it unless the user asks for a different tracking origin. The a/b
   variation is keyed off the visitor's stored `utm_campaign`, not `id` and not
   the slug.
-- `getSemVariation(variationCount)` lives in
-  `docs-src/src/components/a-b-tests.tsx`. It returns `0` during server side
-  rendering, and a stored random index (keyed off the visitor's `utm_campaign`,
-  falling back to `organic`) in the browser.
+- `getSemVariation(variationKeys)` lives in
+  `docs-src/src/components/a-b-tests.tsx`. It takes the list of variation
+  letters (`Object.keys(variations)`) and returns one of them: the first
+  letter during server side rendering, and a stored random letter (keyed off
+  the visitor's `utm_campaign`, falling back to `organic`) in the browser. A
+  stored letter that no longer exists on the page (variation removed) gets
+  re-assigned automatically.
 - Look at existing pages like `docs-src/src/pages/sem/indexeddb-database-2.tsx`
   and `docs-src/src/pages/sem/localstorage-database.tsx` for tone and wording.
 - Keep bulletpoints short (a few words). They render inside a checklist, so

--- a/.claude/skills/create-sem-page/SKILL.md
+++ b/.claude/skills/create-sem-page/SKILL.md
@@ -19,8 +19,16 @@ conversions can be attributed to it.
 Variations are identified by **stable letter keys** (`a`, `b`, `c`, …), never
 by array position: a letter keeps its meaning when variations are added or
 removed later, so stored assignments and GA events stay comparable over time.
-When adding a variation, use the next unused letter; when removing one, retire
-its letter — never re-assign a retired letter to different copy.
+Whenever a page's variations (titles, texts, bulletpoints) get updated, two
+hard rules apply:
+
+- **Never reuse a letter.** A new variation always gets the next unused
+  letter — even if an earlier letter is free because its variation was
+  retired. GA events are attributed by letter, so re-assigning one would mix
+  two different copies under one identifier.
+- **Never delete a variation.** Retire it by **commenting it out** in the
+  `variations` object instead, so its letter and copy stay on record in the
+  file and the letter can't be re-assigned by accident.
 
 The a/b test is keyed off the **`utm_campaign`** URL parameter: our ad final
 URLs carry the full utm parameter set, `getUtmCampaign()`
@@ -90,9 +98,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/components/a-b-tests.tsx
+++ b/docs-src/src/components/a-b-tests.tsx
@@ -1,4 +1,4 @@
-import { randomNumber, randomOfArray } from '../../../plugins/utils';
+import { randomOfArray } from '../../../plugins/utils';
 import { getUtmCampaign, SEM_VARIATION_STORAGE_PREFIX } from './trigger-event';
 // import { HeroEmojiChat } from './hero-section/T4_hero_b';
 // import { ReplicationDiagram } from './replication-diagram';
@@ -105,10 +105,16 @@ export function ABTestContent(
  * randomly per visitor and stores the choice in localStorage so that the
  * visitor always sees the same variation on later visits.
  *
+ * Variations are identified by stable letter keys ('a', 'b', 'c', …), NOT by
+ * their position in an array: a letter keeps its meaning when variations are
+ * added or removed later, so stored assignments and GA events stay comparable
+ * over time. When a page adds a variation it uses the next unused letter;
+ * a removed variation's letter is retired, never re-assigned.
+ *
  * The variation is keyed off the utm_campaign of the ad click (our ad final
  * URLs carry the full utm parameter set), so every sem page of the same
- * campaign shows the same variation index and the tracking events can carry
- * it in their utm-based prefix, e.g. "utm_indexeddb_v2_join_newsletter"
+ * campaign shows the same variation letter and the tracking events can carry
+ * it in their utm-based prefix, e.g. "utm_indexeddb_va_join_newsletter"
  * (see getUtmEventPrefix() in trigger-event.tsx). Visitors without a stored
  * campaign (organic traffic) share the 'organic' key - their variation stays
  * stable too, it is just not attributed to any campaign.
@@ -118,30 +124,33 @@ export function ABTestContent(
  * that could go stale on client side navigations (docusaurus is a SPA) or
  * when a dev server keeps the module alive via hot module replacement.
  */
-export function getSemVariation(variationCount: number): number {
-    if (variationCount <= 1) {
-        return 0;
+export function getSemVariation(variationKeys: string[]): string {
+    const fallback = variationKeys[0];
+    if (variationKeys.length <= 1) {
+        return fallback;
     }
 
     // server side rendering always uses the first variation
     if (typeof localStorage === 'undefined') {
-        return 0;
+        return fallback;
     }
 
     const campaign = getUtmCampaign();
     const storageId = SEM_VARIATION_STORAGE_PREFIX + (campaign ? campaign : 'organic');
-    let index: number;
+    let key: string;
     const fromStorage = localStorage.getItem(storageId);
-    if (fromStorage !== null && !isNaN(parseInt(fromStorage, 10))) {
-        index = parseInt(fromStorage, 10);
+    if (fromStorage !== null && variationKeys.includes(fromStorage)) {
+        key = fromStorage;
     } else {
-        index = randomNumber(0, variationCount - 1);
-        localStorage.setItem(storageId, index + '');
-    }
-    if (index < 0 || index >= variationCount) {
-        index = 0;
+        /**
+         * Either no assignment yet, or the stored variation has been removed
+         * from the page since (or is a numeric index from the pre-letter
+         * system) - assign a fresh one.
+         */
+        key = randomOfArray(variationKeys);
+        localStorage.setItem(storageId, key);
     }
 
-    console.log('currentSemVariation: ' + storageId + ' -> ' + index);
-    return index;
+    console.log('currentSemVariation: ' + storageId + ' -> ' + key);
+    return key;
 }

--- a/docs-src/src/components/a-b-tests.tsx
+++ b/docs-src/src/components/a-b-tests.tsx
@@ -108,8 +108,11 @@ export function ABTestContent(
  * Variations are identified by stable letter keys ('a', 'b', 'c', …), NOT by
  * their position in an array: a letter keeps its meaning when variations are
  * added or removed later, so stored assignments and GA events stay comparable
- * over time. When a page adds a variation it uses the next unused letter;
- * a removed variation's letter is retired, never re-assigned.
+ * over time. The rules when a page's variations get updated:
+ * - a new variation always gets the next unused letter - letters are NEVER
+ *   reused for different copy,
+ * - a variation is never deleted from the page file - it gets commented out
+ *   instead, so its letter and copy stay on record.
  *
  * The variation is keyed off the utm_campaign of the ad click (our ad final
  * URLs carry the full utm parameter set), so every sem page of the same

--- a/docs-src/src/components/a-b-tests.tsx
+++ b/docs-src/src/components/a-b-tests.tsx
@@ -1,4 +1,5 @@
 import { randomNumber, randomOfArray } from '../../../plugins/utils';
+import { getUtmCampaign, SEM_VARIATION_STORAGE_PREFIX } from './trigger-event';
 // import { HeroEmojiChat } from './hero-section/T4_hero_b';
 // import { ReplicationDiagram } from './replication-diagram';
 // import { ScrollToSection, SemPage } from '../pages';
@@ -98,42 +99,26 @@ export function ABTestContent(
 }
 
 
-export function getTestGroupEventPrefix() {
-    const has = localStorage.getItem(TEST_GROUP_STORAGE_ID);
-    if (!has) {
-        return false;
-    } else {
-        const tg = getTestGroup();
-        return [
-            'abt',
-            CURRENT_TEST_RUN.id,
-            Object.keys(CURRENT_TEST_RUN).length > 1 ? 'V:' + tg.variation : undefined,
-            'O:' + tg.originId + (semVariation ? '-' + semVariation.index : ''),
-            'D:' + tg.deviceType,
-        ]
-            .filter(v => !!v)
-            .join('_');
-    }
-}
-
 /**
  * SEM landingpages a/b test multiple sets of title, text and
  * bulletpoints on the same page. getSemVariation() picks one variation
  * randomly per visitor and stores the choice in localStorage so that the
  * visitor always sees the same variation on later visits.
- * The chosen index is appended to the origin id of the tracking event
- * prefix (see getTestGroupEventPrefix), e.g. "O:gads-2", so that
- * conversions can be attributed to the variation.
  *
- * localStorage is the single source of truth for the assigned variation.
- * The in-memory semVariation value only mirrors what is stored, it must
- * not short-circuit the storage lookup. Otherwise clearing localStorage
- * would have no effect until a full page reload resets the module state,
- * which is not the case on client side navigations (docusaurus is a SPA)
- * or when a dev server keeps the module alive via hot module replacement.
+ * The variation is keyed off the utm_campaign of the ad click (our ad final
+ * URLs carry the full utm parameter set), so every sem page of the same
+ * campaign shows the same variation index and the tracking events can carry
+ * it in their utm-based prefix, e.g. "utm_indexeddb_v2_join_newsletter"
+ * (see getUtmEventPrefix() in trigger-event.tsx). Visitors without a stored
+ * campaign (organic traffic) share the 'organic' key - their variation stays
+ * stable too, it is just not attributed to any campaign.
+ *
+ * localStorage is the single source of truth for the assigned variation -
+ * the event prefix reads it back directly, so there is no in-memory state
+ * that could go stale on client side navigations (docusaurus is a SPA) or
+ * when a dev server keeps the module alive via hot module replacement.
  */
-let semVariation: { pageId: string; index: number; } | undefined;
-export function getSemVariation(pageId: string, variationCount: number): number {
+export function getSemVariation(variationCount: number): number {
     if (variationCount <= 1) {
         return 0;
     }
@@ -143,7 +128,8 @@ export function getSemVariation(pageId: string, variationCount: number): number 
         return 0;
     }
 
-    const storageId = 'sem-variation-' + pageId;
+    const campaign = getUtmCampaign();
+    const storageId = SEM_VARIATION_STORAGE_PREFIX + (campaign ? campaign : 'organic');
     let index: number;
     const fromStorage = localStorage.getItem(storageId);
     if (fromStorage !== null && !isNaN(parseInt(fromStorage, 10))) {
@@ -156,7 +142,6 @@ export function getSemVariation(pageId: string, variationCount: number): number 
         index = 0;
     }
 
-    semVariation = { pageId, index };
-    console.log('currentSemVariation: ' + pageId + ' -> ' + index);
+    console.log('currentSemVariation: ' + storageId + ' -> ' + index);
     return index;
 }

--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { getTestGroupEventPrefix } from './a-b-tests';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import { isLikelyEuUser } from '../theme/eu-consent';
 
@@ -89,6 +88,68 @@ function getSessionId(): string {
     } catch (err) {
         return Math.floor(Date.now() / 1000) + '';
     }
+}
+
+/**
+ * Our ad final URLs carry the full utm parameter set
+ * (utm_source/medium/campaign/content/term), see the campaign generator in the
+ * internal repo. The utm_campaign value is persisted here so that later events
+ * of the same visitor can still be attributed to the campaign, and so the SEM
+ * landing pages can key their a/b-test variation off it
+ * (getSemVariation() in a-b-tests.tsx).
+ */
+export const UTM_CAMPAIGN_STORAGE_ID = 'utm_campaign';
+/**
+ * localStorage key prefix under which getSemVariation() stores the assigned
+ * landing-page variation index, keyed by the utm_campaign value.
+ */
+export const SEM_VARIATION_STORAGE_PREFIX = 'sem-variation-';
+
+/**
+ * Returns the current utm_campaign: from the URL when present (persisting it,
+ * last touch wins - like storeAdClickId()), otherwise from localStorage.
+ * Reading the URL first matters because a landing page's own effects run
+ * before the Root component's effects, so the sem pages cannot rely on the
+ * value having been stored already.
+ */
+export function getUtmCampaign(): string | null {
+    if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+        return null;
+    }
+    try {
+        const fromUrl = new URLSearchParams(location.search).get('utm_campaign');
+        if (fromUrl) {
+            localStorage.setItem(UTM_CAMPAIGN_STORAGE_ID, fromUrl);
+            return fromUrl;
+        }
+        return localStorage.getItem(UTM_CAMPAIGN_STORAGE_ID);
+    } catch (err) {
+        return null;
+    }
+}
+
+/**
+ * Prefix for the per-campaign a/b-test events, built from the stored
+ * utm_campaign plus the sem-page variation index (when one was assigned).
+ * This replaced the old invented test-group system (getTestGroupEventPrefix).
+ * GA4 event names only allow letters, digits and underscores and are capped
+ * at 40 chars total, so the campaign part is sanitized and truncated to keep
+ * prefix + '_' + event type within the limit.
+ */
+function getUtmEventPrefix(): string | false {
+    const campaign = getUtmCampaign();
+    if (!campaign) {
+        return false;
+    }
+    let prefix = 'utm_' + campaign
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .substring(0, 12);
+    const semVariation = localStorage.getItem(SEM_VARIATION_STORAGE_PREFIX + campaign);
+    if (semVariation !== null) {
+        prefix += '_v' + semVariation;
+    }
+    return prefix;
 }
 
 function postToWorker(path: string, payload: any) {
@@ -217,11 +278,11 @@ export function triggerTrackingEvent(
             );
 
             // trigger also an event for the A/B Testing
-            const testGroupPrefix = getTestGroupEventPrefix();
-            if (testGroupPrefix) {
+            const utmPrefix = getUtmEventPrefix();
+            if (utmPrefix) {
                 (window as any).gtag(
                     'event',
-                    testGroupPrefix + '_' + type,
+                    utmPrefix + '_' + type,
                     {
                         value: 0,
                         currency: 'EUR'

--- a/docs-src/src/components/trigger-event.tsx
+++ b/docs-src/src/components/trigger-event.tsx
@@ -101,7 +101,7 @@ function getSessionId(): string {
 export const UTM_CAMPAIGN_STORAGE_ID = 'utm_campaign';
 /**
  * localStorage key prefix under which getSemVariation() stores the assigned
- * landing-page variation index, keyed by the utm_campaign value.
+ * landing-page variation letter, keyed by the utm_campaign value.
  */
 export const SEM_VARIATION_STORAGE_PREFIX = 'sem-variation-';
 
@@ -130,7 +130,9 @@ export function getUtmCampaign(): string | null {
 
 /**
  * Prefix for the per-campaign a/b-test events, built from the stored
- * utm_campaign plus the sem-page variation index (when one was assigned).
+ * utm_campaign plus the sem-page variation letter (when one was assigned),
+ * e.g. "utm_indexeddb_va". The letter is a stable variation id (see
+ * getSemVariation() in a-b-tests.tsx), not an array position.
  * This replaced the old invented test-group system (getTestGroupEventPrefix).
  * GA4 event names only allow letters, digits and underscores and are capped
  * at 40 chars total, so the campaign part is sanitized and truncated to keep

--- a/docs-src/src/pages/sem/gaawsds1.tsx
+++ b/docs-src/src/pages/sem/gaawsds1.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaawsds1.tsx
+++ b/docs-src/src/pages/sem/gaawsds1.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}The <b>Migration Path</b> When Your Sync Gets <b>Deprecated</b></>,
-    <>{/* variation 2 */}<b>Migrate Once</b>, Never Get <b>Sunset</b> Again</>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-    <>Your offline sync engine is being sunset, but your app still needs local data and realtime sync. RxDB is open source and actively developed: store data on the device, query it instantly and replicate to the backend you already run.</>,
-    <>RxDB runs inside your app and syncs to infrastructure you control. No vendor can deprecate your data layer: the core is open source, backend-agnostic and runs in browsers, mobile apps and desktop.</>
-];
-
-const bulletpoints = [
-    [
-        <>Build apps that work offline</>,
-        <>Sync with any Backend</>,
-        <>Observable Realtime Queries</>,
-        <>All JavaScript Runtimes Supported</>
-    ],
-    [
-        <>Actively developed, no sunset risk</>,
-        <>Keep your existing GraphQL backend</>,
-        <>Works offline by default</>,
-        <>Free and open source</>
-    ],
-    [
-        <>You own the stack, no lock-in</>,
-        <>Backend-agnostic replication</>,
-        <>Browser, mobile and desktop</>,
-        <>Apache-2.0 licensed core</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <>The <b>Migration Path</b> When Your Sync Gets <b>Deprecated</b></>,
+        text: <>Your offline sync engine is being sunset, but your app still needs local data and realtime sync. RxDB is open source and actively developed: store data on the device, query it instantly and replicate to the backend you already run.</>,
+        bulletpoints: [
+            <>Actively developed, no sunset risk</>,
+            <>Keep your existing GraphQL backend</>,
+            <>Works offline by default</>,
+            <>Free and open source</>
+        ]
+    },
+    c: {
+        title: <><b>Migrate Once</b>, Never Get <b>Sunset</b> Again</>,
+        text: <>RxDB runs inside your app and syncs to infrastructure you control. No vendor can deprecate your data layer: the core is open source, backend-agnostic and runs in browsers, mobile apps and desktop.</>,
+        bulletpoints: [
+            <>You own the stack, no lock-in</>,
+            <>Backend-agnostic replication</>,
+            <>Browser, mobile and desktop</>,
+            <>Apache-2.0 licensed core</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Migrate Off Deprecated Offline Sync',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaawsds1.tsx
+++ b/docs-src/src/pages/sem/gaawsds1.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaawsds1';
 
 const titles = [
     <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaawsds2.tsx
+++ b/docs-src/src/pages/sem/gaawsds2.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Reactive</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}A <b>Local Database</b> That Syncs With Your <b>GraphQL</b> API</>,
-    <>{/* variation 2 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, React Native, Angular or Vue components on every data change, online or offline.</>,
-    <>RxDB replicates over GraphQL, HTTP or WebSocket, so you keep the backend you already run. Offline writes queue locally and sync with conflict handling when the connection returns.</>,
-    <>RxDB's core is free and open source. Replication works against your own servers: no proprietary cloud, no metered realtime billing, no vendor deciding when your data layer dies.</>
-];
-
-const bulletpoints = [
-    [
-        <>First-class TypeScript support</>,
-        <>Bindings for major frameworks</>,
-        <>JSON schema validation</>,
-        <>Works in every JS runtime</>
-    ],
-    [
-        <>GraphQL replication built in</>,
-        <>Keep your existing backend</>,
-        <>Offline queue and conflict handling</>,
-        <>Realtime two-way sync</>
-    ],
-    [
-        <>Free, open-source core</>,
-        <>Self-hostable replication</>,
-        <>Runs on IndexedDB, OPFS or SQLite</>,
-        <>No vendor lock-in</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Reactive</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, React Native, Angular or Vue components on every data change, online or offline.</>,
+        bulletpoints: [
+            <>First-class TypeScript support</>,
+            <>Bindings for major frameworks</>,
+            <>JSON schema validation</>,
+            <>Works in every JS runtime</>
+        ]
+    },
+    b: {
+        title: <>A <b>Local Database</b> That Syncs With Your <b>GraphQL</b> API</>,
+        text: <>RxDB replicates over GraphQL, HTTP or WebSocket, so you keep the backend you already run. Offline writes queue locally and sync with conflict handling when the connection returns.</>,
+        bulletpoints: [
+            <>GraphQL replication built in</>,
+            <>Keep your existing backend</>,
+            <>Offline queue and conflict handling</>,
+            <>Realtime two-way sync</>
+        ]
+    },
+    c: {
+        title: <>An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
+        text: <>RxDB's core is free and open source. Replication works against your own servers: no proprietary cloud, no metered realtime billing, no vendor deciding when your data layer dies.</>,
+        bulletpoints: [
+            <>Free, open-source core</>,
+            <>Self-hostable replication</>,
+            <>Runs on IndexedDB, OPFS or SQLite</>,
+            <>No vendor lock-in</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Open-Source Local-First Database for JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaawsds2.tsx
+++ b/docs-src/src/pages/sem/gaawsds2.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaawsds2';
 
 const titles = [
     <>{/* variation 0 */}The <b>Reactive</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaawsds2.tsx
+++ b/docs-src/src/pages/sem/gaawsds2.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaawsds3.tsx
+++ b/docs-src/src/pages/sem/gaawsds3.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaawsds3';
 
 const titles = [
     <>{/* variation 0 */}<b>Offline Sync</b> You Can Actually <b>Debug</b></>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaawsds3.tsx
+++ b/docs-src/src/pages/sem/gaawsds3.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}<b>Offline Sync</b> You Can Actually <b>Debug</b></>,
-    <>{/* variation 1 */}<b>Realtime Sync</b> Without the <b>Metered Bill</b></>,
-    <>{/* variation 2 */}Your Offline Sync <b>Retires in 2027</b>. RxDB <b>Won't</b>.</>
-];
-
-const texts = [
-    <>Data that silently stops syncing is not a fact of life. RxDB's replication is open source and runs in your code: you can inspect it, log it and test it, with conflict resolution you define.</>,
-    <>Per-connection and per-update pricing punishes successful apps. RxDB syncs to infrastructure you already pay for, so realtime updates and always-on devices stop showing up on your cloud invoice.</>,
-    <>If your app's sync layer has an end-of-life date, the migration is coming either way. RxDB keeps the local-first model you already use: write locally, observe queries, sync in the background, even to your existing GraphQL backend.</>
-];
-
-const bulletpoints = [
-    [
-        <>Open, inspectable sync protocol</>,
-        <>Conflict resolution you control</>,
-        <>Offline writes never get lost</>,
-        <>Works the same on every platform</>
-    ],
-    [
-        <>No per-update billing</>,
-        <>No per-connection billing</>,
-        <>Self-host on your own servers</>,
-        <>Free, open-source core</>
-    ],
-    [
-        <>Same local-first programming model</>,
-        <>Keep your GraphQL backend</>,
-        <>Actively developed and maintained</>,
-        <>Migrate on your schedule, not theirs</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <><b>Offline Sync</b> You Can Actually <b>Debug</b></>,
+        text: <>Data that silently stops syncing is not a fact of life. RxDB's replication is open source and runs in your code: you can inspect it, log it and test it, with conflict resolution you define.</>,
+        bulletpoints: [
+            <>Open, inspectable sync protocol</>,
+            <>Conflict resolution you control</>,
+            <>Offline writes never get lost</>,
+            <>Works the same on every platform</>
+        ]
+    },
+    b: {
+        title: <><b>Realtime Sync</b> Without the <b>Metered Bill</b></>,
+        text: <>Per-connection and per-update pricing punishes successful apps. RxDB syncs to infrastructure you already pay for, so realtime updates and always-on devices stop showing up on your cloud invoice.</>,
+        bulletpoints: [
+            <>No per-update billing</>,
+            <>No per-connection billing</>,
+            <>Self-host on your own servers</>,
+            <>Free, open-source core</>
+        ]
+    },
+    c: {
+        title: <>Your Offline Sync <b>Retires in 2027</b>. RxDB <b>Won't</b>.</>,
+        text: <>If your app's sync layer has an end-of-life date, the migration is coming either way. RxDB keeps the local-first model you already use: write locally, observe queries, sync in the background, even to your existing GraphQL backend.</>,
+        bulletpoints: [
+            <>Same local-first programming model</>,
+            <>Keep your GraphQL backend</>,
+            <>Actively developed and maintained</>,
+            <>Migrate on your schedule, not theirs</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Reliable Offline Sync You Control',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaawsds3.tsx
+++ b/docs-src/src/pages/sem/gaawsds3.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaencdb1.tsx
+++ b/docs-src/src/pages/sem/gaencdb1.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaencdb1.tsx
+++ b/docs-src/src/pages/sem/gaencdb1.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaencdb1';
 
 const titles = [
     <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaencdb1.tsx
+++ b/docs-src/src/pages/sem/gaencdb1.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}The <b>Encrypted</b> Local Database for <b>JavaScript</b></>,
-    <>{/* variation 2 */}Your Data, <b>Encrypted</b> on the <b>Device</b></>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-    <>RxDB is a local database for JavaScript apps with AES encryption built in. Your data is encrypted before it is written to disk, stays available offline and syncs to any backend you choose.</>,
-    <>RxDB stores your app's data locally and encrypts sensitive fields before they touch storage. No plaintext at rest, no required cloud, and your app keeps working with zero network latency.</>
-];
-
-const bulletpoints = [
-    [
-        <>Build apps that work offline</>,
-        <>Sync with any Backend</>,
-        <>Observable Realtime Queries</>,
-        <>All JavaScript Runtimes Supported</>
-    ],
-    [
-        <>AES encryption at rest</>,
-        <>Works fully offline</>,
-        <>Sync with any backend</>,
-        <>Free and open source</>
-    ],
-    [
-        <>No plaintext at rest</>,
-        <>Data stays on the device</>,
-        <>Zero-latency local queries</>,
-        <>Open source and auditable</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <>The <b>Encrypted</b> Local Database for <b>JavaScript</b></>,
+        text: <>RxDB is a local database for JavaScript apps with AES encryption built in. Your data is encrypted before it is written to disk, stays available offline and syncs to any backend you choose.</>,
+        bulletpoints: [
+            <>AES encryption at rest</>,
+            <>Works fully offline</>,
+            <>Sync with any backend</>,
+            <>Free and open source</>
+        ]
+    },
+    c: {
+        title: <>Your Data, <b>Encrypted</b> on the <b>Device</b></>,
+        text: <>RxDB stores your app's data locally and encrypts sensitive fields before they touch storage. No plaintext at rest, no required cloud, and your app keeps working with zero network latency.</>,
+        bulletpoints: [
+            <>No plaintext at rest</>,
+            <>Data stays on the device</>,
+            <>Zero-latency local queries</>,
+            <>Open source and auditable</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: The Encrypted Local Database for Your App',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaencdb2.tsx
+++ b/docs-src/src/pages/sem/gaencdb2.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}<b>Field-Level Encryption</b> for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}An <b>Encrypted</b> Database You Can <b>Self-Host</b></>,
-    <>{/* variation 2 */}Fast, <b>Encrypted</b> Storage for <b>Production</b> Apps</>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript and TypeScript. Mark properties as encrypted in your JSON schema and RxDB encrypts them transparently, in the browser, React Native, Electron and Node.js.</>,
-    <>RxDB's core and its AES encryption plugin are free and open source. Replicate encrypted data to your own servers over HTTP, WebSocket or GraphQL. No proprietary cloud, no per-read pricing, no lock-in.</>,
-    <>RxDB combines encryption with the features real products need: schema validation, migrations, compression and multi-tab support. The Web Crypto based premium plugin encrypts at native browser speed.</>
-];
-
-const bulletpoints = [
-    [
-        <>Declare encrypted fields in your schema</>,
-        <>Browser, mobile and desktop</>,
-        <>First-class TypeScript support</>,
-        <>JSON schema validation</>
-    ],
-    [
-        <>Free, open-source core</>,
-        <>AES encryption plugin included</>,
-        <>Self-hostable replication</>,
-        <>No vendor lock-in</>
-    ],
-    [
-        <>Native Web Crypto performance</>,
-        <>Schema and data migrations</>,
-        <>Multi-tab out of the box</>,
-        <>Works with any framework</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <><b>Field-Level Encryption</b> for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript and TypeScript. Mark properties as encrypted in your JSON schema and RxDB encrypts them transparently, in the browser, React Native, Electron and Node.js.</>,
+        bulletpoints: [
+            <>Declare encrypted fields in your schema</>,
+            <>Browser, mobile and desktop</>,
+            <>First-class TypeScript support</>,
+            <>JSON schema validation</>
+        ]
+    },
+    b: {
+        title: <>An <b>Encrypted</b> Database You Can <b>Self-Host</b></>,
+        text: <>RxDB's core and its AES encryption plugin are free and open source. Replicate encrypted data to your own servers over HTTP, WebSocket or GraphQL. No proprietary cloud, no per-read pricing, no lock-in.</>,
+        bulletpoints: [
+            <>Free, open-source core</>,
+            <>AES encryption plugin included</>,
+            <>Self-hostable replication</>,
+            <>No vendor lock-in</>
+        ]
+    },
+    c: {
+        title: <>Fast, <b>Encrypted</b> Storage for <b>Production</b> Apps</>,
+        text: <>RxDB combines encryption with the features real products need: schema validation, migrations, compression and multi-tab support. The Web Crypto based premium plugin encrypts at native browser speed.</>,
+        bulletpoints: [
+            <>Native Web Crypto performance</>,
+            <>Schema and data migrations</>,
+            <>Multi-tab out of the box</>,
+            <>Works with any framework</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Field-Level Encryption for JavaScript Apps',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaencdb2.tsx
+++ b/docs-src/src/pages/sem/gaencdb2.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaencdb2.tsx
+++ b/docs-src/src/pages/sem/gaencdb2.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaencdb2';
 
 const titles = [
     <>{/* variation 0 */}<b>Field-Level Encryption</b> for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaencdb3.tsx
+++ b/docs-src/src/pages/sem/gaencdb3.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaencdb3.tsx
+++ b/docs-src/src/pages/sem/gaencdb3.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaencdb3';
 
 const titles = [
     <>{/* variation 0 */}Browser Storage Is <b>Not Encrypted</b>. RxDB Is.</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaencdb3.tsx
+++ b/docs-src/src/pages/sem/gaencdb3.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}Browser Storage Is <b>Not Encrypted</b>. RxDB Is.</>,
-    <>{/* variation 1 */}<b>Encrypt</b> Local Data, Keep the <b>Auditors</b> Happy</>,
-    <>{/* variation 2 */}<b>Encrypted</b> Locally, <b>Synced</b> Everywhere</>
-];
-
-const texts = [
-    <>IndexedDB and localStorage keep everything in plaintext, readable by anyone with access to the device. RxDB encrypts sensitive fields with AES before they are written, so stored data stays protected.</>,
-    <>Storing personal or sensitive data on the client? RxDB's field-level encryption keeps it encrypted at rest while your app keeps working offline, and syncs it to servers you control.</>,
-    <>Encryption should not cost you sync. RxDB encrypts fields on the device and still replicates your data in realtime to any backend, with offline queueing and conflict handling built in.</>
-];
-
-const bulletpoints = [
-    [
-        <>Encrypts data before it hits disk</>,
-        <>Password-based AES encryption</>,
-        <>Protects data on shared devices</>,
-        <>Free and open source</>
-    ],
-    [
-        <>Field-level encryption at rest</>,
-        <>Offline access preserved</>,
-        <>Sync to your own backend</>,
-        <>Helps with data-protection rules</>
-    ],
-    [
-        <>Encryption plus realtime sync</>,
-        <>Works offline by default</>,
-        <>Conflict handling included</>,
-        <>Runs on browser and mobile</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>Browser Storage Is <b>Not Encrypted</b>. RxDB Is.</>,
+        text: <>IndexedDB and localStorage keep everything in plaintext, readable by anyone with access to the device. RxDB encrypts sensitive fields with AES before they are written, so stored data stays protected.</>,
+        bulletpoints: [
+            <>Encrypts data before it hits disk</>,
+            <>Password-based AES encryption</>,
+            <>Protects data on shared devices</>,
+            <>Free and open source</>
+        ]
+    },
+    b: {
+        title: <><b>Encrypt</b> Local Data, Keep the <b>Auditors</b> Happy</>,
+        text: <>Storing personal or sensitive data on the client? RxDB's field-level encryption keeps it encrypted at rest while your app keeps working offline, and syncs it to servers you control.</>,
+        bulletpoints: [
+            <>Field-level encryption at rest</>,
+            <>Offline access preserved</>,
+            <>Sync to your own backend</>,
+            <>Helps with data-protection rules</>
+        ]
+    },
+    c: {
+        title: <><b>Encrypted</b> Locally, <b>Synced</b> Everywhere</>,
+        text: <>Encryption should not cost you sync. RxDB encrypts fields on the device and still replicates your data in realtime to any backend, with offline queueing and conflict handling built in.</>,
+        bulletpoints: [
+            <>Encryption plus realtime sync</>,
+            <>Works offline by default</>,
+            <>Conflict handling included</>,
+            <>Runs on browser and mobile</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Encrypt Local App Data on Web and Mobile',
             appName: 'Browser',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaidxdb1';
 
 const titles = [
     <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}<b>IndexedDB</b> Without the <b>Pain</b></>,
-    <>{/* variation 2 */}<b>Instant Queries</b> on <b>IndexedDB</b></>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-    <>RxDB gives you a clean NoSQL API on top of IndexedDB. No transaction boilerplate, no callback chains, just schemas, queries and observables that keep your UI in sync with your data.</>,
-    <>RxDB runs directly inside your app and answers queries with zero network latency. Your data lives in IndexedDB, stays available offline and updates your UI the moment it changes.</>
-];
-
-const bulletpoints = [
-    [
-        <>Build apps that work offline</>,
-        <>Sync with any Backend</>,
-        <>Observable Realtime Queries</>,
-        <>All JavaScript Runtimes Supported</>
-    ],
-    [
-        <>No IndexedDB boilerplate</>,
-        <>Reactive queries out of the box</>,
-        <>JSON schemas and migrations</>,
-        <>Free and open source</>
-    ],
-    [
-        <>Zero-latency local reads</>,
-        <>Works fully offline</>,
-        <>Optimized IndexedDB storage</>,
-        <>Observable realtime queries</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <><b>IndexedDB</b> Without the <b>Pain</b></>,
+        text: <>RxDB gives you a clean NoSQL API on top of IndexedDB. No transaction boilerplate, no callback chains, just schemas, queries and observables that keep your UI in sync with your data.</>,
+        bulletpoints: [
+            <>No IndexedDB boilerplate</>,
+            <>Reactive queries out of the box</>,
+            <>JSON schemas and migrations</>,
+            <>Free and open source</>
+        ]
+    },
+    c: {
+        title: <><b>Instant Queries</b> on <b>IndexedDB</b></>,
+        text: <>RxDB runs directly inside your app and answers queries with zero network latency. Your data lives in IndexedDB, stays available offline and updates your UI the moment it changes.</>,
+        bulletpoints: [
+            <>Zero-latency local reads</>,
+            <>Works fully offline</>,
+            <>Optimized IndexedDB storage</>,
+            <>Observable realtime queries</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: IndexedDB Without the Pain',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaidxdb2.tsx
+++ b/docs-src/src/pages/sem/gaidxdb2.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaidxdb2.tsx
+++ b/docs-src/src/pages/sem/gaidxdb2.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaidxdb2';
 
 const titles = [
     <>{/* variation 0 */}The <b>Reactive</b> JavaScript Database on <b>IndexedDB</b></>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaidxdb2.tsx
+++ b/docs-src/src/pages/sem/gaidxdb2.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Reactive</b> JavaScript Database on <b>IndexedDB</b></>,
-    <>{/* variation 1 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
-    <>{/* variation 2 */}From <b>Prototype</b> to <b>Production</b> on IndexedDB</>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, Angular, Vue or Svelte components on every data change, with your data stored in IndexedDB.</>,
-    <>RxDB&apos;s core is free and open source. Replication works over HTTP, WebSocket or GraphQL against your own servers. No proprietary cloud, no per-read pricing, no lock-in.</>,
-    <>RxDB adds what raw IndexedDB is missing for real products: schema validation, data migrations, encryption, compression and multi-tab handling, with a query API that scales with your app.</>
-];
-
-const bulletpoints = [
-    [
-        <>First-class TypeScript support</>,
-        <>Bindings for major frameworks</>,
-        <>JSON schema validation</>,
-        <>Sync with any backend</>
-    ],
-    [
-        <>Free, open-source core</>,
-        <>Self-hostable replication</>,
-        <>Runs on IndexedDB, OPFS or SQLite</>,
-        <>No vendor lock-in</>
-    ],
-    [
-        <>Schema and data migrations</>,
-        <>Encryption and compression</>,
-        <>Multi-tab leader election</>,
-        <>Pluggable storage adapters</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Reactive</b> JavaScript Database on <b>IndexedDB</b></>,
+        text: <>RxDB is a NoSQL database for JavaScript and TypeScript. Observable queries re-render your React, Angular, Vue or Svelte components on every data change, with your data stored in IndexedDB.</>,
+        bulletpoints: [
+            <>First-class TypeScript support</>,
+            <>Bindings for major frameworks</>,
+            <>JSON schema validation</>,
+            <>Sync with any backend</>
+        ]
+    },
+    b: {
+        title: <>An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
+        text: <>RxDB&apos;s core is free and open source. Replication works over HTTP, WebSocket or GraphQL against your own servers. No proprietary cloud, no per-read pricing, no lock-in.</>,
+        bulletpoints: [
+            <>Free, open-source core</>,
+            <>Self-hostable replication</>,
+            <>Runs on IndexedDB, OPFS or SQLite</>,
+            <>No vendor lock-in</>
+        ]
+    },
+    c: {
+        title: <>From <b>Prototype</b> to <b>Production</b> on IndexedDB</>,
+        text: <>RxDB adds what raw IndexedDB is missing for real products: schema validation, data migrations, encryption, compression and multi-tab handling, with a query API that scales with your app.</>,
+        bulletpoints: [
+            <>Schema and data migrations</>,
+            <>Encryption and compression</>,
+            <>Multi-tab leader election</>,
+            <>Pluggable storage adapters</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: The Reactive JavaScript Database on IndexedDB',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gaidxdb3.tsx
+++ b/docs-src/src/pages/sem/gaidxdb3.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gaidxdb3';
 
 const titles = [
     <>{/* variation 0 */}Fix IndexedDB <b>Limits</b>, <b>Speed</b> and <b>Sync</b></>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gaidxdb3.tsx
+++ b/docs-src/src/pages/sem/gaidxdb3.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gaidxdb3.tsx
+++ b/docs-src/src/pages/sem/gaidxdb3.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}Fix IndexedDB <b>Limits</b>, <b>Speed</b> and <b>Sync</b></>,
-    <>{/* variation 1 */}<b>IndexedDB</b> That <b>Syncs</b> With Your Backend</>,
-    <>{/* variation 2 */}Browser Storage You Can <b>Rely On</b></>
-];
-
-const texts = [
-    <>Quota errors, slow bulk writes, data evicted by the browser? RxDB manages storage carefully, keeps queries fast with caching and indexes, and protects your data by syncing it to your server.</>,
-    <>IndexedDB keeps data on one device, RxDB replicates it. Sync browser data to any backend over HTTP, WebSocket or GraphQL, with conflict handling and offline queueing built in.</>,
-    <>RxDB coordinates writes across tabs, validates every document against your schema and migrates data between app versions, so browser storage stops being the scary part of your stack.</>
-];
-
-const bulletpoints = [
-    [
-        <>Handles storage quotas gracefully</>,
-        <>Fast queries via caching and indexes</>,
-        <>Data survives via server sync</>,
-        <>Works offline by default</>
-    ],
-    [
-        <>Realtime two-way replication</>,
-        <>Conflict resolution included</>,
-        <>Offline writes sync later</>,
-        <>Your servers, your data</>
-    ],
-    [
-        <>Multi-tab write coordination</>,
-        <>Schema validation on every write</>,
-        <>Versioned data migrations</>,
-        <>Open source and auditable</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>Fix IndexedDB <b>Limits</b>, <b>Speed</b> and <b>Sync</b></>,
+        text: <>Quota errors, slow bulk writes, data evicted by the browser? RxDB manages storage carefully, keeps queries fast with caching and indexes, and protects your data by syncing it to your server.</>,
+        bulletpoints: [
+            <>Handles storage quotas gracefully</>,
+            <>Fast queries via caching and indexes</>,
+            <>Data survives via server sync</>,
+            <>Works offline by default</>
+        ]
+    },
+    b: {
+        title: <><b>IndexedDB</b> That <b>Syncs</b> With Your Backend</>,
+        text: <>IndexedDB keeps data on one device, RxDB replicates it. Sync browser data to any backend over HTTP, WebSocket or GraphQL, with conflict handling and offline queueing built in.</>,
+        bulletpoints: [
+            <>Realtime two-way replication</>,
+            <>Conflict resolution included</>,
+            <>Offline writes sync later</>,
+            <>Your servers, your data</>
+        ]
+    },
+    c: {
+        title: <>Browser Storage You Can <b>Rely On</b></>,
+        text: <>RxDB coordinates writes across tabs, validates every document against your schema and migrates data between app versions, so browser storage stops being the scary part of your stack.</>,
+        bulletpoints: [
+            <>Multi-tab write coordination</>,
+            <>Schema validation on every write</>,
+            <>Versioned data migrations</>,
+            <>Open source and auditable</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Fix IndexedDB Limits, Speed and Sync',
             appName: 'Browser',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gajsondb1.tsx
+++ b/docs-src/src/pages/sem/gajsondb1.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The Local-First <b>Database</b> for JavaScript Apps</>,
-    <>{/* variation 1 */}The <b>JSON Database</b> Built for JavaScript</>,
-    <>{/* variation 2 */}Instant Queries on <b>JSON Documents</b></>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-    <>RxDB is a NoSQL database that stores your data as plain JSON documents. Query them with a Mongo-like syntax, observe changes in realtime and keep your app state JSON from the UI to storage to your backend.</>,
-    <>RxDB runs inside your app and answers JSON queries with zero network latency. Your documents stay available offline and your UI updates the moment the data changes.</>
-];
-
-const bulletpoints = [
-    [
-        <>Build apps that work offline</>,
-        <>Sync with any Backend</>,
-        <>Observable Realtime Queries</>,
-        <>All JavaScript Runtimes Supported</>
-    ],
-    [
-        <>Plain JSON documents</>,
-        <>Mongo-like query syntax</>,
-        <>Realtime observable queries</>,
-        <>Free and open source</>
-    ],
-    [
-        <>Zero-latency local reads</>,
-        <>Works fully offline</>,
-        <>Indexes for fast JSON queries</>,
-        <>Live UI updates</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The Local-First <b>Database</b> for JavaScript Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <>The <b>JSON Database</b> Built for JavaScript</>,
+        text: <>RxDB is a NoSQL database that stores your data as plain JSON documents. Query them with a Mongo-like syntax, observe changes in realtime and keep your app state JSON from the UI to storage to your backend.</>,
+        bulletpoints: [
+            <>Plain JSON documents</>,
+            <>Mongo-like query syntax</>,
+            <>Realtime observable queries</>,
+            <>Free and open source</>
+        ]
+    },
+    c: {
+        title: <>Instant Queries on <b>JSON Documents</b></>,
+        text: <>RxDB runs inside your app and answers JSON queries with zero network latency. Your documents stay available offline and your UI updates the moment the data changes.</>,
+        bulletpoints: [
+            <>Zero-latency local reads</>,
+            <>Works fully offline</>,
+            <>Indexes for fast JSON queries</>,
+            <>Live UI updates</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: The JSON Database for JavaScript Apps',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gajsondb1.tsx
+++ b/docs-src/src/pages/sem/gajsondb1.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gajsondb1.tsx
+++ b/docs-src/src/pages/sem/gajsondb1.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gajsondb1';
 
 const titles = [
     <>{/* variation 0 */}The Local-First <b>Database</b> for JavaScript Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gajsondb2.tsx
+++ b/docs-src/src/pages/sem/gajsondb2.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The NoSQL <b>JSON Database</b> With Schemas</>,
-    <>{/* variation 1 */}An Open-Source <b>JSON Database</b> You Can Self-Host</>,
-    <>{/* variation 2 */}The Reactive <b>JSON Database</b> for Your Framework</>
-];
-
-const texts = [
-    <>RxDB validates every document against your JSON Schema and ships full TypeScript typings. You get NoSQL flexibility without the anything goes chaos, plus versioned migrations when your data model evolves.</>,
-    <>RxDB's core is free and open source. Replicate JSON documents to your own servers over HTTP, WebSocket or GraphQL: no proprietary cloud, no per-read pricing, no lock-in.</>,
-    <>RxDB's observable queries re-render your React, Angular, Vue or Svelte components whenever a JSON document changes. One database, every JavaScript runtime: browser, Node.js, Electron and mobile.</>
-];
-
-const bulletpoints = [
-    [
-        <>JSON Schema validation</>,
-        <>First-class TypeScript support</>,
-        <>Versioned schema migrations</>,
-        <>NoSQL query engine</>
-    ],
-    [
-        <>Free, open-source core</>,
-        <>Self-hostable replication</>,
-        <>Runs on IndexedDB, OPFS or SQLite</>,
-        <>No vendor lock-in</>
-    ],
-    [
-        <>Bindings for major frameworks</>,
-        <>Observable realtime queries</>,
-        <>Browser, Node.js and mobile</>,
-        <>Sync with any backend</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The NoSQL <b>JSON Database</b> With Schemas</>,
+        text: <>RxDB validates every document against your JSON Schema and ships full TypeScript typings. You get NoSQL flexibility without the anything goes chaos, plus versioned migrations when your data model evolves.</>,
+        bulletpoints: [
+            <>JSON Schema validation</>,
+            <>First-class TypeScript support</>,
+            <>Versioned schema migrations</>,
+            <>NoSQL query engine</>
+        ]
+    },
+    b: {
+        title: <>An Open-Source <b>JSON Database</b> You Can Self-Host</>,
+        text: <>RxDB's core is free and open source. Replicate JSON documents to your own servers over HTTP, WebSocket or GraphQL: no proprietary cloud, no per-read pricing, no lock-in.</>,
+        bulletpoints: [
+            <>Free, open-source core</>,
+            <>Self-hostable replication</>,
+            <>Runs on IndexedDB, OPFS or SQLite</>,
+            <>No vendor lock-in</>
+        ]
+    },
+    c: {
+        title: <>The Reactive <b>JSON Database</b> for Your Framework</>,
+        text: <>RxDB's observable queries re-render your React, Angular, Vue or Svelte components whenever a JSON document changes. One database, every JavaScript runtime: browser, Node.js, Electron and mobile.</>,
+        bulletpoints: [
+            <>Bindings for major frameworks</>,
+            <>Observable realtime queries</>,
+            <>Browser, Node.js and mobile</>,
+            <>Sync with any backend</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Open-Source NoSQL JSON Database for JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/gajsondb2.tsx
+++ b/docs-src/src/pages/sem/gajsondb2.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gajsondb2.tsx
+++ b/docs-src/src/pages/sem/gajsondb2.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gajsondb2';
 
 const titles = [
     <>{/* variation 0 */}The NoSQL <b>JSON Database</b> With Schemas</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gajsondb3.tsx
+++ b/docs-src/src/pages/sem/gajsondb3.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'gajsondb3';
 
 const titles = [
     <>{/* variation 0 */}Outgrown JSON Files? Get a Real <b>JSON Database</b></>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/gajsondb3.tsx
+++ b/docs-src/src/pages/sem/gajsondb3.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/gajsondb3.tsx
+++ b/docs-src/src/pages/sem/gajsondb3.tsx
@@ -8,56 +8,63 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}Outgrown JSON Files? Get a Real <b>JSON Database</b></>,
-    <>{/* variation 1 */}<b>JSON Documents</b> That Sync Across Devices</>,
-    <>{/* variation 2 */}<b>JSON Storage</b> That Scales With Your App</>
-];
-
-const texts = [
-    <>Writing app data to JSON files means rewriting the whole file on every change, looping instead of querying, and corrupted data under concurrent writes. RxDB keeps your data JSON and fixes all of that.</>,
-    <>A JSON file lives on one machine. RxDB replicates JSON documents between your clients and your backend, with offline queueing and conflict handling built in.</>,
-    <>RxDB queries JSON documents through indexes instead of loading everything into memory, and keeps working offline. Grow from a prototype to production without changing your data model.</>
-];
-
-const bulletpoints = [
-    [
-        <>Indexed queries on JSON</>,
-        <>Safe concurrent writes</>,
-        <>Schemas and migrations</>,
-        <>Realtime UI updates</>
-    ],
-    [
-        <>Two-way realtime replication</>,
-        <>Conflict resolution included</>,
-        <>Offline writes sync later</>,
-        <>Your servers, your data</>
-    ],
-    [
-        <>Indexes, not full scans</>,
-        <>Zero-latency local reads</>,
-        <>Works offline by default</>,
-        <>Production-ready open source</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>Outgrown JSON Files? Get a Real <b>JSON Database</b></>,
+        text: <>Writing app data to JSON files means rewriting the whole file on every change, looping instead of querying, and corrupted data under concurrent writes. RxDB keeps your data JSON and fixes all of that.</>,
+        bulletpoints: [
+            <>Indexed queries on JSON</>,
+            <>Safe concurrent writes</>,
+            <>Schemas and migrations</>,
+            <>Realtime UI updates</>
+        ]
+    },
+    b: {
+        title: <><b>JSON Documents</b> That Sync Across Devices</>,
+        text: <>A JSON file lives on one machine. RxDB replicates JSON documents between your clients and your backend, with offline queueing and conflict handling built in.</>,
+        bulletpoints: [
+            <>Two-way realtime replication</>,
+            <>Conflict resolution included</>,
+            <>Offline writes sync later</>,
+            <>Your servers, your data</>
+        ]
+    },
+    c: {
+        title: <><b>JSON Storage</b> That Scales With Your App</>,
+        text: <>RxDB queries JSON documents through indexes instead of loading everything into memory, and keeps working offline. Grow from a prototype to production without changing your data model.</>,
+        bulletpoints: [
+            <>Indexes, not full scans</>,
+            <>Zero-latency local reads</>,
+            <>Works offline by default</>,
+            <>Production-ready open source</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Outgrown JSON Files? Get a Real JSON Database',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/garealm1.tsx
+++ b/docs-src/src/pages/sem/garealm1.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/garealm1.tsx
+++ b/docs-src/src/pages/sem/garealm1.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}<b>Sync</b> That No Vendor Can <b>Shut Down</b></>,
-    <>{/* variation 2 */}Keep <b>Offline-First</b>. Replace the <b>Dead Sync</b>.</>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-    <>Your managed mobile sync reached end of life. RxDB is open source: the local database and the replication layer run on your infrastructure, so nobody can switch them off again.</>,
-    <>RxDB keeps the model you already built on: a local NoSQL database with live queries plus realtime replication. Move your data layer without rewriting your app's offline logic.</>
-];
-
-const bulletpoints = [
-    [
-        <>Build apps that work offline</>,
-        <>Sync with any Backend</>,
-        <>Observable Realtime Queries</>,
-        <>All JavaScript Runtimes Supported</>
-    ],
-    [
-        <>Open-source local database</>,
-        <>Self-hosted realtime sync</>,
-        <>Actively maintained and funded</>,
-        <>No proprietary cloud required</>
-    ],
-    [
-        <>Local NoSQL with live queries</>,
-        <>Realtime two-way replication</>,
-        <>Offline writes queue and sync</>,
-        <>Runs in React Native and the web</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <><b>Sync</b> That No Vendor Can <b>Shut Down</b></>,
+        text: <>Your managed mobile sync reached end of life. RxDB is open source: the local database and the replication layer run on your infrastructure, so nobody can switch them off again.</>,
+        bulletpoints: [
+            <>Open-source local database</>,
+            <>Self-hosted realtime sync</>,
+            <>Actively maintained and funded</>,
+            <>No proprietary cloud required</>
+        ]
+    },
+    c: {
+        title: <>Keep <b>Offline-First</b>. Replace the <b>Dead Sync</b>.</>,
+        text: <>RxDB keeps the model you already built on: a local NoSQL database with live queries plus realtime replication. Move your data layer without rewriting your app's offline logic.</>,
+        bulletpoints: [
+            <>Local NoSQL with live queries</>,
+            <>Realtime two-way replication</>,
+            <>Offline writes queue and sync</>,
+            <>Runs in React Native and the web</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: The Maintained Local Database With Realtime Sync',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/garealm1.tsx
+++ b/docs-src/src/pages/sem/garealm1.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'garealm1';
 
 const titles = [
     <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/garealm2.tsx
+++ b/docs-src/src/pages/sem/garealm2.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'garealm2';
 
 const titles = [
     <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/pages/sem/garealm2.tsx
+++ b/docs-src/src/pages/sem/garealm2.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/garealm2.tsx
+++ b/docs-src/src/pages/sem/garealm2.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-    <>{/* variation 1 */}An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
-    <>{/* variation 2 */}Built for <b>Production</b> <b>Offline-First</b> Apps</>
-];
-
-const texts = [
-    <>RxDB is a NoSQL database for JavaScript and TypeScript. It runs in React Native, Capacitor, browsers, Electron and Node.js, with observable queries that update your UI in realtime.</>,
-    <>RxDB's core is free and open source. Replication runs over HTTP, WebSocket or GraphQL against your own backend: no proprietary sync cloud, no per-device pricing, no lock-in.</>,
-    <>RxDB ships what a production migration needs: JSON schema validation, data migrations, conflict resolution, encryption and multi-tab support, proven in years of production use.</>
-];
-
-const bulletpoints = [
-    [
-        <>First-class TypeScript support</>,
-        <>React Native and Expo ready</>,
-        <>Observable realtime queries</>,
-        <>NoSQL JSON documents</>
-    ],
-    [
-        <>Free, open-source core</>,
-        <>Self-hostable replication</>,
-        <>Works with any backend</>,
-        <>No vendor lock-in</>
-    ],
-    [
-        <>Schema validation and migrations</>,
-        <>Conflict resolution built in</>,
-        <>Encryption plugin available</>,
-        <>Battle-tested sync protocol</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript and TypeScript. It runs in React Native, Capacitor, browsers, Electron and Node.js, with observable queries that update your UI in realtime.</>,
+        bulletpoints: [
+            <>First-class TypeScript support</>,
+            <>React Native and Expo ready</>,
+            <>Observable realtime queries</>,
+            <>NoSQL JSON documents</>
+        ]
+    },
+    b: {
+        title: <>An <b>Open-Source</b> Database You Can <b>Self-Host</b></>,
+        text: <>RxDB's core is free and open source. Replication runs over HTTP, WebSocket or GraphQL against your own backend: no proprietary sync cloud, no per-device pricing, no lock-in.</>,
+        bulletpoints: [
+            <>Free, open-source core</>,
+            <>Self-hostable replication</>,
+            <>Works with any backend</>,
+            <>No vendor lock-in</>
+        ]
+    },
+    c: {
+        title: <>Built for <b>Production</b> <b>Offline-First</b> Apps</>,
+        text: <>RxDB ships what a production migration needs: JSON schema validation, data migrations, conflict resolution, encryption and multi-tab support, proven in years of production use.</>,
+        bulletpoints: [
+            <>Schema validation and migrations</>,
+            <>Conflict resolution built in</>,
+            <>Encryption plugin available</>,
+            <>Battle-tested sync protocol</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: The Local-First JavaScript Database With Sync',
             appName: 'JavaScript',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/garealm3.tsx
+++ b/docs-src/src/pages/sem/garealm3.tsx
@@ -10,9 +10,10 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * The a/b test variations, identified by stable letter keys - NOT by array
- * position. Letters keep their meaning when variations are added or removed
- * later: use the next unused letter for a new variation, retire the letter
- * of a removed one and never re-assign it to different copy.
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
     a: {

--- a/docs-src/src/pages/sem/garealm3.tsx
+++ b/docs-src/src/pages/sem/garealm3.tsx
@@ -8,57 +8,64 @@ import { getSemVariation } from '../../components/a-b-tests';
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
-const titles = [
-    <>{/* variation 0 */}Stranded by a <b>Deprecated</b> Sync Service?</>,
-    <>{/* variation 1 */}Never Get <b>Locked Into</b> a Sync Cloud Again</>,
-    <>{/* variation 2 */}One <b>Database</b> for Web, Mobile and Desktop</>
-];
-
-const texts = [
-    <>When a managed sync service shuts down, the local database keeps working but your realtime sync is gone. RxDB restores it: local NoSQL storage plus replication to a backend you control.</>,
-    <>RxDB is open source and backend-agnostic. Sync over HTTP, WebSocket or GraphQL to infrastructure you own, with no per-device pricing and no proprietary service that can be discontinued.</>,
-    <>Native mobile databases leave the browser behind. RxDB runs the same code in React Native, the web, Electron and Node.js, so one data layer serves every platform you ship to.</>
-];
-
-const bulletpoints = [
-    [
-        <>Realtime two-way sync restored</>,
-        <>Keep working fully offline</>,
-        <>Your backend, your rules</>,
-        <>Clear migration documentation</>
-    ],
-    [
-        <>No proprietary sync cloud</>,
-        <>No per-device pricing</>,
-        <>Open source, auditable code</>,
-        <>Backend-agnostic replication</>
-    ],
-    [
-        <>Full browser support</>,
-        <>React Native and Capacitor</>,
-        <>Electron and Node.js</>,
-        <>One API on every platform</>
-    ]
-];
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations are added or removed
+ * later: use the next unused letter for a new variation, retire the letter
+ * of a removed one and never re-assign it to different copy.
+ */
+const variations = {
+    a: {
+        title: <>Stranded by a <b>Deprecated</b> Sync Service?</>,
+        text: <>When a managed sync service shuts down, the local database keeps working but your realtime sync is gone. RxDB restores it: local NoSQL storage plus replication to a backend you control.</>,
+        bulletpoints: [
+            <>Realtime two-way sync restored</>,
+            <>Keep working fully offline</>,
+            <>Your backend, your rules</>,
+            <>Clear migration documentation</>
+        ]
+    },
+    b: {
+        title: <>Never Get <b>Locked Into</b> a Sync Cloud Again</>,
+        text: <>RxDB is open source and backend-agnostic. Sync over HTTP, WebSocket or GraphQL to infrastructure you own, with no per-device pricing and no proprietary service that can be discontinued.</>,
+        bulletpoints: [
+            <>No proprietary sync cloud</>,
+            <>No per-device pricing</>,
+            <>Open source, auditable code</>,
+            <>Backend-agnostic replication</>
+        ]
+    },
+    c: {
+        title: <>One <b>Database</b> for Web, Mobile and Desktop</>,
+        text: <>Native mobile databases leave the browser behind. RxDB runs the same code in React Native, the web, Electron and Node.js, so one data layer serves every platform you ship to.</>,
+        bulletpoints: [
+            <>Full browser support</>,
+            <>React Native and Capacitor</>,
+            <>Electron and Node.js</>,
+            <>One API on every platform</>
+        ]
+    }
+};
 
 export default function Page() {
     /**
-     * Render the first variation on the server and on the first client render
+     * Render variation "a" on the server and on the first client render
      * to avoid a hydration mismatch, then swap to the assigned variation.
      */
-    const [variation, setVariation] = useState(0);
+    const [variationKey, setVariationKey] = useState('a');
     useEffect(() => {
-        setVariation(getSemVariation(titles.length));
+        setVariationKey(getSemVariation(Object.keys(variations)));
     }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
 
     return Home({
         sem: {
             id: 'gads',
             metaTitle: 'RxDB: Replace Your Deprecated Mobile Sync Stack',
             appName: 'React Native',
-            title: titles[variation],
-            text: texts[variation],
-            bulletpoints: bulletpoints[variation]
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
         }
     });
 }

--- a/docs-src/src/pages/sem/garealm3.tsx
+++ b/docs-src/src/pages/sem/garealm3.tsx
@@ -7,7 +7,6 @@ import { getSemVariation } from '../../components/a-b-tests';
  * A/b tests 3 variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
-const PAGE_ID = 'garealm3';
 
 const titles = [
     <>{/* variation 0 */}Stranded by a <b>Deprecated</b> Sync Service?</>,
@@ -49,7 +48,7 @@ export default function Page() {
      */
     const [variation, setVariation] = useState(0);
     useEffect(() => {
-        setVariation(getSemVariation(PAGE_ID, titles.length));
+        setVariation(getSemVariation(titles.length));
     }, []);
 
     return Home({

--- a/docs-src/src/theme/Root.tsx
+++ b/docs-src/src/theme/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { AD_CLICK_STORAGE_ID, onCopy, setTrackingConsent, triggerTrackingEvent } from '../components/trigger-event';
+import { AD_CLICK_STORAGE_ID, getUtmCampaign, onCopy, setTrackingConsent, triggerTrackingEvent } from '../components/trigger-event';
 import { isLikelyEuUser } from './eu-consent';
 import { type ConsentState, initEuConsentBanner, updateGoogleConsent } from './consent-manager';
 import { randomNumber } from '../../../plugins/utils';
@@ -167,6 +167,12 @@ export default function Root({ children }) {
     useEffect(() => {
         // addCommunityChatButton();
         storeAdClickId();
+        /**
+         * Persist the utm_campaign of the landing URL so later events on
+         * other pages still attribute to the campaign (used for the a/b-test
+         * event prefix and the sem-page variation keying).
+         */
+        getUtmCampaign();
 
         /**
          * EU/EEA visitors only get trackers after they accepted them in the


### PR DESCRIPTION
## This PR contains:

Something else: a rework of the docs-site tracking/a/b-test attribution (marketing infrastructure, no database code touched).

## Describe the problem you have without this PR

The docs site uses an own-invented a/b tracking system: `getTestGroupEventPrefix()` builds `abt_…` event prefixes from a localStorage test group, and each SEM landing page stores its a/b variation under a hard-coded `PAGE_ID`. We want to replace that with standard UTM tracking, since the ad final URLs now carry the full UTM parameter set.

With this PR:

- **`getUtmCampaign()`** (`trigger-event.tsx`) reads `utm_campaign` from the landing URL and persists it in `localStorage` (last touch wins, like the stored ad click id). `Root.tsx` calls it on page load so every UTM-tagged visit is captured.
- **`getUtmEventPrefix()`** replaces `getTestGroupEventPrefix()` in `triggerTrackingEvent()`: the a/b GA event is now `utm_` + campaign + `_v` + variation letter, e.g. `utm_indexeddb_va_join_newsletter` (campaign part sanitized/truncated for GA4's 40-char event-name limit), so conversions attribute to the campaign and landing-page variant.
- **`getSemVariation(variationKeys)`** keys the stored variation off the visitor's `utm_campaign` (falling back to `organic`) instead of a per-page `PAGE_ID`.
- **Variations are identified by stable letter keys** (`a`/`b`/`c`, …), not array positions: each sem page defines a letter-keyed `variations` object instead of parallel `titles`/`texts`/`bulletpoints` arrays, so variants can be added (next unused letter) or removed (letter retired) later without shifting the identity of the remaining ones. A stored letter that no longer exists on the page (or a numeric index from the old system) gets re-assigned automatically. All 15 `/sem/` pages and the `create-sem-page` skill were converted.

The homepage headline test (`getTestGroup`/`CURRENT_TEST_RUN`) is untouched — it only renders the variation and no longer feeds event prefixes.

Verified: `tsc --noEmit` on `docs-src` produces an error list identical to `master` (no new type errors).

## Todos
- [x] Documentation (`create-sem-page` skill updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXxUhSytZiehLgrzseSP9y