### PR TITLE
Add sourced adoption and activity stats to all alternatives articles

### DIFF
--- a/docs-src/docs/articles/alternatives/absurd-sql-alternative.md
+++ b/docs-src/docs/articles/alternatives/absurd-sql-alternative.md
@@ -67,6 +67,8 @@ If a user opens your app in two tabs, both tabs talk to the same IndexedDB block
 
 These are common requirements for local-first apps. With absurd-sql you build them on top of SQL. RxDB ships them as plugins.
 
+The numbers reflect this. As of July 30, 2026, [absurd-sql](https://github.com/jlongster/absurd-sql) has 4,325 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `absurd-sql` package was downloaded 54,780 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/absurd-sql-vs-rxdb)). The last commit to the [absurd-sql repository](https://github.com/jlongster/absurd-sql) was in August 2023.
+
 ## Why RxDB Fits Better for Most Apps
 
 ### Storage-agnostic with modern options

--- a/docs-src/docs/articles/alternatives/apollo-alternative.md
+++ b/docs-src/docs/articles/alternatives/apollo-alternative.md
@@ -75,6 +75,8 @@ Apollo's cache can grow without bound, and garbage collection through `cache.gc(
 
 RxDB documents stay in storage until you delete them. Storage size is bounded by the underlying engine (IndexedDB, OPFS, SQLite) rather than by query reachability.
 
+Both projects are under active development. As of July 30, 2026, [Apollo Client](https://github.com/apollographql/apollo-client) has 19,808 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## What RxDB Brings to the Table
 
 ### A Real Local Database

--- a/docs-src/docs/articles/alternatives/aws-amplify-datastore-alternative.md
+++ b/docs-src/docs/articles/alternatives/aws-amplify-datastore-alternative.md
@@ -217,6 +217,8 @@ RxDB uses the [event-reduce](https://github.com/pubkey/event-reduce) algorithm i
 
 ---
 
+Both projects are under active development. As of July 30, 2026, [Amplify](https://github.com/aws-amplify/amplify-js) has 9,555 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## How RxDB Covers the DataStore Use Case
 
 ### Replicating with AWS AppSync via GraphQL

--- a/docs-src/docs/articles/alternatives/cloudant-alternative.md
+++ b/docs-src/docs/articles/alternatives/cloudant-alternative.md
@@ -60,6 +60,8 @@ Cloudant pricing is based on provisioned throughput capacity for reads, writes, 
 
 PouchDB ships a small query engine and basic change events. There is no schema validation, no typed collections, no reactive query results out of the box, and no first-class hooks for migrations or encryption. Application code has to fill those gaps.
 
+The numbers reflect this. As of July 30, 2026, [the official Cloudant Node.js client](https://github.com/cloudant/nodejs-cloudant) has 255 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `@cloudant/cloudant` package was downloaded 15,918 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/@cloudant/cloudant-vs-rxdb)). The last commit to the [nodejs-cloudant repository](https://github.com/cloudant/nodejs-cloudant) was in January 2022.
+
 ## Why RxDB Works as a Cloudant Alternative
 
 RxDB keeps the parts that made Cloudant attractive and replaces the parts that hurt on the client.

--- a/docs-src/docs/articles/alternatives/couchdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/couchdb-alternative.md
@@ -95,6 +95,8 @@ When using CouchDB from a browser, queries go over the network to the server. Th
 
 ---
 
+Both projects are under active development. As of July 30, 2026, [the CouchDB server](https://github.com/apache/couchdb) has 6,933 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## How RxDB Solves These Problems
 
 [RxDB](https://rxdb.info) is a local-first JavaScript database designed to run on the client. All reads and writes go to local storage. Network replication happens in the background. RxDB includes a [CouchDB replication plugin](../../replication-couchdb.md) so you can use CouchDB as a backend while gaining all the client-side benefits of RxDB.

--- a/docs-src/docs/articles/alternatives/dexie-alternative.md
+++ b/docs-src/docs/articles/alternatives/dexie-alternative.md
@@ -50,6 +50,8 @@ Plain Dexie has no replication. The official answer is Dexie Cloud, a hosted ser
 
 When two tabs or two devices write to the same document, Dexie itself does not resolve the conflict. The application code has to detect it, decide which write wins, and apply the result. There is no [CRDT plugin](../../crdt.md) and no pluggable [conflict handler](../../transactions-conflicts-revisions.md). For a single-user, single-device app this rarely matters. For collaborative or multi-device apps it becomes the central problem.
 
+Both projects are under active development. As of July 30, 2026, [Dexie.js](https://github.com/dexie/Dexie.js) has 14,507 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## What RxDB Adds on Top
 
 RxDB was designed around the gaps above.

--- a/docs-src/docs/articles/alternatives/electricsql-alternative.md
+++ b/docs-src/docs/articles/alternatives/electricsql-alternative.md
@@ -60,6 +60,8 @@ The sync service is written in Elixir and runs as its own process in front of Po
 
 ElectricSQL assumes Postgres is the source of truth. If your backend uses MongoDB, MySQL, DynamoDB, a custom service, or a mix of stores, ElectricSQL is the wrong fit. The shape model is tied to Postgres replication internals.
 
+Both projects are under active development. As of July 30, 2026, [ElectricSQL](https://github.com/electric-sql/electric) has 10,286 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## RxDB Advantages
 
 ### 1. Stable and Production Tested

--- a/docs-src/docs/articles/alternatives/gundb-alternative.md
+++ b/docs-src/docs/articles/alternatives/gundb-alternative.md
@@ -54,6 +54,8 @@ There is no official devtools panel, no schema explorer, and no migration runner
 
 GUN ships informal type definitions through community packages. The graph traversal API is dynamic enough that type inference rarely catches mistakes. Developers used to typed end-to-end pipelines lose that safety net the moment they touch GUN code.
 
+The numbers reflect this. As of July 30, 2026, [GUN](https://github.com/amark/gun) has 19,086 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `gun` package was downloaded 211,647 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/gun-vs-rxdb)). The last commit to the [GUN repository](https://github.com/amark/gun) was in March 2026.
+
 ## Where RxDB Helps
 
 RxDB targets the same set of use cases (offline reads, real time updates, peer-to-peer sync) and addresses the points above directly.

--- a/docs-src/docs/articles/alternatives/hoodie-alternative.md
+++ b/docs-src/docs/articles/alternatives/hoodie-alternative.md
@@ -64,6 +64,8 @@ Hoodie depends on PouchDB for local storage. PouchDB works, but its IndexedDB ad
 
 Hoodie inherits CouchDB's conflict model, which surfaces conflicts but leaves resolution entirely to the application. RxDB lets you supply a [custom conflict handler](../../transactions-conflicts-revisions.md) per collection, so merges happen automatically and consistently across clients.
 
+The numbers reflect this. As of July 30, 2026, [Hoodie](https://github.com/hoodiehq/hoodie) has 4,454 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `hoodie` package was downloaded 989 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/hoodie-vs-rxdb)). The last commit to the [Hoodie repository](https://github.com/hoodiehq/hoodie) was in January 2021.
+
 ## Why RxDB is a Strong Hoodie Replacement
 
 ### Actively Maintained

--- a/docs-src/docs/articles/alternatives/horizon-alternative.md
+++ b/docs-src/docs/articles/alternatives/horizon-alternative.md
@@ -123,6 +123,8 @@ Horizon required a specific project structure, a specific server process (`hz se
 
 ---
 
+The numbers reflect this. As of July 30, 2026, [Horizon](https://github.com/rethinkdb/horizon) has 6,735 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `@horizon/client` package was downloaded 545 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/@horizon/client-vs-rxdb)). The last commit to the [Horizon repository](https://github.com/rethinkdb/horizon) was in January 2021.
+
 ## How RxDB Covers the Same Ground (and More)
 
 [RxDB](https://rxdb.info) shares Horizon's core idea: data changes should propagate automatically to the UI through a reactive, Observable-based API. But RxDB implements this on the client side, in a full local database, rather than as a subscription mechanism to a remote server.

--- a/docs-src/docs/articles/alternatives/instantdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/instantdb-alternative.md
@@ -60,6 +60,8 @@ The InstantDB client picks its own persistence layer. RxDB exposes a [storage in
 
 InstantDB resolves write conflicts internally. You get optimistic updates and rollback, but the resolution policy is mostly fixed. RxDB lets you write a [custom conflict handler](../../transactions-conflicts-revisions.md) per collection, or opt into [CRDTs](../../crdt.md) when you need automatic merging without server arbitration.
 
+Both projects are under active development. As of July 30, 2026, [InstantDB](https://github.com/instantdb/instant) has 10,366 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## Why Teams Pick RxDB Instead
 
 ### Bring Your Own Backend

--- a/docs-src/docs/articles/alternatives/localforage-alternative.md
+++ b/docs-src/docs/articles/alternatives/localforage-alternative.md
@@ -45,6 +45,8 @@ The places where localForage runs out of road are predictable once you list them
 
 For a cache of avatars or a saved form draft, none of this matters. For an app that wants to feel like a product with offline support, all of it matters.
 
+The numbers reflect this. As of July 30, 2026, the last commit to the [localForage repository](https://github.com/localForage/localForage) was in July 2024.
+
 ## What RxDB Adds On Top
 
 RxDB treats the browser like a real database environment.

--- a/docs-src/docs/articles/alternatives/lokijs-alternative.md
+++ b/docs-src/docs/articles/alternatives/lokijs-alternative.md
@@ -39,6 +39,8 @@ The shortcomings below are the ones that show up most often when teams move off 
 - **Dated codebase and low activity.** New runtimes, new browser storage APIs (OPFS, modern IndexedDB usage patterns), and new bundler conventions are not being adopted.
 - **Maintenance mode.** Bug fixes and security patches arrive slowly, if at all.
 
+The numbers reflect this. As of July 30, 2026, [LokiJS](https://github.com/techfort/LokiJS) has 6,830 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296. The last commit to the [LokiJS repository](https://github.com/techfort/LokiJS) was in March 2022.
+
 ## What RxDB Gives You Instead
 
 RxDB was designed around the assumption that the database has to outlive a tab crash and stay consistent across many clients.

--- a/docs-src/docs/articles/alternatives/lowdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/lowdb-alternative.md
@@ -66,6 +66,8 @@ LowDB types come from the TypeScript generic the developer provides at construct
 
 Two Node.js processes opening the same LowDB file race on read and write. The last writer wins and silently overwrites the other process's changes. RxDB storages such as the SQLite or IndexedDB adapters coordinate writes, and the [multi-instance support](../../rx-collection.md) broadcasts changes between tabs and workers.
 
+The numbers reflect this. As of July 30, 2026, [LowDB](https://github.com/typicode/lowdb) has 22,567 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296. The last commit to the [LowDB repository](https://github.com/typicode/lowdb) was in March 2026.
+
 ## What RxDB Adds
 
 - **Scalable storages on Node.js.** Pick from SQLite, MongoDB, in-memory, or filesystem-backed engines. See [Node.js database options](../../nodejs-database.md).

--- a/docs-src/docs/articles/alternatives/minimongo-alternative.md
+++ b/docs-src/docs/articles/alternatives/minimongo-alternative.md
@@ -105,6 +105,8 @@ Each browser tab running a Minimongo-based application maintains its own in-memo
 
 ---
 
+The numbers reflect this. As of July 30, 2026, [Minimongo](https://github.com/mWater/minimongo) has 1,212 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `minimongo` package was downloaded 13,787 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/minimongo-vs-rxdb)).
+
 ## How RxDB Solves These Problems
 
 [RxDB](https://rxdb.info) is a local-first JavaScript database that treats the local store as the primary data source. Every read and write happens locally first, and replication with a backend server runs in the background. The database persists to the chosen storage engine, so data survives page refreshes and browser restarts without any network connection.

--- a/docs-src/docs/articles/alternatives/mongodb-realm-alternative.md
+++ b/docs-src/docs/articles/alternatives/mongodb-realm-alternative.md
@@ -40,6 +40,8 @@ The deprecation is the most pressing reason to migrate, but Realm had structural
 - **License and vendor lock in**: While the SDKs are open source, the sync server and conflict resolution logic live inside MongoDB Atlas. Migrating away from Atlas meant rebuilding sync from scratch.
 - **Schema migrations**: Schema changes in Realm required writing imperative migration functions in every client release, with limited tooling for testing migrations against production data.
 
+The numbers reflect this. As of July 30, 2026, [the Realm JavaScript SDK](https://github.com/realm/realm-js) has 6,000 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `realm` package was downloaded 217,771 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/realm-vs-rxdb)).
+
 ## RxDB advantages for former Realm users
 
 RxDB addresses each of the points above.

--- a/docs-src/docs/articles/alternatives/nedb-alternative.md
+++ b/docs-src/docs/articles/alternatives/nedb-alternative.md
@@ -52,6 +52,8 @@ A NeDB database opened in two browser tabs has no concept of shared state. Write
 ### 6. No Schema Validation
 NeDB is schemaless. Every document can have any shape, which sounds flexible at first but quickly leads to runtime errors when fields drift over time. There is no migration system either, so changing data shape has to be handled by the application.
 
+The numbers reflect this. As of July 30, 2026, [NeDB](https://github.com/louischatriot/nedb) has 13,542 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `nedb` package was downloaded 200,490 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/nedb-vs-rxdb)). The last commit to the [NeDB repository](https://github.com/louischatriot/nedb) was in May 2025.
+
 ## How RxDB Solves These Problems
 
 RxDB keeps the document-oriented model that NeDB users like, and adds the features missing from NeDB:

--- a/docs-src/docs/articles/alternatives/pouchdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/pouchdb-alternative.md
@@ -107,6 +107,8 @@ During RxDB's time as a PouchDB wrapper, many PouchDB bugs were encountered that
 
 ---
 
+Both projects are under active development. As of July 30, 2026, [PouchDB](https://github.com/pouchdb/pouchdb) has 17,598 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## How RxDB Solves These Problems
 
 [RxDB](https://rxdb.info) is a local-first JavaScript database that runs on the client and handles all the challenges described above. It stores data locally, supports reactive queries through RxJS Observables, validates documents against a JSON Schema, and replicates with a wide range of backends without being tied to any single protocol.

--- a/docs-src/docs/articles/alternatives/powersync-alternative.md
+++ b/docs-src/docs/articles/alternatives/powersync-alternative.md
@@ -53,6 +53,8 @@ const query = db.tasks.find({
 });
 ```
 
+Both projects are under active development. As of July 30, 2026, [the PowerSync JavaScript SDK](https://github.com/powersync-ja/powersync-js) has 698 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## Why RxDB Works Well as a PowerSync Alternative
 
 ### Storage-Agnostic Client

--- a/docs-src/docs/articles/alternatives/replicache-alternative.md
+++ b/docs-src/docs/articles/alternatives/replicache-alternative.md
@@ -57,6 +57,8 @@ Replicache hands you a sync protocol but expects you to maintain the canonical s
 
 Replicache is a client-server protocol. RxDB ships a [WebRTC replication plugin](../../replication.md) so peers can sync directly without a central server.
 
+The numbers reflect this. As of July 30, 2026, [Replicache](https://github.com/rocicorp/replicache) has 1,172 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `replicache` package was downloaded 50,513 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/replicache-vs-rxdb)). The last commit to the [Replicache repository](https://github.com/rocicorp/replicache) was in April 2022.
+
 ## Why Teams Pick RxDB Instead
 
 - **Apache 2.0 license** with no revenue gates on the core.

--- a/docs-src/docs/articles/alternatives/rethinkdb-alternative.md
+++ b/docs-src/docs/articles/alternatives/rethinkdb-alternative.md
@@ -99,6 +99,8 @@ ReQL is specific to RethinkDB. Knowledge of ReQL does not transfer to other data
 
 ---
 
+The numbers reflect this. As of July 30, 2026, the `rethinkdb` package was downloaded 65,314 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/rethinkdb-vs-rxdb)). The last commit to the [RethinkDB server repository](https://github.com/rethinkdb/rethinkdb) was in March 2026.
+
 ## How RxDB Approaches the Same Problems
 
 [RxDB](https://rxdb.info) is a local-first JavaScript database built for client-side environments: browsers, React Native, Electron, and Node.js. It shares the reactive programming goal of RethinkDB (data changes should automatically propagate to the UI) but implements it on the client side rather than relying on a persistent server connection.

--- a/docs-src/docs/articles/alternatives/signaldb-alternative.md
+++ b/docs-src/docs/articles/alternatives/signaldb-alternative.md
@@ -39,6 +39,8 @@ SignalDB is well designed for what it covers, but several gaps appear in product
 - **Smaller ecosystem.** Community plugins, examples, and long-term issue history are thinner. For business apps that ship for years, ecosystem depth matters.
 - **No schema-driven migrations.** SignalDB collections are loosely typed at runtime. RxDB enforces JSON Schema and runs versioned migrations on schema changes.
 
+The numbers reflect this. As of July 30, 2026, [SignalDB](https://github.com/maxnowack/signaldb) has 673 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `@signaldb/core` package was downloaded 6,642 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/@signaldb/core-vs-rxdb)).
+
 ## Why Teams Pick RxDB Instead
 
 ### Durable storage with a swappable engine

--- a/docs-src/docs/articles/alternatives/sql-js-alternative.md
+++ b/docs-src/docs/articles/alternatives/sql-js-alternative.md
@@ -50,6 +50,8 @@ Two browser tabs running sql.js each hold their own copy of the in-memory databa
 ### 6. Manual indexing strategy
 You get SQLite indexes, but you also get the responsibility of designing them around access patterns that change as the app grows.
 
+The numbers reflect this. As of July 30, 2026, [sql.js](https://github.com/sql-js/sql.js) has 13,652 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296. The last commit to the [sql.js repository](https://github.com/sql-js/sql.js) was in March 2026.
+
 ## Where RxDB Helps
 
 RxDB addresses each of those gaps without giving up on the option to keep SQLite as the engine.

--- a/docs-src/docs/articles/alternatives/watermelondb-alternative.md
+++ b/docs-src/docs/articles/alternatives/watermelondb-alternative.md
@@ -130,6 +130,8 @@ WatermelonDB's observable and reactive helpers are primarily designed for React 
 
 ---
 
+The numbers reflect this. As of July 30, 2026, [WatermelonDB](https://github.com/Nozbe/WatermelonDB) has 11,754 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296, and the `@nozbe/watermelondb` package was downloaded 247,829 times on npm in the last 30 days compared to 269,555 downloads of `rxdb` ([npm trends](https://npmtrends.com/@nozbe/watermelondb-vs-rxdb)). The last commit to the [WatermelonDB repository](https://github.com/Nozbe/WatermelonDB) was in August 2025.
+
 ## How RxDB Addresses These Problems
 
 [RxDB](https://rxdb.info) is a local-first JavaScript database built around the principle that all reads and writes happen against the local storage first, and replication with a server runs in the background. It has been in active development since 2016 and runs on browsers, React Native, Electron, and Node.js with the same API.

--- a/docs-src/docs/articles/alternatives/yjs-alternative.md
+++ b/docs-src/docs/articles/alternatives/yjs-alternative.md
@@ -65,6 +65,8 @@ Persistence is delegated to providers like `y-indexeddb` or `y-leveldb`. Each pr
 
 Yjs sync moves the entire update stream of a `Y.Doc`. That works for one shared document. For an app with thousands of independent records (orders, messages, contacts), you either pack everything into one giant `Y.Doc` and pay for it on every load, or you manage many small docs and write your own catalog, fan-out, and authorization layer.
 
+Both projects are under active development. As of July 30, 2026, [Yjs](https://github.com/yjs/yjs) has 22,263 GitHub stars while [RxDB](https://github.com/pubkey/rxdb) has 23,296.
+
 ## Where RxDB Fits
 
 RxDB approaches the same problem from the database side:


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (25 files under `docs-src/docs/articles/alternatives/`)

## Describe the problem you have without this PR

The alternatives articles make qualitative claims about the competitors ("maintenance mode", "low activity") without numbers. Per the GEO guideline in `CLAUDE.md` (the Princeton GEO study found sourced statistics raise AI citation visibility by roughly 30 to 40%), those claims should be backed by concrete, dated, sourced figures.

Each article's limitations section now gets one short paragraph, following three rules:

- **GitHub stars** are shown only where RxDB (23,296) has more than the alternative.
- **npm downloads (last 30 days)** are shown only where RxDB (269,555) has more, with an npm trends link as the source.
- **Last commit month** is shown only where the alternative's default branch has not seen a commit for more than 3 months (from 4 months for LowDB and RethinkDB up to 5.5 years for Hoodie and Horizon).

All numbers were measured on July 30, 2026 via the GitHub API and `api.npmjs.org`. Framing stays fair per the style guide: articles about actively developed projects (Dexie.js, Yjs, Apollo Client, PouchDB, ElectricSQL, InstantDB, PowerSync, CouchDB, Amplify) open the stat with "Both projects are under active development" and state only the star counts.

Not changed: `supabase-alternative.md`, `meteor-alternative.md`, and `couchbase-alternative.md`. Supabase leads RxDB on every metric, Meteor's npm package is not its real distribution channel (a downloads comparison would mislead), and Couchbase Lite's core repo star count is not an apples-to-apples adoption measure for a commercial product.

## Todos
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JANh8dbsUjfKG7GhveqpU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JANh8dbsUjfKG7GhveqpU1)_