### PR TITLE
Remove karma-ie-launcher

### DIFF
--- a/config/karma.conf.cjs
+++ b/config/karma.conf.cjs
@@ -95,7 +95,6 @@ module.exports = async function (config) {
             'karma-chrome-launcher',
             'karma-safari-launcher',
             'karma-firefox-launcher',
-            'karma-ie-launcher',
             'karma-opera-launcher',
             'karma-detect-browsers',
             'karma-spec-reporter',

--- a/package.json
+++ b/package.json
@@ -663,7 +663,6 @@
     "karma-chrome-launcher": "3.2.0",
     "karma-detect-browsers": "2.3.3",
     "karma-firefox-launcher": "2.1.3",
-    "karma-ie-launcher": "1.0.0",
     "karma-mocha": "2.0.1",
     "karma-opera-launcher": "1.0.0",
     "karma-safari-launcher": "1.0.0",


### PR DESCRIPTION
## This PR contains:

Something else: removal of an obsolete test devDependency.

## Describe the problem you have without this PR

`karma-ie-launcher` was still listed as a devDependency and loaded in the Karma `plugins` array. Internet Explorer is end-of-life and is never selected by `karma-detect-browsers`, so the plugin is dead weight in every install and every browser test run.

Changes:

- `package.json`: dropped the `karma-ie-launcher` devDependency.
- `config/karma.conf.cjs`: removed `'karma-ie-launcher'` from the loaded plugins.

No other file referenced the launcher, and no test behavior changes: the browsers actually used in CI come from `detectBrowsers.postDetection`, which never returned IE.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

None apply. This removes an unused dependency, so it is neither a testcase nor a fix and gets no changelog entry per the repo rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzwbibFAi2jzEYAevXuRQt)_