### PR TITLE
docs: add sem landingpages galocal1-3

### DIFF
--- a/docs-src/src/pages/sem/galocal1.tsx
+++ b/docs-src/src/pages/sem/galocal1.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "galocal1".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+        bulletpoints: [
+            <>Build apps that work offline</>,
+            <>Sync with any Backend</>,
+            <>Observable Realtime Queries</>,
+            <>All JavaScript Runtimes Supported</>
+        ]
+    },
+    b: {
+        title: <><b>Zero Latency</b>. Your Data Is <b>Already There</b>.</>,
+        text: <>RxDB keeps your app's data on the device, so every query answers instantly. No request waterfalls, no loading spinners. The network is only used for sync, and your app works with or without it.</>,
+        bulletpoints: [
+            <>Instant queries, no network round trip</>,
+            <>Works offline out of the box</>,
+            <>Realtime sync in the background</>,
+            <>Open source, works with any backend</>
+        ]
+    },
+    c: {
+        title: <><b>Local-First</b> Is the Future. Build It With <b>RxDB</b>.</>,
+        text: <>You own your data, in spite of the cloud. RxDB brings the local-first architecture to JavaScript: data lives on the device, syncs to any backend you choose, and your app keeps working offline.</>,
+        bulletpoints: [
+            <>Local-first architecture, ready today</>,
+            <>You own your data and your backend</>,
+            <>Conflict handling built in</>,
+            <>Works with React, Vue, and Angular</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Build Local-First Apps With Zero-Latency Queries',
+            appName: 'JavaScript',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}

--- a/docs-src/src/pages/sem/galocal2.tsx
+++ b/docs-src/src/pages/sem/galocal2.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "galocal2".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <>The <b>Local-First</b> Database for Your <b>JavaScript</b> Stack</>,
+        text: <>RxDB is a reactive NoSQL database that runs in browsers, React Native, Capacitor, Electron, and Node.js. Observable queries keep your UI in sync, and replication connects any backend you choose.</>,
+        bulletpoints: [
+            <>React, Vue, Angular, and Svelte</>,
+            <>React Native, Capacitor, Electron</>,
+            <>Observable realtime queries</>,
+            <>TypeScript support out of the box</>
+        ]
+    },
+    b: {
+        title: <><b>Local-First</b> With Sync <b>You Control</b></>,
+        text: <>RxDB replicates over HTTP, WebSocket, GraphQL, or WebRTC to a backend you own. Open-source core, pluggable storage engines, and no per-read pricing. Your data stays your data.</>,
+        bulletpoints: [
+            <>Self-hostable replication</>,
+            <>Open-source core</>,
+            <>Pluggable storage engines</>,
+            <>No vendor lock-in</>
+        ]
+    },
+    c: {
+        title: <>A <b>Local-First</b> Database With Real <b>Conflict Handling</b></>,
+        text: <>Offline writes create conflicts. RxDB detects them and resolves them with custom handlers or CRDTs, keeps every browser tab consistent, and replicates changes in realtime to any backend.</>,
+        bulletpoints: [
+            <>Conflict detection and resolution</>,
+            <>CRDT support included</>,
+            <>Multi-tab consistency</>,
+            <>Realtime replication</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Open-Source Local-First Database for JavaScript',
+            appName: 'JavaScript',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}

--- a/docs-src/src/pages/sem/galocal3.tsx
+++ b/docs-src/src/pages/sem/galocal3.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import Home from '..';
+import { getSemVariation } from '../../components/a-b-tests';
+
+/**
+ * SEM landingpage for "galocal3".
+ * A/b tests 3 variations of the title, description and bulletpoints.
+ * The variation is picked randomly per visitor and kept stable via localStorage.
+ */
+
+/**
+ * The a/b test variations, identified by stable letter keys - NOT by array
+ * position. Letters keep their meaning when variations change over time:
+ * - NEVER reuse a letter: a new variation always gets the next unused letter.
+ * - NEVER delete a variation: comment it out instead, so its letter and copy
+ *   stay on record and cannot be re-assigned by accident.
+ */
+const variations = {
+    a: {
+        title: <><b>Local-First</b> Without the <b>Hand-Rolled Sync</b></>,
+        text: <>Building your own sync engine means retries, conflicts, and edge cases that bite back. RxDB ships the sync engine: replication to any backend, conflict handling, and offline support in one database.</>,
+        bulletpoints: [
+            <>No hand-written sync code</>,
+            <>Conflict handling included</>,
+            <>Automatic retries on reconnect</>,
+            <>Works offline by default</>
+        ]
+    },
+    b: {
+        title: <>Your Users Should <b>Never See a Spinner</b></>,
+        text: <>When data lives on the device, the UI never waits for the network. RxDB gives you instant queries, background sync, and an app that keeps working when the connection drops.</>,
+        bulletpoints: [
+            <>Instant UI from local data</>,
+            <>Background sync when online</>,
+            <>Keeps working offline</>,
+            <>Open source, any backend</>
+        ]
+    },
+    c: {
+        title: <><b>Local-First</b> Sync Without the <b>SaaS Bill</b></>,
+        text: <>Cloud-first backends charge for every read and hold your data. RxDB stores data on the device and syncs to infrastructure you already run. No per-read pricing, no lock-in, open source.</>,
+        bulletpoints: [
+            <>Sync to your own backend</>,
+            <>No per-read pricing</>,
+            <>Open-source core</>,
+            <>You keep your data</>
+        ]
+    }
+};
+
+export default function Page() {
+    /**
+     * Render variation "a" on the server and on the first client render
+     * to avoid a hydration mismatch, then swap to the assigned variation.
+     */
+    const [variationKey, setVariationKey] = useState('a');
+    useEffect(() => {
+        setVariationKey(getSemVariation(Object.keys(variations)));
+    }, []);
+    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+
+    return Home({
+        sem: {
+            id: 'gads',
+            metaTitle: 'RxDB: Local-First Sync Without the Hand-Rolled Code',
+            appName: 'JavaScript',
+            title: variation.title,
+            text: variation.text,
+            bulletpoints: variation.bulletpoints
+        }
+    });
+}


### PR DESCRIPTION
## This PR contains:
- Three new SEM landingpages: `docs-src/src/pages/sem/galocal1.tsx`, `galocal2.tsx`, `galocal3.tsx`

## Describe the problem you have without this PR
The `/sem/galocal1/`, `/sem/galocal2/` and `/sem/galocal3/` landingpage URLs do not exist yet. Each new page follows the existing sem page pattern (same structure as `garealm1.tsx`): it renders the main landingpage through the `sem` prop and a/b tests 3 copy variations (title, description, bulletpoints) keyed by stable letters via `getSemVariation`, focused on local-first app development with RxDB.

No changelog entry: sem landingpages are not a testcase or a FIX, so the Changelog Rule does not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Xi72t2zQw6mDT6WGcuTRT)_