### PR TITLE
Add security findings prompt to generic prompts article

### DIFF
--- a/docs-src/docs/articles/generic-prompts.md
+++ b/docs-src/docs/articles/generic-prompts.md
@@ -87,6 +87,19 @@ Add the improvement to the changelog.
 
 ## Security
 
+### Find and fix a security issue
+
+Agents tend to report theoretical security problems that no attacker can trigger in practice. This prompt forces the agent to prove each finding with a reproduction before it is allowed to fix anything.
+
+```txt
+Do a security review of FEATURE_NAME and make a list of possible security findings, ranked by severity. For each finding explain how an attacker could exploit it in practice. Findings that require the attacker to already run arbitrary code inside of the same process do not count. Pick the most severe finding and write a test case that reproduces the problem. In the test case you can only use the public API with correct TypeScript type usage. First run the test case without a fix and show me the output. Then apply a fix and run the test case again and show me the output.
+
+- Ensure all other tests run successful.
+- Do not add new dependencies as part of the fix.
+- Add the fix to the changelog.
+- Ensure the linting is ok.
+```
+
 ## SEO
 
 -------------

--- a/docs-src/docs/articles/generic-prompts.md
+++ b/docs-src/docs/articles/generic-prompts.md
@@ -92,7 +92,12 @@ Add the improvement to the changelog.
 Agents tend to report theoretical security problems that no attacker can trigger in practice. This prompt forces the agent to prove each finding with a reproduction before it is allowed to fix anything.
 
 ```txt
-Do a security review of FEATURE_NAME and make a list of possible security findings, ranked by severity. For each finding explain how an attacker could exploit it in practice. Findings that require the attacker to already run arbitrary code inside of the same process do not count. Pick the most severe finding and write a test case that reproduces the problem. In the test case you can only use the public API with correct TypeScript type usage. First run the test case without a fix and show me the output. Then apply a fix and run the test case again and show me the output.
+Do a security review of FEATURE_NAME and make a list of possible security findings, ranked by severity.
+For each finding explain how an attacker could exploit it in practice.
+Findings that require the attacker to already run arbitrary code inside of the same process do not count.
+Pick the most severe finding and write a test case that reproduces the problem.
+In the test case you can only use the public API.
+First run the test case without a fix and show me the output. Then apply a fix and run the test case again and show me the output.
 
 - Ensure all other tests run successful.
 - Do not add new dependencies as part of the fix.


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS

## Describe the problem you have without this PR
The `## Security` section on the generic prompts page (`docs-src/docs/articles/generic-prompts.md`) is empty. This PR adds a reusable "Find and fix a security issue" prompt in the same style as the existing "Find a bug and fix it" prompt: the agent has to rank findings by severity, explain a practical exploit, reproduce the most severe finding with a test case through the public API, and only then fix it. Findings that require the attacker to already run arbitrary code in the same process are excluded to filter out theoretical reports.

## Todos
- [x] Documentation

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8UxcJb73BsQ1MNudFftW3)_