### PR TITLE
docs: shorten the sitewide title suffix to "| RxDB"

### DIFF
--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -33,7 +33,18 @@ const rehypePrettyCodeOptions: RehypePrettyCodeOptions = {
 
 /** @type {import('@docusaurus/types').Config} */
 const config: Config = {
-    title: 'RxDB - JavaScript Database',
+    /**
+     * Docusaurus appends this to every page title as `<page title> | <title>`
+     * (see useTitleFormatter in @docusaurus/theme-common), so it doubles as the
+     * sitewide title suffix. Keep it short: Google truncates titles around 60
+     * characters and treats repeated boilerplate as a reason to rewrite the
+     * title link, which loses us control of the search listing.
+     * @link https://developers.google.com/search/docs/appearance/title-link
+     *
+     * Pages that need the longer descriptive form set it explicitly (the
+     * homepage and /consulting/ pass HOME_TITLE below).
+     */
+    title: 'RxDB',
     tagline: 'Realtime JavaScript Database',
     favicon: '/files/logo/logo.svg',
     headTags: [

--- a/docs-src/src/constants.ts
+++ b/docs-src/src/constants.ts
@@ -1,6 +1,14 @@
 export const NON_PREMIUM_COLLECTION_LIMIT = 13;
 
 /**
+ * Descriptive page title for the two pages that stand alone in search results
+ * and have no parent topic to give them context: the homepage and /consulting/.
+ * Everywhere else the page sets its own topical title and Docusaurus appends
+ * ` | RxDB` from the `title` in docusaurus.config.ts.
+ */
+export const HOME_TITLE = 'RxDB - JavaScript Database';
+
+/**
  * Premium tier prices in dollars per month, billed annually.
  * Shown on the premium page and used to calculate
  * the lead value on the premium-submitted pages.

--- a/docs-src/src/pages/chat-rules.tsx
+++ b/docs-src/src/pages/chat-rules.tsx
@@ -1,16 +1,14 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { } from 'react';
 
 
 export default function Chat() {
-    const { siteConfig } = useDocusaurusContext();
 
 
 
     return (
         <Layout
-            title={`Chat - ${siteConfig.title}`}
+            title={'Chat'}
             description="RxDB Community Chat Rules"
         >
             <main>

--- a/docs-src/src/pages/chat.tsx
+++ b/docs-src/src/pages/chat.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 
 export default function Chat() {
-    const { siteConfig } = useDocusaurusContext();
 
     useEffect(() => {
         triggerTrackingEvent('join_chat', 0.40);
@@ -12,7 +10,7 @@ export default function Chat() {
 
     return (
         <Layout
-            title={`Chat - ${siteConfig.title}`}
+            title={'Chat'}
             description="RxDB Community Chat"
         >
             <main>

--- a/docs-src/src/pages/code.tsx
+++ b/docs-src/src/pages/code.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 
 export default function Home() {
-    const { siteConfig } = useDocusaurusContext();
     useEffect(() => {
         triggerTrackingEvent('goto_code', 0.40);
     });
@@ -12,7 +10,7 @@ export default function Home() {
 
     return (
         <Layout
-            title={`Code - ${siteConfig.title}`}
+            title={'Code'}
             description="RxDB Source Code"
         >
             <main>

--- a/docs-src/src/pages/consulting.tsx
+++ b/docs-src/src/pages/consulting.tsx
@@ -1,5 +1,3 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 
@@ -10,9 +8,9 @@ const FILE_EVENT_ID = 'consulting-link-clicked';
 import { triggerTrackingEvent } from '../components/trigger-event';
 import { IframeFormModal } from '../components/modal';
 import { Button } from '../components/button';
+import { HOME_TITLE } from '../constants';
 
 export default function Consulting() {
-    const { siteConfig } = useDocusaurusContext();
     useEffect(() => {
         (() => {
             triggerTrackingEvent(FILE_EVENT_ID, 2);
@@ -29,7 +27,7 @@ export default function Consulting() {
                 <link rel="canonical" href="/consulting/" />
             </Head>
             <Layout
-                title={`${siteConfig.title}`}
+                title={HOME_TITLE}
                 description="RxDB is a fast, local-first NoSQL-database for JavaScript Applications like Websites, hybrid Apps, Electron-Apps, Progressive Web Apps and Node.js"
             >
                 <main>

--- a/docs-src/src/pages/demo-submitted.tsx
+++ b/docs-src/src/pages/demo-submitted.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 
 export default function DemoSubmitted() {
-    const { siteConfig } = useDocusaurusContext();
 
     useEffect(() => {
         (() => {
@@ -14,7 +12,7 @@ export default function DemoSubmitted() {
 
     return (
         <Layout
-            title={`Schedule Demo Submitted - ${siteConfig.title}`}
+            title={'Schedule Demo Submitted'}
             description="RxDB Schedule Demo Submitted"
         >
             <main>

--- a/docs-src/src/pages/index.tsx
+++ b/docs-src/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 
@@ -26,6 +25,7 @@ import { IconQuickstart } from '../components/icons/quickstart';
 import { FeaturesSection } from '../components/features-section';
 import { getTestGroup } from '../components/a-b-tests';
 import { CoreConceptSection } from '../components/core-concept-section';
+import { HOME_TITLE } from '../constants';
 
 
 export const colors = [
@@ -219,8 +219,6 @@ export default function Home(props: {
   // must be directly called here first, before any A/B-Test content is rendered
   getTestGroup(props.sem ? props.sem.id : '');
 
-  const { siteConfig } = useDocusaurusContext();
-
   const isBrowser = useIsBrowser();
   useEffect(() => {
     if (isBrowser) {
@@ -284,7 +282,7 @@ export default function Home(props: {
         <link rel="canonical" href="https://rxdb.info/" />
       </Head>
       <Layout
-        title={props.sem ? props.sem.metaTitle : siteConfig.title}
+        title={props.sem ? props.sem.metaTitle : HOME_TITLE}
         description="RxDB is a fast, local-first NoSQL-database for JavaScript Applications like Websites, hybrid Apps, Electron-Apps, Progressive Web Apps and Node.js">
         <main>
 

--- a/docs-src/src/pages/legal-notice.tsx
+++ b/docs-src/src/pages/legal-notice.tsx
@@ -1,17 +1,15 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import React from 'react';
 
 export default function LegalNotice() {
-    const { siteConfig } = useDocusaurusContext();
     return (
         <>
             <Head>
                 <meta name="robots" content="noindex"></meta>
             </Head>
             <Layout
-                title={`Legal Notice - ${siteConfig.title}`}
+                title={'Legal Notice'}
                 description="RxDB Legal Notice"
             >
                 <main>

--- a/docs-src/src/pages/license-preview.tsx
+++ b/docs-src/src/pages/license-preview.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import React from 'react';
 
 export default function LicensePreview() {
-    const { siteConfig } = useDocusaurusContext();
 
     return (
         <>
@@ -13,7 +11,7 @@ export default function LicensePreview() {
                 <meta name="robots" content="noindex, nofollow" />
             </Head>
             <Layout
-                title={`License Preview - ${siteConfig.title}`}
+                title={'License Preview'}
                 description="Preview the RxDB Premium License Agreement"
             >
                 <main>

--- a/docs-src/src/pages/license.tsx
+++ b/docs-src/src/pages/license.tsx
@@ -5,7 +5,6 @@
  * Therefore just use a rxdb.info link that redirects to pipedrive.
  * This also allows to track the conversion event.
  */
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect, useState } from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
@@ -14,7 +13,6 @@ import { triggerTrackingEvent } from '../components/trigger-event';
 const FILE_EVENT_ID = 'premium_license_opened';
 
 export default function LicensePreview() {
-    const { siteConfig } = useDocusaurusContext();
 
     const [goalUrl, setGoalUrl] = useState(null);
     const isBrowser = useIsBrowser();
@@ -44,7 +42,7 @@ export default function LicensePreview() {
 
     return (
         <Layout
-            title={`License Preview - ${siteConfig.title}`}
+            title={'License Preview'}
             description="License Preview"
         >
             <main>

--- a/docs-src/src/pages/meeting-paid-starter.tsx
+++ b/docs-src/src/pages/meeting-paid-starter.tsx
@@ -1,11 +1,9 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 const FILE_EVENT_ID = 'paid-meeting-link-clicked-starter-pack';
 
 export default function Meeting() {
-    const { siteConfig } = useDocusaurusContext();
     useEffect(() => {
         (() => {
             triggerTrackingEvent(FILE_EVENT_ID, 100, 1);
@@ -14,7 +12,7 @@ export default function Meeting() {
 
     return (
         <Layout
-            title={`Meeting - ${siteConfig.title}`}
+            title={'Meeting'}
             description="RxDB Meeting Scheduler"
         >
             <main>

--- a/docs-src/src/pages/meeting-paid.tsx
+++ b/docs-src/src/pages/meeting-paid.tsx
@@ -1,11 +1,9 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 const FILE_EVENT_ID = 'paid-meeting-link-clicked';
 
 export default function Meeting() {
-    const { siteConfig } = useDocusaurusContext();
     useEffect(() => {
         (() => {
             triggerTrackingEvent(FILE_EVENT_ID, 100, 1);
@@ -14,7 +12,7 @@ export default function Meeting() {
 
     return (
         <Layout
-            title={`Meeting - ${siteConfig.title}`}
+            title={'Meeting'}
             description="RxDB Meeting Scheduler"
         >
             <main>

--- a/docs-src/src/pages/meeting.tsx
+++ b/docs-src/src/pages/meeting.tsx
@@ -1,11 +1,9 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 const FILE_EVENT_ID = 'meeting-link-clicked';
 
 export default function Meeting() {
-    const { siteConfig } = useDocusaurusContext();
     useEffect(() => {
         (() => {
             triggerTrackingEvent(FILE_EVENT_ID, 40, 1);
@@ -14,7 +12,7 @@ export default function Meeting() {
 
     return (
         <Layout
-            title={`Meeting - ${siteConfig.title}`}
+            title={'Meeting'}
             description="RxDB Meeting Scheduler"
         >
             <main>

--- a/docs-src/src/pages/newsletter.tsx
+++ b/docs-src/src/pages/newsletter.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 
 export default function Newsletter() {
-    const { siteConfig } = useDocusaurusContext();
 
     useEffect(() => {
         triggerTrackingEvent('get_newsletter', 0.40);
@@ -12,7 +10,7 @@ export default function Newsletter() {
 
     return (
         <Layout
-            title={`Newsletter - ${siteConfig.title}`}
+            title={'Newsletter'}
             description="RxDB Newsletter"
         >
             <main>

--- a/docs-src/src/pages/premium.tsx
+++ b/docs-src/src/pages/premium.tsx
@@ -1,4 +1,3 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 
@@ -53,7 +52,6 @@ const PRODUCT_JSON_LD = {
 };
 
 export default function Premium() {
-    const { siteConfig } = useDocusaurusContext();
     const isBrowser = useIsBrowser();
     const [initDone, setInitDone] = React.useState<boolean>(false);
 
@@ -109,7 +107,7 @@ export default function Premium() {
             </Head>
 
             <Layout
-                title={`RxDB for Professionals - ${siteConfig.title}`}
+                title={'RxDB for Professionals'}
                 description="RxDB plugins for professionals. FAQ, pricing and license"
             >
                 <main>

--- a/docs-src/src/pages/privacy.tsx
+++ b/docs-src/src/pages/privacy.tsx
@@ -1,17 +1,15 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import React from 'react';
 
 export default function Privacy() {
-    const { siteConfig } = useDocusaurusContext();
     return (
         <>
             <Head>
                 <meta name="robots" content="noindex, nofollow"></meta>
             </Head>
             <Layout
-                title={`Datenschutzerklärung / Privacy Policy - ${siteConfig.title}`}
+                title={'Datenschutzerklärung / Privacy Policy'}
                 description="RxDB Datenschutzerklärung / Privacy Policy"
             >
                 <main>

--- a/docs-src/src/pages/release.tsx
+++ b/docs-src/src/pages/release.tsx
@@ -1,10 +1,8 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect, useState } from 'react';
 
 
 export default function Home() {
-    const { siteConfig } = useDocusaurusContext();
     const [redirectUrl, setRedirectUrl] = useState('https://github.com/pubkey/rxdb');
 
     useEffect(() => {
@@ -31,7 +29,7 @@ export default function Home() {
 
     return (
         <Layout
-            title={`Code - ${siteConfig.title}`}
+            title={'Code'}
             description="RxDB Source Code"
         >
             <main>

--- a/docs-src/src/pages/service-submitted.tsx
+++ b/docs-src/src/pages/service-submitted.tsx
@@ -1,11 +1,9 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 const FILE_EVENT_ID = 'paid-meeting-link-clicked';
 
 export default function ServiceSubmitted() {
-    const { siteConfig } = useDocusaurusContext();
 
     useEffect(() => {
         (() => {
@@ -15,7 +13,7 @@ export default function ServiceSubmitted() {
 
     return (
         <Layout
-            title={`Service Request Submitted - ${siteConfig.title}`}
+            title={'Service Request Submitted'}
             description="RxDB Meeting Scheduler"
         >
             <main>

--- a/docs-src/src/pages/survey.tsx
+++ b/docs-src/src/pages/survey.tsx
@@ -1,15 +1,13 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React from 'react';
 
 export default function Home() {
-    const { siteConfig } = useDocusaurusContext();
 
 
 
     return (
         <Layout
-            title={`RxDB User Survey - ${siteConfig.title}`}
+            title={'RxDB User Survey'}
             description="RxDB User Survey"
         >
             <main>

--- a/docs-src/src/theme/PageMetadata/index.tsx
+++ b/docs-src/src/theme/PageMetadata/index.tsx
@@ -7,10 +7,16 @@ import type { Props } from '@theme/PageMetadata';
 /**
  * Swizzled version of the default Docusaurus PageMetadata.
  *
- * The only difference to the original is the page title:
- * Docusaurus appends the site title (`| RxDB - JavaScript Database`)
- * to every page title. This removes that suffix so the SEO title
- * is just the page title itself.
+ * The only difference to the original is the page title: this renders the raw
+ * page title instead of running it through `useTitleFormatter`.
+ *
+ * NOTE: this does NOT remove the ` | <site title>` suffix from rendered pages,
+ * even though it skips the formatter. Docs and plugin pages import
+ * `PageMetadata` from `@docusaurus/theme-common` directly rather than through
+ * `@theme/PageMetadata`, so they never reach this component and the suffix is
+ * still appended. Verified 2026-07-30: every page on the live site ends with
+ * the site title. The suffix is controlled by `title` in docusaurus.config.ts,
+ * which is the only global lever for it.
  * @link https://github.com/pubkey/rxdb
  */
 export default function PageMetadata({

--- a/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -1,0 +1,48 @@
+import React, { type ReactNode } from 'react';
+import { TitleFormatterProvider } from '@docusaurus/theme-common/internal';
+import { HOME_TITLE } from '../../../constants';
+
+/**
+ * Swizzled title formatter.
+ *
+ * Docusaurus renders every page title as `<page title> | <siteConfig.title>`.
+ * `siteConfig.title` is therefore the sitewide suffix, and it is deliberately
+ * kept short (`RxDB`) so titles stay inside Google's ~60 character budget.
+ *
+ * The default formatter skips the suffix only when the page title is exactly
+ * equal to `siteConfig.title`. That is too narrow for us: the homepage and
+ * /consulting/ carry the longer descriptive HOME_TITLE, which already contains
+ * the brand, so appending the suffix would render `RxDB - JavaScript Database
+ * | RxDB`. Treat HOME_TITLE the same way Docusaurus treats the site title.
+ *
+ * NOTE: `ThemeProvider/TitleFormatter` is a real theme component (shipped by
+ * theme-classic at lib/theme/ThemeProvider/TitleFormatter) but it is not in
+ * `docusaurus swizzle --list`, so it counts as an unsafe swizzle: a Docusaurus
+ * upgrade could move or rename it. If it ever stops being picked up, the
+ * symptom is the homepage title rendering as
+ * `RxDB - JavaScript Database | RxDB`. The fallback is to drop this file and
+ * give the homepage a title that reads correctly with the suffix appended,
+ * e.g. `Local-First JavaScript Database` -> `Local-First JavaScript Database | RxDB`.
+ *
+ * @link https://docusaurus.io/docs/swizzling
+ */
+const formatter: React.ComponentProps<
+    typeof TitleFormatterProvider
+>['formatter'] = (params) => {
+    if (params.title?.trim() === HOME_TITLE) {
+        return HOME_TITLE;
+    }
+    return params.defaultFormatter(params);
+};
+
+export default function ThemeProviderTitleFormatter({
+    children,
+}: {
+    children: ReactNode;
+}): ReactNode {
+    return (
+        <TitleFormatterProvider formatter={formatter}>
+            {children}
+        </TitleFormatterProvider>
+    );
+}


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (SEO / page titles)

## Describe the problem you have without this PR

Every page title on rxdb.info ends with `| RxDB - JavaScript Database`, a 29-character suffix. Because the pages under `src/pages` *also* concatenated the site title into their own title, most of them rendered the brand three times. Verified live on 2026-07-30:

```
Legal Notice - RxDB - JavaScript Database | RxDB - JavaScript Database
RxDB for Professionals - RxDB - JavaScript Database | RxDB - JavaScript Database
RxDB User Survey - RxDB - JavaScript Database | RxDB - JavaScript Database
```

Two reasons this costs us clicks:

1. **Truncation.** Google cuts desktop titles around 60 characters. Nine of the ten highest-impression article titles are longer than that; four are over 90.
2. **Boilerplate rewriting.** Google's [title link documentation](https://developers.google.com/search/docs/appearance/title-link) names repeated boilerplate as a reason it replaces your title with one of its own choosing. A rewritten title is a search listing we no longer control.

The motivation was an analysis of our Search Console export: 69 non-brand queries where we rank at position 10 or better but click through at under 75% of our own average CTR for that position, together about 4,200 clicks below baseline.

## What changed

- **`docusaurus.config.ts`**: `title` from `'RxDB - JavaScript Database'` to `'RxDB'`. This is the only global lever for the suffix. Docusaurus builds it from `siteConfig.title` in `useTitleFormatter` (`@docusaurus/theme-common/src/utils/titleFormatterUtils.tsx`), so there is no separate suffix setting.
- **16 pages under `src/pages`**: dropped the `- ${siteConfig.title}` concatenation, since the global suffix already supplies the brand. Removed the `useDocusaurusContext` imports that became unused.
- **`constants.ts`**: added `HOME_TITLE`, the descriptive title for the two pages that stand alone in search results with no parent topic for context (the homepage and `/consulting/`).
- **`theme/ThemeProvider/TitleFormatter/`** (new): skips the suffix when the page title is `HOME_TITLE`, mirroring the guard Docusaurus already applies when the page title equals the site title. Without it the homepage would render `RxDB - JavaScript Database | RxDB`.
- **`theme/PageMetadata/`**: corrected a comment. It claimed the swizzle strips the site-title suffix; it does not, because docs and plugin pages import `PageMetadata` from `@docusaurus/theme-common` directly and never reach the swizzled component. The live titles confirm the suffix is still applied everywhere.

### Resulting titles

| | Before | After |
| --- | --- | --- |
| `crdt.html` | `CRDT - Conflict-free replicated data type Database \| RxDB - JavaScript Database` (79) | `CRDT - Conflict-free replicated data type Database \| RxDB` (57) |
| `/legal-notice/` | `Legal Notice - RxDB - JavaScript Database \| RxDB - JavaScript Database` (70) | `Legal Notice \| RxDB` (19) |
| `/premium/` | `RxDB for Professionals - RxDB - JavaScript Database \| RxDB - JavaScript Database` (80) | `RxDB for Professionals \| RxDB` (29) |
| homepage | `RxDB - JavaScript Database` | unchanged |

The homepage is deliberately untouched: it is the highest-impression page on the site and its title is already only 26 characters.

## Notes for review

- **`ThemeProvider/TitleFormatter` is an unlisted swizzle target.** It is a real theme component shipped by `theme-classic`, but it does not appear in `docusaurus swizzle --list`, so a Docusaurus upgrade could move it. The file documents the symptom (homepage rendering `RxDB - JavaScript Database | RxDB`) and the fallback: delete the override and give the homepage a title that reads correctly with the suffix appended, e.g. `Local-First JavaScript Database`. Happy to take that simpler route instead if you would rather not carry the swizzle.
- **`src/pages/release.tsx` had `title={'Code - ...'}`**, which looks like a copy-paste from `code.tsx`. I preserved the label as `Code` rather than renaming it, since that is a content decision. Worth a separate fix.

## Todos

- [ ] Tests — none added; this is a docs/config change with no runtime behavior to assert on, and the repo has no title-rendering test to extend.
- [x] Documentation — the reasoning is documented inline in `docusaurus.config.ts`, `constants.ts`, and the new formatter.
- [ ] Typings — no typing changes.
- [ ] Changelog — not user-facing for the library.

## Verification

- `npx tsc --noEmit` over `docs-src`: **482 errors before, 482 after**, identical set with only line numbers shifted. No new type errors. (The pre-existing errors come from running `tsc` without the generated Docusaurus types and an unbuilt root package.)
- A full `docusaurus build` was not run here: it needs the root `rxdb` package built, which this environment did not have. CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdFsKbki2tz7pjYUL8xBzA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdFsKbki2tz7pjYUL8xBzA)_