### PR TITLE
docs(sem): drop underperforming variation 'c' from gaidxdb1 landing page

### DIFF
--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -35,17 +35,23 @@ const variations = {
             <>JSON schemas and migrations</>,
             <>Free and open source</>
         ]
-    },
-    c: {
-        title: <><b>Instant Queries</b> on <b>IndexedDB</b></>,
-        text: <>RxDB runs directly inside your app and answers queries with zero network latency. Your data lives in IndexedDB, stays available offline and updates your UI the moment it changes.</>,
-        bulletpoints: [
-            <>Zero-latency local reads</>,
-            <>Works fully offline</>,
-            <>Optimized IndexedDB storage</>,
-            <>Observable realtime queries</>
-        ]
     }
+    /**
+     * Variation 'c' was removed on 2026-07-27 after its first A/B readout:
+     * it was the weakest of the three on engagement. Kept on record (commented
+     * out, not deleted) so its letter and copy stay reserved and 'c' is never
+     * reused for different copy, per the rules in getSemVariation().
+     */
+    // c: {
+    //     title: <><b>Instant Queries</b> on <b>IndexedDB</b></>,
+    //     text: <>RxDB runs directly inside your app and answers queries with zero network latency. Your data lives in IndexedDB, stays available offline and updates your UI the moment it changes.</>,
+    //     bulletpoints: [
+    //         <>Zero-latency local reads</>,
+    //         <>Works fully offline</>,
+    //         <>Optimized IndexedDB storage</>,
+    //         <>Observable realtime queries</>
+    //     ]
+    // }
 };
 
 export default function Page() {


### PR DESCRIPTION
## This PR contains:

- Landing-page content change (SEM A/B test update)

## Describe the problem you have without this PR

The `/sem/gaidxdb1/` SEM landing page A/B-tests three variations (`a`, `b`, `c`) of the title, text and bulletpoints. After the first readout of the test, variation `c` ("Instant Queries on IndexedDB") was the weakest of the three on visitor engagement. Leaving it in the live split keeps sending a third of that page's paid traffic to the worst-performing copy.

This PR removes `c` from the active split. Following the letter-stability rules documented in `getSemVariation()` (`docs-src/src/components/a-b-tests.tsx`), the variation is **commented out, not deleted**, so:

- its letter `c` and copy stay on record and can never be reused for different copy;
- variations `a` and `b` keep their letters, so stored `localStorage` assignments and the `utm_indexeddb_v{a,b}_*` GA events stay comparable across the change;
- visitors previously assigned `c` are transparently reassigned to `a`/`b` on their next visit (the helper already handles a stored key that is no longer active).

Only `docs-src/src/pages/sem/gaidxdb1.tsx` changes; `gaidxdb2`/`gaidxdb3` are untouched.

## Todos

- [ ] ~~Tests~~ — n/a: content/config change to a landing page's A/B variation set; no behavior under unit test (the removal path in `getSemVariation()` is pre-existing).
- [x] Documentation — the removed variation is documented inline in the page file.
- [ ] Typings — unchanged.
- [ ] Changelog — n/a for a landing-page copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hi2T1kD7bccDgcfzj9ddKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hi2T1kD7bccDgcfzj9ddKE)_