### PR TITLE
Update dependency react-native to 0.86.2

### DIFF
--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -25,7 +25,7 @@
     "jest-expo": "54.0.16",
     "random-token": "0.0.8",
     "react": "19.2.8",
-    "react-native": "0.84.1",
+    "react-native": "0.86.2",
     "react-native-gesture-handler": "3.1.0",
     "react-native-get-random-values": "2.0.0",
     "react-native-quick-base64": "3.0.1",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@expo/cli": "57.0.10",
+    "@react-native/jest-preset": "0.86.2",
     "babel-preset-expo": "54.0.9",
     "buffer": "6.0.3",
     "cross-fetch": "4.1.0",
@@ -36,6 +37,11 @@
     "stream": "0.0.3"
   },
   "//": "NOTICE: For the Github CI we use the local RxDB build (rxdb-local.tgz). In your app should just install 'rxdb' from npm instead",
+  "//overrides": "babel-preset-expo pins the react-native codegen packages to a version that cannot parse the react-native sources. They have to match the installed react-native version so that 'expo export' can bundle.",
+  "overrides": {
+    "@react-native/codegen": "0.86.2",
+    "@react-native/babel-plugin-codegen": "0.86.2"
+  },
   "dependencies": {
     "expo-crypto": "57.0.1",
     "expo-sqlite": "57.0.1",


### PR DESCRIPTION
## This PR contains:

Dependency update for the React Native example.

Bumps `react-native` in `examples/react-native` from `0.84.1` to `0.86.2`, plus the two changes needed to keep the CI job green with the pinned Expo SDK.

## Describe the problem you have without this PR

`react-native` in the React Native example was two minor versions behind the current release. Bumping it on its own breaks both steps of the `example-react-native-expo` CI job, because two things changed between `0.84` and `0.86`:

**1. The Jest preset moved out of the `react-native` package.**

Since `react-native@0.85`, `react-native/jest-preset` is a thin re-export of the separate `@react-native/jest-preset` package, and it throws when that package is missing:

```
An unknown error occurred in jest-expo/ios:
  The React Native Jest preset has moved to a separate package.
```

`@react-native/jest-preset` is declared as a peer dependency of `react-native`, but the CI installs with `--legacy-peer-deps`, so peers are not installed automatically. It is now listed explicitly in `devDependencies`, pinned to the same version as `react-native`.

**2. `babel-preset-expo` ships a codegen that cannot parse the new sources.**

`babel-preset-expo@54.0.9` pins `@react-native/babel-preset` to `0.81.5`, which pulls in `@react-native/codegen@0.81.5`. That codegen fails on the `react-native@0.86` sources, so `expo export` aborts:

```
SyntaxError: node_modules/react-native/src/private/components/virtualview/VirtualViewExperimentalNativeComponent.js:
  Unable to determine event arguments for "onModeChange"
```

`expo`, `babel-preset-expo`, and `jest-expo` are in `ignoreDeps` in `renovate.json` and stay on 54, so the codegen packages are pinned to the installed `react-native` version through an `overrides` block instead.

### Verification

Both steps of the `example-react-native-expo` job were run locally against the freshly built RxDB tarball:

- `npm run test` - 2 test suites, 6 tests passed (iOS and Android jest projects)
- `npm run test:bundle` - `Exported: dist`

For reference, `expo export` was also confirmed to succeed on the previous `react-native@0.84.1`, so the bundle failure above is caused by the version bump and not pre-existing.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

No changelog entry: this is a dependency update in an example app, not a testcase or a FIX.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R1oiPzyCgH4Y3cHLxiAYSk)_