### PR TITLE
docs-src: fire visit_x_urls at 3 urls, add premium_form_focus_10_sec event

### DIFF
--- a/docs-src/src/components/modal.tsx
+++ b/docs-src/src/components/modal.tsx
@@ -1,5 +1,5 @@
 // Modal.tsx
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import type { ModalProps as AntdModalProps } from 'antd';
 import { Modal as AntdModal } from 'antd';
 import { IconClose } from './icons/close';
@@ -85,11 +85,58 @@ export function IframeFormModal(props: {
      * e.g. 'buy_form' fires 'buy_form_loaded' on success and 'buy_form_error' on failure.
      */
     eventId?: string;
+    /**
+     * When provided, this event is fired once the visitor keeps keyboard
+     * focus inside the form iframe for 10 seconds. The form is a
+     * cross-origin iframe so we cannot observe typing; sustained focus is
+     * the closest measurable signal for "started filling the form" and
+     * separates it from an accidental single click.
+     */
+    focusEventType?: string;
 }) {
     const handleClose = () => {
         props.onClose();
     };
     const eventId = props.eventId;
+    const focusEventType = props.focusEventType;
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+
+    useEffect(() => {
+        if (!props.open || !focusEventType) {
+            return;
+        }
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const cancel = () => {
+            if (timer) {
+                clearTimeout(timer);
+                timer = undefined;
+            }
+        };
+        const onWindowBlur = () => {
+            // focus moved into the iframe (not to another tab/app)
+            if (document.activeElement === iframeRef.current && !document.hidden) {
+                cancel();
+                timer = setTimeout(() => {
+                    triggerTrackingEvent(focusEventType, 1, 1);
+                }, 10 * 1000);
+            }
+        };
+        const onVisibilityChange = () => {
+            if (document.hidden) {
+                cancel();
+            }
+        };
+        window.addEventListener('blur', onWindowBlur);
+        window.addEventListener('focus', cancel);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        return () => {
+            cancel();
+            window.removeEventListener('blur', onWindowBlur);
+            window.removeEventListener('focus', cancel);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+        };
+    }, [props.open, focusEventType]);
+
     return <Modal
         className="modal-consulting-page"
         open={props.open}
@@ -98,6 +145,7 @@ export function IframeFormModal(props: {
         footer={null}
     >
         <iframe
+            ref={iframeRef}
             style={{
                 width: '100%',
                 height: '70vh',

--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -606,7 +606,7 @@ function CustomFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/63f2Y0mNbp1veI9X0QPYMmLKq4xeHmvN4OgxfmUyvIzLDQeAsTOFC3yLEP17TQWGNt'
         eventId='custom_package_form'
-        focusEventType='premium_form_focus_10_sec'
+        focusEventType='premium_form_focus_x_sec'
     />;
 }
 
@@ -616,7 +616,7 @@ function ProFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/6NclWCnYX2vvtF69NxoNKttBklqjCFyxArtY3ir4YZfLRDCIrBnCu3iewgluQcx5K3'
         eventId='pro_form'
-        focusEventType='premium_form_focus_10_sec'
+        focusEventType='premium_form_focus_x_sec'
     />;
 }
 
@@ -626,6 +626,6 @@ function ProPlusFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/ce8xmRLPWF5wdMuU49wkdta9IFUGbsVGfQpZZnnJUwJHhwztGs6jsqCnOaLFHaHhPJ'
         eventId='pro_plus_form'
-        focusEventType='premium_form_focus_10_sec'
+        focusEventType='premium_form_focus_x_sec'
     />;
 }

--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -606,6 +606,7 @@ function CustomFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/63f2Y0mNbp1veI9X0QPYMmLKq4xeHmvN4OgxfmUyvIzLDQeAsTOFC3yLEP17TQWGNt'
         eventId='custom_package_form'
+        focusEventType='premium_form_focus_10_sec'
     />;
 }
 
@@ -615,6 +616,7 @@ function ProFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/6NclWCnYX2vvtF69NxoNKttBklqjCFyxArtY3ir4YZfLRDCIrBnCu3iewgluQcx5K3'
         eventId='pro_form'
+        focusEventType='premium_form_focus_10_sec'
     />;
 }
 
@@ -624,5 +626,6 @@ function ProPlusFormDialog({ onClose, open }) {
         open={open}
         iframeUrl='https://webforms.pipedrive.com/f/ce8xmRLPWF5wdMuU49wkdta9IFUGbsVGfQpZZnnJUwJHhwztGs6jsqCnOaLFHaHhPJ'
         eventId='pro_plus_form'
+        focusEventType='premium_form_focus_10_sec'
     />;
 }

--- a/docs-src/src/theme/Root.tsx
+++ b/docs-src/src/theme/Root.tsx
@@ -698,7 +698,7 @@ function trackUrlChanges() {
     }
 
     const STORAGE_KEY = 'visited_urls';
-    const URL_EVENT_COUNT = 5;
+    const URL_EVENT_COUNT = 3;
     const stored = localStorage.getItem(STORAGE_KEY);
     const visitedUrls = new Set<string>(stored ? JSON.parse(stored) : []);
 


### PR DESCRIPTION
## This PR contains:
- SOMETHING ELSE (docs-site tracking-event changes, no library code touched)

## Describe the problem you have without this PR
Two gaps in the rxdb.info tracking events:

1. `visit_x_urls` only fired on the 5th distinct URL a visitor opens. Most sessions never get that far, so the event was too rare to be useful. It now fires on the 3rd distinct URL (`URL_EVENT_COUNT` 5 -> 3 in `trackUrlChanges()`; the accompanying `visit_<n>_urls` event becomes `visit_3_urls` automatically).

2. There was no signal between "opened a premium package form" and "submitted it". The forms are cross-origin Pipedrive iframes, so typing cannot be observed from the parent page. This PR adds an optional `focusEventType` prop to `IframeFormModal`: when the visitor keeps focus inside the form iframe for 10 seconds (detected via `window` blur with the iframe as `document.activeElement`, cancelled when the window regains focus or the tab is hidden), the event fires once per user. The three premium package dialogs pass `premium_form_focus_10_sec`, so an accidental single click into the form does not count, sustained focus does.

## Todos
- [ ] Tests: not applicable, docs-site tracking only (no `test/` coverage exists for `docs-src` tracking events)
- [ ] Documentation: not applicable, internal tracking behavior
- [ ] Typings: included (`focusEventType?: string` prop)
- [ ] Changelog: not applicable, no library change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3tLAPjHjiPNA3dEUgooRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3tLAPjHjiPNA3dEUgooRd)_