### PR TITLE
Update dependency deno to v2.9.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1119,7 +1119,7 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           # https://github.com/denoland/deno/releases
-          deno-version: "2.6.5"
+          deno-version: "2.9.4"
       - name: run deno tests:dexie
         run: |
           sudo npm i -g cross-env


### PR DESCRIPTION
## This PR contains:

Something else: a dependency update. The Deno version used by `denoland/setup-deno` in `.github/workflows/main.yml` goes from `2.6.5` to `2.9.4`.

## Describe the problem you have without this PR

The CI Deno job pins Deno `2.6.5`, so the Deno tests (`test:deno:dexie` and `test:deno:denokv`) run against an outdated runtime while users install the current release. `2.9.4` is the latest stable Deno release, so CI now matches what people actually run.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

No test, docs, typings, or changelog changes are needed. This only bumps a CI runtime version and does not touch source code.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135Zu4qu6QVZxX6HLNgy73Z)_