### PR TITLE
Fix 404 for /articles/generic-prompts.html by adding missing frontmatter

### DIFF
--- a/docs-src/docs/articles/generic-prompts.md
+++ b/docs-src/docs/articles/generic-prompts.md
@@ -1,6 +1,13 @@
-# Generic Prompts for Github Repos
+---
+title: Generic Prompts for GitHub Repos - Reusable Agent Prompts for Any Project
+slug: generic-prompts.html
+description: Generic prompts you can give your AI agent to improve any GitHub or open source project, from build cleanup to bug fixes and performance.
+image: /headers/generic-prompts.jpg
+---
 
-Prompts that are useful for any github or open source project which you can give your agent to improve the project.
+# Generic Prompts for GitHub Repos
+
+Prompts that are useful for any GitHub or open source project which you can give your agent to improve the project.
 
 
 ## Clean up


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS

## Describe the problem you have without this PR
https://rxdb.info/articles/generic-prompts.html returns a 404. The page `docs-src/docs/articles/generic-prompts.md` is listed in `sidebars.js` but has no frontmatter, so Docusaurus serves it at the default URL `/articles/generic-prompts` instead of the `.html` slug that all other article pages use.

This PR adds the standard frontmatter (`title`, `slug: generic-prompts.html`, `description`, `image`) following the existing article pattern, and corrects "Github" to "GitHub" in the H1 and intro sentence.

Note: the header image `/headers/generic-prompts.jpg` is referenced like on other article pages but header images are not stored in this repo, so it still needs to be deployed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt7DX6bmpxj31YiNzH2Ugg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt7DX6bmpxj31YiNzH2Ugg)_