### PR TITLE
Replace unmaintained child-process-promise with Node built-ins

### DIFF
--- a/config/karma.webpack.conf.cjs
+++ b/config/karma.webpack.conf.cjs
@@ -14,6 +14,8 @@ const externals = {};
     'net',
     'querystring',
     'sqlite',
+    'util',
+    'child_process',
     'zlib'
 ].forEach(k => externals['node:' + k] = '{}');
 

--- a/package.json
+++ b/package.json
@@ -633,7 +633,6 @@
     "async-test-util": "2.5.0",
     "babel-loader": "10.1.1",
     "babel-plugin-transform-class-properties": "6.24.1",
-    "child-process-promise": "2.2.1",
     "clone": "2.1.2",
     "concurrently": "10.0.3",
     "copy-webpack-plugin": "14.0.0",

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -18,7 +18,8 @@ import {
 } from '../../plugins/test-utils/index.mjs';
 import { assertThrows } from 'async-test-util';
 import { RxDBDevModePlugin, DEV_MODE_PLUGIN_NAME } from '../../plugins/dev-mode/index.mjs';
-import { createRequire } from 'node:module';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { RxDBCleanupPlugin } from '../../plugins/cleanup/index.mjs';
 addRxPlugin(RxDBCleanupPlugin);
 
@@ -51,28 +52,27 @@ describe('plugin.test.js', () => {
             if (!isNode)
                 return;
 
-            const require = createRequire(import.meta.url);
-            const { spawn } = await require('child-process-promise');
-            const stdout: any[] = [];
-            const stderr: any[] = [];
-            const promise = spawn('mocha', [getRootPath() + 'test_tmp/unit/full.node.js']);
-            const childProcess = promise.childProcess;
-            childProcess.stdout.on('data', (data: any) => stdout.push(data.toString()));
-            childProcess.stderr.on('data', (data: any) => stderr.push(data.toString()));
+            const execFileAsync = promisify(execFile);
+            let stderr = '';
             try {
-                await promise;
-            } catch (err) {
+                const result = await execFileAsync(
+                    'mocha',
+                    [getRootPath() + 'test_tmp/unit/full.node.js'],
+                    { maxBuffer: 1024 * 1024 * 64 }
+                );
+                stderr = result.stderr;
+            } catch (err: any) {
                 console.error('errrrr');
-                console.dir(stdout);
+                console.dir(err.stdout);
                 throw new Error(`could not run full.node.js.
                     # Error: ${err}
-                    # Output: ${stdout}
-                    # ErrOut: ${stderr}
+                    # Output: ${err.stdout}
+                    # ErrOut: ${err.stderr}
                     `, { cause: err });
             }
 
             if (stderr.length > 0) {
-                throw new Error('got stderr: ' + stderr.join(', '));
+                throw new Error('got stderr: ' + stderr);
             }
         });
     });

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -53,11 +53,19 @@ describe('plugin.test.js', () => {
                 return;
 
             const execFileAsync = promisify(execFile);
-            let stderr = '';
+            let stderr: string;
             try {
+                /**
+                 * Run the mocha entrypoint with the current node binary
+                 * instead of relying on the `mocha` shim being in the PATH,
+                 * this also works on windows.
+                 */
                 const result = await execFileAsync(
-                    'mocha',
-                    [getRootPath() + 'test_tmp/unit/full.node.js'],
+                    process.execPath,
+                    [
+                        getRootPath() + 'node_modules/mocha/bin/mocha.js',
+                        getRootPath() + 'test_tmp/unit/full.node.js'
+                    ],
                     { maxBuffer: 1024 * 1024 * 64 }
                 );
                 stderr = result.stderr;


### PR DESCRIPTION
## This PR contains:

- IMPROVED TESTS
- SOMETHING ELSE (dependency cleanup)

## Describe the problem you have without this PR

`child-process-promise` is unmaintained (last release 2019). It was used in exactly one place, `test/unit/plugin.test.ts`, to spawn the `full.node.js` test run and await its exit.

Node ships an equivalent out of the box, so the dependency is not needed:

- `test/unit/plugin.test.ts` now uses `promisify(execFile)` from `node:util` / `node:child_process` instead of `child-process-promise`'s `spawn`. The `createRequire` indirection is gone as well, the imports are plain ESM imports now.
- The buffered `stdout` / `stderr` come straight off the resolved value, and on a non-zero exit off the rejected error, so the assertions and the error output of the test stay the same. `maxBuffer` is raised to 64 MB so a long mocha run does not get truncated.
- `child-process-promise` is removed from `devDependencies` in `package.json`.

No source code changes, this only touches the test setup and the devDependencies.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog <!-- dev-only dependency change, no user-facing fix or new testcase -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6WUjMrDPHv57MBrJEkNCH)_