### PR TITLE
docs-src: add SEM landing pages gadxie1-3

### DIFF
--- a/docs-src/src/pages/sem/gadxie1.tsx
+++ b/docs-src/src/pages/sem/gadxie1.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gadxie1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <>Keep <b>IndexedDB</b>. Add <b>Realtime Sync</b>.</>,
+        text: <>RxDB is a local-first NoSQL database that runs on IndexedDB. You keep the storage you know and get the parts every wrapper leaves out: realtime sync to any backend, conflict handling, and multi-tab support.</>,
+        bulletpoints: [
+            <>Runs on the IndexedDB you already use</>,
+            <>Sync with any backend, self-hosted</>,
+            <>Conflict handling built in</>,
+            <>Multi-tab support out of the box</>
+        ]
+    },
+    b: {
+        title: <><b>Local Data</b> Without the <b>Pain</b></>,
+        text: <>Hand-rolled sync code, broken multi-tab state, and schema drift are what an IndexedDB wrapper leaves you to solve alone. RxDB solves them once: reactive queries, replication, and migrations in one open-source database.</>,
+        bulletpoints: [
+            <>No hand-written sync code</>,
+            <>Reactive queries across tabs</>,
+            <>Schema migrations included</>,
+            <>Open source and battle-tested</>
+        ]
+    },
+    c: {
+        title: <>From <b>Single-Tab Cache</b> to <b>Synced App</b></>,
+        text: <>Your app already stores data locally. RxDB turns that local store into an offline-first, multi-device app: data syncs in realtime to any backend and every open tab stays consistent.</>,
+        bulletpoints: [
+            <>Offline-first by design</>,
+            <>Realtime sync across devices</>,
+            <>Every tab stays consistent</>,
+            <>Works with React, Angular, Vue</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: The Upgrade Path From Your IndexedDB Wrapper',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gadxie2.tsx
+++ b/docs-src/src/pages/sem/gadxie2.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gadxie2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Open-Source</b> Database With <b>Self-Hosted Sync</b></>,
+        text: <>RxDB is an open-source, local-first NoSQL database for JavaScript. Replication works with CouchDB, GraphQL, HTTP, WebRTC, and more, all self-hostable. Your data stays on your infrastructure, with no proprietary sync cloud.</>,
+        bulletpoints: [
+            <>Apache-2.0 licensed core</>,
+            <>Sync to any backend you control</>,
+            <>No proprietary cloud required</>,
+            <>Large plugin ecosystem</>
+        ]
+    },
+    b: {
+        title: <>One <b>Local Database</b> for Your Whole <b>Stack</b></>,
+        text: <>RxDB runs in the browser, Electron, Node.js, and React Native, with bindings for React, Angular, Vue, and Svelte. You define a schema once and get reactive queries, migrations, and sync on every platform.</>,
+        bulletpoints: [
+            <>Browser, Electron, Node.js, RN</>,
+            <>React, Angular, Vue, Svelte</>,
+            <>One schema, every platform</>,
+            <>TypeScript support included</>
+        ]
+    },
+    c: {
+        title: <>A <b>Local Database</b> Ready for <b>Production</b></>,
+        text: <>RxDB ships the features production apps need: schema validation, data migrations, encryption, compression, and attachment handling. Reactive queries keep the UI consistent and replication keeps every device in sync.</>,
+        bulletpoints: [
+            <>Schema validation and migrations</>,
+            <>Encryption and compression</>,
+            <>Reactive queries everywhere</>,
+            <>Battle-tested replication</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Open-Source Local Database With Self-Hosted Sync',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}

--- a/docs-src/src/pages/sem/gadxie3.tsx
+++ b/docs-src/src/pages/sem/gadxie3.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "gadxie3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <><b>Sync Code</b> You Do Not Have to <b>Write</b></>,
+        text: <>Hand-written sync breaks on flaky networks, lost tabs, and concurrent edits. RxDB ships a replication protocol that handles offline writes, retries, and conflicts, and it works with any backend you already run.</>,
+        bulletpoints: [
+            <>Offline writes sync automatically</>,
+            <>Retries and backoff handled</>,
+            <>Conflict resolution built in</>,
+            <>Works with your existing backend</>
+        ]
+    },
+    b: {
+        title: <>Every <b>Tab</b> Shows the <b>Same Data</b></>,
+        text: <>When your app runs in two tabs, local state drifts and users see stale data. RxDB shares one reactive database across tabs, so a write in one tab updates every other tab instantly.</>,
+        bulletpoints: [
+            <>One database, every tab</>,
+            <>Reactive queries update the UI</>,
+            <>Leader election out of the box</>,
+            <>No BroadcastChannel plumbing</>
+        ]
+    },
+    c: {
+        title: <><b>Offline Edits</b> Without <b>Lost Data</b></>,
+        text: <>Users edit offline, reconnect, and expect nothing to be lost. RxDB stores writes locally, replicates them when the network returns, and resolves conflicts with a strategy you control.</>,
+        bulletpoints: [
+            <>Local-first writes, zero latency</>,
+            <>Automatic replication on reconnect</>,
+            <>Custom conflict strategies</>,
+            <>Data survives page reloads</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB Solves Sync, Multi-Tab State and Offline Conflicts',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}


### PR DESCRIPTION
## This PR contains:

- SOMETHING ELSE: three new SEM landing pages under `docs-src/src/pages/sem/` (`gadxie1.tsx`, `gadxie2.tsx`, `gadxie3.tsx`)

## Describe the problem you have without this PR

The final URLs of a new ads campaign point at `/sem/gadxie1/`, `/sem/gadxie2/` and `/sem/gadxie3/`, which do not exist yet. Each page a/b tests 3 letter-keyed variations of title, description and bulletpoints, keyed off `utm_campaign` via `getSemVariation()`, following the existing `gaidxdb*` pages' pattern.

No changelog entry: SEM landing pages are neither a testcase nor a FIX, so the Changelog Rule does not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSyKW96AgGf7333MZNFiqJ)_