### PR TITLE
Document GitHub Pages docs hosting in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@
 - **Generate Error Messages**: `npm run generate:error-messages`
 - **Start Docs Server**: `npm run docs:serve`
 
+## Docs Hosting
+- The docs at rxdb.info are deployed via GitHub Pages from the `docs` branch. They are NOT hosted on Cloudflare Pages; the deploy step in `.github/workflows/cloudflare-pages.yml` is commented out and inactive.
+- GitHub Pages serves static files only: there are no server-side functions and no access to request logs. Any feature that needs server-side logic or log analysis requires an external endpoint.
+
 ## Code Style & Patterns
 - **Language**: TypeScript
 - **Database**: RxDB (local-first, NoSQL)


### PR DESCRIPTION
## This PR contains:

Improved docs for tooling: a CLAUDE.md note stating that rxdb.info is served by GitHub Pages from the `docs` branch, not by Cloudflare Pages.

## Describe the problem you have without this PR

The repository contains `.github/workflows/cloudflare-pages.yml`, but its deploy step is commented out and inactive. Without a note, tooling reads that workflow file and wrongly concludes the docs run on Cloudflare Pages, then suggests server-side features (Pages Functions, request log analysis) that GitHub Pages cannot provide. The note records the actual hosting setup and its static-only constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4ZJqzqANVxayxSV2h1f1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4ZJqzqANVxayxSV2h1f1L)_