### PR TITLE
Revert "Add Google Tag Manager tag to dev-mode-iframe.html"

### DIFF
--- a/docs-src/static/html/dev-mode-iframe.html
+++ b/docs-src/static/html/dev-mode-iframe.html
@@ -1,41 +1,22 @@
 <html>
 
 <head>
-    <script>
-        /**
-         * Google Consent Mode v2 default, same as in docs-src/docusaurus.config.ts.
-         * For EU/EEA (and UK) regions the analytics and ad storage is denied.
-         * The commands are queued on dataLayer before the async GTM library
-         * boots, so the default applies to the very first hit.
-         */
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('consent', 'default', {
-            ad_storage: 'denied',
-            ad_user_data: 'denied',
-            ad_personalization: 'denied',
-            analytics_storage: 'denied',
-            wait_for_update: 500,
-            region: [
-                'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR',
-                'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK',
-                'SI', 'ES', 'SE',
-                'IS', 'LI', 'NO',
-                'GB'
-            ]
-        });
-        gtag('set', 'ads_data_redaction', true);
-    </script>
-    <!-- Google Tag Manager -->
-    <script>(function (w, d, s, l, i) {
-            w[l] = w[l] || []; w[l].push({
-                'gtm.start':
-                    new Date().getTime(), event: 'gtm.js'
-            }); var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-PL63TR5');</script>
-    <!-- End Google Tag Manager -->
+    <!--
+        IMPORTANT: Do NOT add Google Tag Manager (or any other analytics script)
+        to this page. It was added once and reverted on purpose:
+        - This page runs as a cross-site iframe inside the apps of RxDB users.
+          Browser storage partitioning makes any GA client id unjoinable with
+          later rxdb.info visits, so the hits are worthless.
+        - There is no consent UI inside a hidden iframe, so for EU/EEA/UK users
+          consent stays denied forever and for everyone else cookies would be
+          set without any disclosure.
+        - Loading gtm.js inside third-party apps makes this iframe a target for
+          adblockers, which would also break the cookie mechanism below.
+        The only job of this page is to set the cookie. The actual tracking
+        event is fired later on the docs page (docs-src/src/theme/Root.tsx)
+        when the cookie is read. Dev-mode boot counts can be taken from the
+        server logs of this file via the ?version= query parameter.
+    -->
     <script>
         /**
          * Instead of directly creating analytics events inside of the iframe,
@@ -58,10 +39,6 @@
 </head>
 
 <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PL63TR5" height="0" width="0"
-            style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <p>
         This is the page is shown in an iframe when the <a
             href="https://rxdb.info/dev-mode.html"


### PR DESCRIPTION
## This PR contains:

A revert of #8861 (removes the Google Tag Manager snippet from `docs-src/static/html/dev-mode-iframe.html`) plus a guard comment so it does not get re-added.

## Describe the problem you have without this PR

The GTM container added in #8861 contradicts the design of the dev-mode iframe, which deliberately does not fire analytics events itself and only sets a cookie that is later read on the docs page (`docs-src/src/theme/Root.tsx`):

- The page runs as a cross-site iframe inside the apps of RxDB users. Browser storage partitioning makes any GA client id unjoinable with later rxdb.info visits, so the hits are worthless.
- There is no consent UI inside a hidden 1px iframe, so for EU/EEA/UK users the Consent Mode default stays denied forever, and for everyone else cookies would be set without any disclosure.
- Loading `gtm.js` inside third-party apps makes the iframe a target for adblockers, which would also break the cookie mechanism.

Dev-mode boot counts are still available from the server logs of this file via the `?version=` query parameter. This PR also adds an HTML comment at the top of the file explaining why no analytics script must be added to this page again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4ZJqzqANVxayxSV2h1f1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4ZJqzqANVxayxSV2h1f1L)_