### PR TITLE
Note the simple-peer replacement in before-next-major.md

### DIFF
--- a/orga/before-next-major.md
+++ b/orga/before-next-major.md
@@ -36,6 +36,30 @@ https://github.com/pubkey/rxdb/issues/6810
 
 https://discord.com/channels/969553741705539624/1237000453791678487/threads/1327921349808885831
 
+## Replace `simple-peer` with `@thaunknown/simple-peer`
+
+The `simple-peer` package that the [WebRTC replication](https://rxdb.info/replication-webrtc.html), the Google Drive replication and the Microsoft OneDrive replication use is unmaintained. Its last release was `9.11.1` in February 2022 and its repository has over 100 open issues. It depends on `buffer`, `readable-stream`, `randombytes`, `get-browser-rtc`, `queue-microtask`, `err-code` and `debug`, and those Node.js shims are what reaches the users:
+
+- https://github.com/pubkey/rxdb/issues/8605 `ReferenceError: global is not defined` from `randombytes`, which breaks Angular builds.
+- https://github.com/pubkey/rxdb/issues/4960 `Cannot read properties of undefined (reading 'call') at _Peer.Readable`.
+- https://github.com/pubkey/rxdb/issues/7365 npm audit reports `rxdb -> Depends on vulnerable versions of simple-peer`.
+- The error code `RC7` exists only to tell people that `simple-peer` needs `process.nextTick()` to be polyfilled.
+- `createSimplePeerWrtc()` exists only to work around `simple-peer` mutating the `RTCSessionDescription` objects of WebRTC polyfills.
+
+[@thaunknown/simple-peer](https://www.npmjs.com/package/@thaunknown/simple-peer) is an API compatible fork that is still released. It is ESM, replaces `readable-stream` and `buffer` with `streamx` and `Uint8Array`, and has a `lite.js` entry point that contains only the data channel code and not the MediaStream handling, which is the only part that RxDB uses.
+
+RxDB only uses `new Peer({initiator, config, trickle})`, the `signal`, `connect`, `data`, `close` and `error` events and `.signal()`, `.send()` and `.destroy()`, so the swap itself is small. These things were found while trying it out and have to be handled:
+
+- **It must be an optional peer dependency**, like `firebase` and `mongodb`. The fork depends on `webrtc-polyfill`, which depends on `node-datachannel`, a native NAPI addon with an install script. As a normal dependency that native install runs on every `npm install rxdb`, browser only apps included. Requiring the install is the main reason why this is a breaking change.
+- **It can never be loaded with `require()`.** `webrtc-polyfill` has no `require` condition in its `exports` map, which fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and `webrtc-polyfill/lib/Blob.js` starts with a top-level await, which fails with `ERR_REQUIRE_ASYNC_MODULE` on every Node.js version. Raising the `engines` field does not help. It has to be loaded with a dynamic `import()`, which babel and tsx both leave untouched, otherwise `require('rxdb/plugins/replication-webrtc')` breaks in the CommonJS build. The testcases of the Google Drive and OneDrive replication run through tsx and are affected the same way.
+- **The `data` event emits `Uint8Array` instead of a Node.js `Buffer`.** All three call sites decode the payload with `toString()` or `+ ''`, which on a `Uint8Array` returns the comma separated byte values instead of the JSON string. They have to decode with a `TextDecoder`, otherwise every message fails to parse.
+- **React Native still needs a WebRTC implementation.** The fork removed the `wrtc` option and reads the api from `webrtc-polyfill`, which covers browsers with the native api and Node.js with `node-datachannel`. React Native is neither and `webrtc-polyfill` has no `react-native` export condition. Because the fork reads the api from the global scope once at load time, the `wrtc` option can be kept working by writing it to the global scope right before the lazy `import()`. On top of that, Metro has to be told to resolve `webrtc-polyfill` to its browser build, otherwise it picks the Node.js one with the native module.
+- `RC7` and `ensureProcessNextTickIsSet()` can be removed. `streamx` uses `queueMicrotask()`.
+- `@types/simple-peer` can be dropped, but the fork ships no types, so the used part of the api has to be declared. Declaring only the used part narrows the public `SimplePeer` type, which breaks the builds of people who call other methods on the peers from `connect$` and `message$`.
+- `@thaunknown/simple-peer` has to be added to the ignored modules of the `test:deps` script, next to `ws`, because `dependency-check` only detects static imports.
+
+A full implementation with green CI is at https://github.com/pubkey/rxdb/pull/8900
+
 
 ---------------------------------
 ## Maybe later (not sure if should be done)


### PR DESCRIPTION
## This PR contains:

- SOMETHING ELSE (a note in `orga/before-next-major.md`, no source changes)

## Describe the problem you have without this PR

The `simple-peer` package that the WebRTC, Google Drive and Microsoft OneDrive replication use is unmaintained. Its last release was `9.11.1` in February 2022 and its repository has over 100 open issues. Its Node.js shim dependencies are what reaches the users:

- [#8605](https://github.com/pubkey/rxdb/issues/8605): `ReferenceError: global is not defined` from `randombytes`, which breaks Angular builds.
- [#4960](https://github.com/pubkey/rxdb/issues/4960): `Cannot read properties of undefined (reading 'call') at _Peer.Readable`.
- [#7365](https://github.com/pubkey/rxdb/issues/7365): npm audit reports `rxdb -> Depends on vulnerable versions of simple-peer`.
- The error code `RC7` exists only to tell people that `simple-peer` needs `process.nextTick()` polyfilled.
- `createSimplePeerWrtc()` exists only to work around `simple-peer` mutating `RTCSessionDescription` objects.

[@thaunknown/simple-peer](https://www.npmjs.com/package/@thaunknown/simple-peer) is an API compatible fork that is still released. Swapping to it is a **breaking change**, mainly because it has to be an optional peer dependency: it depends on `webrtc-polyfill`, which depends on `node-datachannel`, a native NAPI addon with an install script. As a normal dependency that native install would run on every `npm install rxdb`, browser only apps included. So users of the three affected replication plugins would have to install it themselves.

Because of that this PR does not implement the swap. It only writes the task and the findings down in `orga/before-next-major.md` so the work can be picked up for the next major release without having to be rediscovered.

### What the note records

Beyond the motivation, the entry keeps the non-obvious things that came up while trying the swap out:

- The fork can **never** be loaded with `require()`. `webrtc-polyfill` has no `require` condition in its `exports` map (`ERR_PACKAGE_PATH_NOT_EXPORTED`) and `webrtc-polyfill/lib/Blob.js` starts with a top-level await (`ERR_REQUIRE_ASYNC_MODULE`, on every Node.js version). Raising `engines` does not help. It has to be loaded with a dynamic `import()`, or `require('rxdb/plugins/replication-webrtc')` breaks in the CommonJS build. The tsx-run Drive and OneDrive testcases are affected the same way.
- The `data` event emits `Uint8Array` instead of a Node.js `Buffer`. All three call sites decode with `toString()` or `+ ''`, which on a `Uint8Array` returns the comma separated byte values instead of the JSON string, so every message would fail to parse without a `TextDecoder`.
- React Native still needs a WebRTC implementation. The fork removed the `wrtc` option and `webrtc-polyfill` has no `react-native` export condition. The option can be kept working by writing the implementation to the global scope right before the lazy `import()`, plus a Metro resolver entry so `webrtc-polyfill` resolves to its browser build.
- `RC7` and `ensureProcessNextTickIsSet()` become removable, `@types/simple-peer` can be dropped but the used api has to be declared by hand, and the fork has to join the ignored modules of `test:deps` next to `ws`.

A full working implementation of the swap, with all CI checks green, is preserved in the history of this branch for whoever picks this up.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

No testcase, source or `FIX` change is included, so per the changelog rule no changelog entry is added.