### PR TITLE
QuoteBlock: use semantic HTML (figure/blockquote/figcaption) so AI crawlers recognize quotes

### DIFF
--- a/docs-src/src/components/quoteblock.tsx
+++ b/docs-src/src/components/quoteblock.tsx
@@ -27,21 +27,33 @@ export function QuoteBlock({
     ...(year ? { datePublished: year } : {}),
   };
   return (
-    <div
+    <figure
       style={{
         borderLeft: '2px solid var(--color-top)',
         paddingLeft: '1rem',
         paddingTop: '0.5rem',
         paddingBottom: '0.5rem',
         marginTop: 30,
-        marginBottom: 30
+        marginBottom: 30,
+        marginLeft: 0,
+        marginRight: 0
       }}
     >
       <JsonLd data={quotationJsonLd} />
       <IconQuoteStart />
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+      <blockquote
+        cite={sourceLink}
+        style={{
+          margin: 0,
+          padding: 0,
+          border: 'none',
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '0.5rem'
+        }}
+      >
         <p style={{ margin: 0 }}>{children}</p>
-      </div>
+      </blockquote>
       <div style={{
         display: 'flex',
         justifyContent: 'flex-end',
@@ -50,7 +62,7 @@ export function QuoteBlock({
 
         <IconQuoteEnd />
       </div>
-      <p
+      <figcaption
         style={{
           marginTop: '0.75rem',
           marginBottom: 0,
@@ -71,7 +83,7 @@ export function QuoteBlock({
           author
         )}
         {year && `, ${year}`}
-      </p>
-    </div>
+      </figcaption>
+    </figure>
   );
 }


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (docs-site component, `docs-src/src/components/quoteblock.tsx`)

## Describe the problem you have without this PR

`<QuoteBlock>` already emits schema.org `Quotation` JSON-LD, which serves classic structured-data crawlers. But the visible markup is a plain styled `<div>` with `<p>` tags. AI crawlers (GPTBot, PerplexityBot, ClaudeBot) typically reduce pages to text or markdown and drop `<script type="application/ld+json">` blocks, so for the engines the quotation tactic targets, a QuoteBlock quote is indistinguishable from body text.

Changes:

- The wrapper `<div>` becomes a `<figure>`, the quote text is wrapped in `<blockquote cite={sourceLink}>`, and the attribution line becomes a `<figcaption>`. This is the MDN-recommended pattern for attributed quotes, and a `<blockquote>` survives HTML-to-markdown reduction as an actual quote.
- The JSON-LD emission is unchanged, so structured-data crawlers keep working as before.
- Visual appearance is unchanged: the existing inline styles moved onto the new elements, and the `<blockquote>` gets explicit `margin: 0; padding: 0; border: none` so the theme's default blockquote styling cannot leak in. The figure carries the existing left border.
- No API change: the `author` / `year` / `sourceLink` / `children` props are untouched, so all existing usages keep working without edits.

## Todos
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JANh8dbsUjfKG7GhveqpU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JANh8dbsUjfKG7GhveqpU1)_