### PR TITLE
Rewrite offline-database article with modern sync section and improvement guide

### DIFF
--- a/docs-src/docs/articles/offline-database.md
+++ b/docs-src/docs/articles/offline-database.md
@@ -1,272 +1,293 @@
 ---
-title: RxDB - The Ultimate Offline Database with Sync and Encryption
+title: Offline Database - Local Data Storage and Sync with RxDB
 slug: offline-database.html
-description: Discover how RxDB serves as a powerful offline database, offering real-time synchronization, secure encryption, and an offline-first approach for modern web and mobile apps.
+description: An offline database stores data on the client and syncs it in the background. Learn how RxDB handles offline storage, realtime sync, and encryption.
 image: /headers/offline-database.jpg
 ---
 
 import {Faq, FaqItem} from '@site/src/components/faq';
 import {CenteredImage} from '@site/src/components/centered-image';
 
-# RxDB - The Ultimate Offline Database with Sync and Encryption
+# Offline Database - Local Data Storage and Sync with RxDB
 
-When building modern applications, a reliable **offline database** can make all the difference. Users need fast, uninterrupted access to data, even without an internet connection, and they need that data to stay secure. **RxDB** meets these requirements by providing a **local-first** architecture, **real-time sync** to any backend, and optional **encryption** for sensitive fields.
+An **offline database** stores your application data directly on the client device and syncs it with a server in the background. Instead of sending a request over the network for every read and write, your app talks to a [local database](./local-database.md) that responds in microseconds, no matter if the device is online or not. [RxDB](https://rxdb.info/) is a [local-first](./local-first-future.md), NoSQL database for JavaScript applications that was built for exactly this pattern. This page explains what an offline database is, how the RxDB [Sync Engine](../replication.md) replicates data with any backend, and how you can improve your offline database setup step by step.
 
-In this article, we'll cover:
-- Why an **offline database** approach significantly improves user experience
-- How RxDB’s **sync** and **encryption** features work
-- Step-by-step guidance on getting started
+<RxdbLogo alt="offline database" />
 
----
+## What is an Offline Database?
 
-## Why Choose an Offline Database?
+An offline database keeps a full copy of the relevant data on the client, inside of a storage like [IndexedDB](../rx-storage-indexeddb.md), [OPFS](../rx-storage-opfs.md), or [SQLite](../rx-storage-sqlite.md). The app reads and writes against this local copy, and a replication process exchanges changes with the backend when a connection is available.
 
-[Offline-first](../offline-first.md) or **local-first** software stores data directly on the client device. This strategy isn’t just about surviving network outages; it also makes your application faster, more user-friendly, and better at handling multiple usage scenarios.
+This is different from a cache. A cache holds a temporary subset of server responses and treats the server as the source of truth. An offline database makes the local data the source of truth for the client. Writes succeed locally first, the UI updates immediately, and the sync to the server happens later. This pattern is called [offline-first](../offline-first.md) or local-first.
+
+## Why Your App Needs an Offline Database
+
+Storing data on the client is not only about surviving network outages. It changes how the whole application behaves.
 
 ### 1. Zero Loading Spinners
-Applications that call remote servers for every request inevitably show loading spinners. With an offline database, read and write operations happen locally to provide near-instant feedback. Users no longer stare at progress indicators or wait for server responses, resulting in a smoother and more fluid experience.
+
+Applications that call a remote server for every interaction show loading spinners while the user waits. With an offline database, reads and writes happen locally and respond in under a millisecond, which enables a [zero-latency user experience](./zero-latency-local-first.md). The user clicks, and the UI updates in the same frame. There is nothing to wait for.
 
 <CenteredImage src="/files/loading-spinner-not-needed.gif" alt="loading spinner not needed" width={300} />
 
-### 2. Multi-Tab Consistency
-Many websites mishandle data across multiple browser tabs. In an offline database, all tabs share the same local datastore. If the user updates data in one tab (like completing a to-do item), changes instantly reflect in every other tab. This removes complex multi-window synchronization problems.
+### 2. The App Works Without a Network
+
+When the device is offline, in a tunnel, on a plane, or on a flaky mobile connection, the app keeps working. Users can read their data and make changes, and the [Sync Engine](../replication.md) pushes those changes to the server when the connection comes back. For field worker apps, point-of-sale systems, and mobile apps in general, this is the difference between a usable product and an error page.
+
+### 3. Realtime UI Updates
+
+RxDB queries are observable. When the underlying data changes, either through a local write or through incoming replicated data from the server, the query emits the new result set and the UI updates automatically. You get realtime behavior without building a separate push system, because the replication and the [reactivity](../reactivity.md) are part of the same database.
+
+### 4. Multi-Tab Consistency
+
+Many web apps mishandle data across multiple browser tabs. With an offline database, all tabs of the same origin share one local state. When the user completes a to-do item in one tab, every other tab reflects the change instantly. RxDB handles this out of the box, and its [leader election](../leader-election.md) makes sure that background work like replication runs in exactly one tab at a time.
 
 <CenteredImage src="/files/multiwindow.gif" alt="RxDB multi tab" width={450} />
 
-### 3. Real-Time Data Feeds
-Apps that rely on a purely server-driven approach often show stale data unless they add a separate real-time push system (like websockets). Local-first solutions with built-in replication essentially get real-time updates “for free.” Once the server sends any changes, your local offline database updates to keep your UI live and accurate.
+### 5. Reduced Server Load
 
-### 4. Reduced Server Load
-In a traditional app, every interaction triggers a request to the server, scaling up resource usage quickly as traffic grows. Offline-first setups replicate data to the client once, and subsequent local reads or writes do not stress the backend. Your server usage grows with the amount of data rather than every user action, leading to more efficient scaling.
+In a traditional app, every user interaction triggers one or more requests to the backend. With an offline database, data is replicated once and then queried locally as often as the UI needs it. Your server load grows with the amount of changed data, not with the number of user interactions. This makes scaling cheaper and more predictable.
 
-### 5. Simpler Development: Fewer Endpoints, No Extra State Library
-Typical apps require numerous REST endpoints and possibly a client-side state manager (like Redux) to handle data flow. If you adopt an offline database, you can replicate nearly everything to the client. The local DB becomes your single source of truth, and you may skip advanced state libraries altogether.
+### 6. Simpler Code
 
+When the local database is the single source of truth, you no longer need a separate client-side state management layer that mirrors server state. Components subscribe to queries, writes go to the database, and the Sync Engine handles the network. Fewer REST endpoints, no manual cache invalidation, no hand-written retry logic.
 
-<RxdbLogo alt="RxDB" />
+## RxDB as an Offline Database
 
-## Introducing RxDB - A Powerful Offline Database Solution
+**RxDB (Reactive Database)** is a local-first, NoSQL database for JavaScript applications. It runs in the browser, [Node.js](../nodejs-database.md), [Electron](../electron-database.md), [React Native](../react-native-database.md), [Capacitor](../capacitor-database.md), Deno, and Bun.
 
-**RxDB (Reactive Database)** is a **[NoSQL](./in-memory-nosql-database.md)** JavaScript database that lives entirely in your client environment. It’s optimized for:
-
-- **Offline-first usage**
-- **Reactive queries** (your UI updates in real time)
-- **Flexible replication** with various backends
-- **Field-level encryption** to protect sensitive data
-
-You can run RxDB in:
-- **Browsers** ([IndexedDB](../rx-storage-indexeddb.md), [OPFS](../rx-storage-opfs.md))
-- **Mobile hybrid apps** ([Ionic](./ionic-database.md), [Capacitor](../capacitor-database.md))
-- **Native modules** ([React Native](../react-native-database.md))
-- **Desktop environments** ([Electron](../electron-database.md))
-- **[Node.js](../nodejs-database.md)** [Servers](../rx-server.md) or Scripts 
-
-Wherever your JavaScript executes, RxDB can serve as a robust offline database.
-
----
+RxDB itself does not persist data. It uses a swappable [RxStorage](../rx-storage.md) layer, so the same database code runs on top of [IndexedDB](../rx-storage-indexeddb.md), [OPFS](../rx-storage-opfs.md), [SQLite](../rx-storage-sqlite.md), [in-memory](../rx-storage-memory.md), and others. Switching storages is a configuration change, not a rewrite. On top of that, RxDB provides MongoDB-style (Mango) queries, observable query results, [encryption](../encryption.md), [schema migration](../migration-schema.md), and replication with almost any backend.
 
 ## Quick Setup Example
 
-Below is a short demo of how to create an RxDB [database](../rx-database.md), add a [collection](../rx-collection.md), and observe a [query](../rx-query.md). You can expand upon this to enable encryption or full sync.
+The following code creates a [database](../rx-database.md), adds a [collection](../rx-collection.md), inserts a document, and subscribes to a [query](../rx-query.md).
 
 ```ts
-import { createRxDatabase } from 'rxdb/plugins/core';
+import { createRxDatabase } from 'rxdb';
 import { getRxStorageLocalstorage } from 'rxdb/plugins/storage-localstorage';
 
-async function initDB() {
-  // Create a local offline database
-  const db = await createRxDatabase({
-    name: 'myOfflineDB',
+const db = await createRxDatabase({
+    name: 'myofflinedb',
     storage: getRxStorageLocalstorage()
-  });
+});
 
-  // Add collections
-  await db.addCollections({
+await db.addCollections({
     tasks: {
-      schema: {
-        title: 'tasks schema',
-        version: 0,
-        type: 'object',
-        primaryKey: 'id',
-        properties: {
-          id: { type: 'string', maxLength: 100 },
-          title: { type: 'string' },
-          done: { type: 'boolean' }
+        schema: {
+            title: 'tasks schema',
+            version: 0,
+            type: 'object',
+            primaryKey: 'id',
+            properties: {
+                id: { type: 'string', maxLength: 100 },
+                title: { type: 'string' },
+                done: { type: 'boolean' }
+            },
+            required: ['id', 'title', 'done']
         }
-      }
     }
-  });
+});
 
-  // Observe changes in real time
-  db.tasks
+await db.tasks.insert({
+    id: 'task-1',
+    title: 'buy milk',
+    done: false
+});
+
+// Reactive query: emits a new array whenever a matching doc changes.
+db.tasks
     .find({ selector: { done: false } })
-    .$ // returns an observable that emits whenever the result set changes
+    .$
     .subscribe(undoneTasks => {
-      console.log('Currently undone tasks:', undoneTasks);
+        console.log('Currently undone tasks:', undoneTasks.length);
     });
-
-  return db;
-}
 ```
 
-Now the `tasks` collection is ready to store data offline. You could also [replicate](../replication.md) it to a backend, encrypt certain fields, or utilize more advanced features like conflict resolution.
+The `tasks` collection now stores data offline. The next step is to sync it with a backend.
 
+## How the RxDB Sync Engine Works
 
-## How Offline Sync Works in RxDB
+RxDB replicates data with its own [Sync Engine](../replication.md), a protocol that was designed so that the complex parts run inside of RxDB, not in your backend. The backend can stay 'dumb', which makes the Sync Engine compatible with almost any infrastructure, no matter if your server stores data in PostgreSQL, MongoDB, or anything else.
 
-RxDB uses a [Sync Engine](../replication.md) that pushes local changes to the server and pulls remote updates back down. This ensures local data is always fresh and that the server has the latest offline edits once the device reconnects.
+On the document level, the replication works like git. The client is a fork of the server state. Local writes pile up on the fork, and the client pushes them to the server together with the last known server state. When the server state has moved on in the meantime, the push is rejected and the client resolves the [conflict](../transactions-conflicts-revisions.md) locally before pushing again. **All conflicts are resolved on the client**, with a conflict handler you can customize per collection. The default handler drops the local state in favor of the server state, so a device that was offline for months cannot silently overwrite newer changes from other users.
 
-**Multiple Plugins** exist to handle various backends or replication methods:
-- [CouchDB](../replication-couchdb.md) or **PouchDB**
-- [Google Firestore](./firestore-alternative.md)
-- [GraphQL](../replication-graphql.md) endpoints
-- REST / [HTTP](../replication-http.md)
-- **WebSocket** or [WebRTC](../replication-webrtc.md) (for peer-to-peer sync)
+On the transfer level, your backend only has to provide three endpoints:
 
-You pick the plugin that fits your stack, and RxDB handles everything from conflict detection to event emission, allowing you to focus on building your user-facing features.
+- **Pull handler**: returns all documents that changed after a given checkpoint, in batches.
+- **Push handler**: accepts batches of client writes and returns the current server state of any conflicting documents.
+- **Pull stream**: an observable of ongoing server changes, for example over a WebSocket or server-sent events.
+
+The replication runs in two modes. On startup, or when the client comes back online, it iterates checkpoints against the pull handler until the local state has caught up with the server. Then it switches to event observation and applies live changes from the pull stream. When the connection drops and recovers, the stream emits a `RESYNC` event and the replication falls back to checkpoint iteration to close the gap. You do not have to manage any of these offline-online switches yourself.
+
+All transfers happen in batches. Batching means fewer requests, better compression, and faster processing on the client, because storages like IndexedDB and OPFS are faster when writing data in bulks.
 
 ```ts
 import { replicateRxCollection } from 'rxdb/plugins/replication';
 
-replicateRxCollection({
-  collection: db.tasks,
-  replicationIdentifier: 'tasks-sync',
-  pull: { /* fetch updates from server */ },
-  push: { /* send local writes to server */ },
-  live: true // keep them in sync constantly
+const replicationState = await replicateRxCollection({
+    collection: db.tasks,
+    replicationIdentifier: 'tasks-to-https://example.com/api/sync',
+    live: true,
+    pull: {
+        async handler(checkpoint, batchSize) {
+            const updatedAt = checkpoint ? checkpoint.updatedAt : 0;
+            const id = checkpoint ? checkpoint.id : '';
+            const response = await fetch(
+                `https://example.com/api/sync/pull?updatedAt=${updatedAt}&id=${id}&limit=${batchSize}`
+            );
+            const data = await response.json();
+            return {
+                documents: data.documents,
+                checkpoint: data.checkpoint
+            };
+        }
+    },
+    push: {
+        async handler(changeRows) {
+            const response = await fetch('https://example.com/api/sync/push', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(changeRows)
+            });
+            // Must return the current server state of all conflicting documents.
+            return await response.json();
+        }
+    }
 });
 ```
 
-## Securing Your Offline Database with Encryption
-Local data can be a risk if it’s sensitive or personal. RxDB offers [encryption plugins](../encryption.md) to keep specific document fields secure at rest.
+When you do not want to build the endpoints yourself, RxDB ships replication plugins for many backends:
 
-#### Encryption Example
+- [HTTP](../replication-http.md) for plain REST endpoints
+- [GraphQL](../replication-graphql.md)
+- [WebSocket](../replication-websocket.md)
+- [CouchDB](../replication-couchdb.md)
+- [Firestore](../replication-firestore.md)
+- [MongoDB](../replication-mongodb.md)
+- [Supabase](../replication-supabase.md)
+- [Appwrite](../replication-appwrite.md)
+- [NATS](../replication-nats.md)
+- [WebRTC](../replication-webrtc.md) for [peer-to-peer](../replication-p2p.md) sync without a central server
+- [RxServer](../rx-server.md), a Node.js server built on RxDB itself
+
+In a multi-tab browser app, the replication respects the [leader election](../leader-election.md). Only one tab runs the replication at any given time, which saves client resources and backend connections. When that tab closes, another tab takes over.
+
+## Encrypting the Offline Database
+
+Data on a client device can be extracted when the device is lost or stolen. When you store sensitive fields, you should encrypt them at rest with one of the [encryption plugins](../encryption.md). The encryption wraps the storage, so it works with any RxStorage.
 
 ```ts
-import { createRxDatabase } from 'rxdb/plugins/core';
+import { createRxDatabase } from 'rxdb';
 import { getRxStorageLocalstorage } from 'rxdb/plugins/storage-localstorage';
 import {
-  wrappedKeyEncryptionCryptoJsStorage
+    wrappedKeyEncryptionCryptoJsStorage
 } from 'rxdb/plugins/encryption-crypto-js';
 
-async function initSecureDB() {
-  // Wrap the storage with crypto-js encryption
-  const encryptedStorage = wrappedKeyEncryptionCryptoJsStorage({
+const encryptedStorage = wrappedKeyEncryptionCryptoJsStorage({
     storage: getRxStorageLocalstorage()
-  });
+});
 
-  // Create database with a password
-  const db = await createRxDatabase({
-    name: 'secureOfflineDB',
+const db = await createRxDatabase({
+    name: 'secureofflinedb',
     storage: encryptedStorage,
     password: 'myTopSecretPassword'
-  });
+});
 
-  // Define an encrypted collection
-  await db.addCollections({
-    userSecrets: {
-      schema: {
-        title: 'encrypted user data',
-        version: 0,
-        type: 'object',
-        primaryKey: 'id',
-        properties: {
-          id: { type: 'string', maxLength: 100 },
-          secretData: { type: 'string' }
-        },
-        required: ['id'],
-        encrypted: ['secretData'] // field is encrypted at rest
-      }
+await db.addCollections({
+    usersecrets: {
+        schema: {
+            title: 'encrypted user data',
+            version: 0,
+            type: 'object',
+            primaryKey: 'id',
+            properties: {
+                id: { type: 'string', maxLength: 100 },
+                secretData: { type: 'string' }
+            },
+            required: ['id'],
+            encrypted: ['secretData']
+        }
     }
-  });
-
-  return db;
-}
+});
 ```
 
-When the device is off or the database file is extracted, `secretData` remains unreadable without the specified password. This ensures only authorized parties can access sensitive fields, even in offline scenarios.
+The `secretData` field is now unreadable without the password, even when someone copies the raw database files from the device. For production apps, the 👑 [RxDB Premium](/premium/) Web Crypto encryption plugin is recommended because it is faster and uses the browser's native crypto APIs.
 
+## How to Improve Your Offline Database Setup
 
+A working setup is the start, not the end. The following steps make an offline database faster, smaller, and safer in production.
 
+### 1. Pick the Right Storage
+
+Storage performance differs a lot between environments. In the browser, [IndexedDB](../rx-storage-indexeddb.md) is the default choice, while [OPFS](../rx-storage-opfs.md) is 3x-4x faster for many workloads. On native platforms like React Native or Capacitor, the [SQLite storage](../rx-storage-sqlite.md) is the fastest option. Compare the numbers on the [storage performance page](../rx-storage-performance.md) and remember that switching storages later is a configuration change, not a rewrite.
+
+### 2. Sync Only the Data You Need
+
+Replicating the whole dataset to every client wastes bandwidth, disk space, and initial sync time. With [partial sync](../partial-sync.md) you filter the replication so each client only receives the documents it needs, for example only the current user's documents or only data from the last month.
+
+### 3. Clean Up Deleted Documents
+
+Replicated documents are never physically removed, they are marked with a `_deleted` flag so the deletion can sync to other instances. Over time these tombstones slow down queries. The [cleanup plugin](../cleanup.md) purges deleted documents after a safe time window.
+
+### 4. Compress Stored Data
+
+The [key compression](../key-compression.md) plugin replaces field names with shorter tokens before writing to disk, which saves up to 40% storage space without changing how you query the data.
+
+### 5. Move Database Work Off the Main Thread
+
+Heavy queries and writes on the main thread can block rendering. With the [Worker](../rx-storage-worker.md) and [SharedWorker](../rx-storage-shared-worker.md) storages you run the whole database in a background thread and keep the UI responsive, while all tabs share one database process.
+
+### 6. Plan Schema Migrations
+
+Shipped clients keep old data in old formats. When your schema changes, the [schema migration plugin](../migration-schema.md) transforms existing documents on the client to the new schema version. Define migration strategies from the first release, because an offline database without a migration path corners you later.
+
+### 7. Handle Conflicts Deliberately
+
+The default conflict handler drops local changes in favor of the server state. This is a safe default, but for collaborative apps you should write a [custom conflict handler](../transactions-conflicts-revisions.md#custom-conflict-handler) that merges fields, or use the [CRDT plugin](../crdt.md) for deterministic merges of concurrent changes.
+
+### 8. Know the Tradeoffs
+
+Offline-first is not free. Conflicts can happen, initial replication takes time on large datasets, and client storage is limited by [browser quotas](./indexeddb-max-storage-limit.md). Read the [downsides of offline-first](../downsides-of-offline-first.md) before you commit, so the known limits do not bite back in production.
 
 ## FAQ
 
 <Faq>
-<FaqItem question="Which offline-first database has the fastest sync speeds?">
+<FaqItem question="What is the difference between an offline database and a cache?">
 
-RxDB provides one of the fastest sync speeds among offline-first databases. RxDB synchronizes data in bulks. This bulk processing reduces overhead and minimizes network requests. The sync process operates as fast as your backend can provide or store the data. You avoid the bottlenecks common in row-by-row replication. You achieve near-instant data consistency across large datasets.
-
-</FaqItem>
-<FaqItem question="What are the best offline-first database solutions for field worker apps?">
-
-RxDB provides a reliable offline database for field worker applications. Field workers require data access in areas with poor network coverage. RxDB stores data locally on the device. Users read and write data without an internet connection. The sync engine pushes local changes to the server when the device reconnects. RxDB resolves conflicts automatically to prevent data loss. You ensure continuous operations for your field workforce regardless of network status.
+A cache stores temporary copies of server responses and treats the server as the source of truth. An offline database like **[RxDB](../rx-database.md)** makes the local data the source of truth for the client. Writes succeed locally without a network connection, and the [Sync Engine](../replication.md) merges local and remote changes in the background, including conflict resolution.
 
 </FaqItem>
-<FaqItem question="What are the top rated mobile databases with built-in offline and peer syncing?">
+<FaqItem question="Is IndexedDB an offline database?">
 
-RxDB ranks highly among mobile databases that feature built-in offline capabilities and peer-to-peer synchronization. You construct responsive mobile applications using local data storage. RxDB operates directly on the mobile device to guarantee data availability without an internet connection. The WebRTC replication plugin facilitates direct peer-to-peer syncing between devices. You achieve real-time data sharing across mobile clients without relying on a centralized server.
-
-</FaqItem>
-<FaqItem question="What is the best offline-first database for real-time data syncing?">
-
-RxDB serves as the best offline-first database for real-time data syncing. RxDB uses observable queries to push updates to the user interface. You receive instant feedback when local data changes. The sync engine processes data replication with your server automatically. You eliminate manual data fetching and continuous polling. Real-time subscriptions guarantee your application state reflects the most recent data.
+No, not on its own. [IndexedDB](../rx-storage-indexeddb.md) is a low-level browser storage API without sync, observable queries, or a schema. An offline database builds these features on top of a storage. RxDB uses IndexedDB as one of several [RxStorage](../rx-storage.md) options and adds replication, reactivity, encryption, and Mango queries.
 
 </FaqItem>
-<FaqItem question="What offline frameworks and architectures are best for enterprise apps in disconnected environments?">
+<FaqItem question="How does an offline database sync data with the server?">
 
-Enterprise applications operating in disconnected environments (like remote field work or deep mining) require architectures that prioritize a heavy **[Local-First](./local-first-future.md)** storage engine coupled with a deterministic sync protocol. The best frameworks pair a robust client-side NoSQL storage like **[RxDB](../rx-database.md)** or WatermelonDB with an offline-capable replication mechanism that batches and pushes operations sequentially, ensuring massive volumes of local writes can safely merge with the central enterprise backend upon reconnection.
-
-</FaqItem>
-<FaqItem question="Should I use Firebase, SQLite, or RxDB for offline-first apps?">
-
-**Firebase** is excellent if you strictly want a fully managed Cloud backend and only need brief periods of offline caching before syncing. **[SQLite](../rx-storage-sqlite.md)** is a low-level, high-performance C-library essential if you require pure SQL queries on native mobile/desktop platforms without needing automated cross-platform sync. **[RxDB](../rx-database.md)** sits entirely above these; it is an offline-first NoSQL JSON database specifically engineered to provide fully automated sync mechanisms across *any* persistent storage layer including SQLite or IndexedDB while granting true real-time UI [reactivity](../reactivity.md).
+RxDB syncs through its [Sync Engine](../replication.md), which needs only three endpoints on the backend: a pull handler for changed documents after a checkpoint, a push handler for client writes, and an event stream for live changes. All transfers run in batches, and conflicts are resolved on the client. This works with any backend, from a REST API over [GraphQL](../replication-graphql.md) to services like [Supabase](../replication-supabase.md) or [Firestore](../replication-firestore.md).
 
 </FaqItem>
-<FaqItem question="How do leading offline-first solutions handle data sync reliably?">
+<FaqItem question="What happens when two users edit the same document while offline?">
 
-Leading offline-first solutions (like **[RxDB](../rx-database.md)**) handle sync reliably by treating the [local database](./local-database.md) as the primary source of truth. They utilize deterministic [Replication Protocols](../replication.md) that queue write operations during offline periods. When connectivity is restored, they push these batched changes efficiently to the server, pull any remote changes based on a checkpoint (like a server-side timestamp), and use mathematically sound algorithms (like vector clocks or custom resolvers) to automatically resolve any merge conflicts.
-
-</FaqItem>
-<FaqItem question="How do location APIs and similar native services handle offline functionality?">
-
-Native services like GPS/Location APIs fundamentally do not require an internet connection to calculate coordinates via satellite triangulation. However, converting those raw coordinates into human-readable addresses (Reverse Geocoding) usually requires a cloud API. In offline-first apps, you must store raw GPS coordinates during offline periods and either wait to batch-geocode them upon reconnection, or ship the app with a massive, localized pre-cached GIS database.
+The first push to the server wins. The second client's push is rejected, and RxDB calls the collection's conflict handler on that client to produce a merged state, which is then pushed again. By default the server state wins, but a [custom conflict handler](../transactions-conflicts-revisions.md#custom-conflict-handler) or the [CRDT plugin](../crdt.md) can merge both changes field by field.
 
 </FaqItem>
-<FaqItem question="Are there reliable CRDT-based offline first architectures for real-time collaboration?">
+<FaqItem question="Can I encrypt data in an offline database?">
 
-Yes, architectures utilizing Conflict-free Replicated Data Types (CRDTs) like Yjs or Automerge are extremely reliable for fine-grained, real-time collaboration (e.g., Google Docs-style text editing or Figma-style canvas drawing). However, true CRDTs carry significant computational overhead and memory bloat over time. Because of this, [RxDB](../rx-database.md) instead utilizes mathematically simpler Document-level conflict resolution (where the state is purely deterministic), which is generally much more performant and suitable for complex business data than pure character-by-character CRDT algorithms.
+Yes. RxDB provides [encryption plugins](../encryption.md) that encrypt marked fields at rest, on top of any storage. The data is only readable with the database password. Encrypted fields cannot be used inside of query selectors, so keep fields you need to query against unencrypted.
 
 </FaqItem>
-<FaqItem question="How to integrate online systems with offline-first local data workloads?">
+<FaqItem question="Which offline database should I use for web and mobile apps?">
 
-Integrating legacy online systems with offline-first local workloads essentially involves implementing a robust syncing [middleware](../middleware.md). Instead of having the client interact directly with your legacy REST endpoints, you implement a [custom replication plugin](../replication-http.md) (or use an intermediate GraphQL layer) that maps your local NoSQL database events to your backend's CRUD operations. This decouples the network lifecycle from the user interface, allowing your frontend to react instantly to the local datastore while the syncing middleware quietly synchronizes state in the background.
+RxDB is a strong choice when you need one codebase across platforms, because it runs in the browser, [React Native](../react-native-database.md), [Capacitor](../capacitor-database.md), [Electron](../electron-database.md), and Node.js, and it can sync with any backend. Firebase fits when you want a fully managed cloud backend and accept vendor lock-in. Plain [SQLite](../rx-storage-sqlite.md) fits native apps that need SQL but no automatic sync.
 
 </FaqItem>
 </Faq>
 
 ## Follow Up
 
-Integrating an offline database approach into your app delivers near-instant interactions, true multi-tab data consistency, automatic real-time updates, and reduced server dependencies. By choosing RxDB, you gain:
-
-- Offline-first local storage
-- Flexible replication to various backends
-- Encryption of sensitive fields
-- Reactive queries for real-time UI updates
-
-RxDB transforms how you build and scale apps, removing loading spinners, stale data, and complicated offline handling. Everything is local, synced, and secured.
-
-Continue your learning path:
-
-- **Explore the RxDB Ecosystem**
-  Dive into additional features like [Compression](../key-compression.md) or advanced [Conflict Handling](../transactions-conflicts-revisions.md#custom-conflict-handler) to optimize your offline database.
-
-- **Learn More About Offline-First**
-  Read our [Offline First documentation](../offline-first.md) for a deeper understanding of why local-first architectures improve user experience and reduce server load.
-
-- **Join the Community**
-  Have questions or feedback? Connect with us on the [RxDB Chat](/chat/) or open an issue on [GitHub](/code/).
-
-- **Upgrade to Premium**
-  If you need high-performance features like [SQLite storage](../rx-storage-sqlite.md) for mobile or the [Web Crypto-based encryption plugin](/premium/), consider our premium offerings.
-
-By adopting an offline database approach with RxDB, you unlock speed, reliability, and security for your applications, leading to a truly seamless user experience.
+- Start building with the [RxDB Quickstart](../quickstart.md).
+- Read how the [Sync Engine](../replication.md) replicates with any backend.
+- Learn why [offline-first](../offline-first.md) improves user experience and where it has [downsides](../downsides-of-offline-first.md).
+- Explore the [local-first movement](./local-first-future.md) and [zero-latency apps](./zero-latency-local-first.md).
+- Ask questions in the [RxDB Chat](/chat/) and leave a star ⭐ on [GitHub](/code/).

--- a/docs-src/docs/articles/offline-database.md
+++ b/docs-src/docs/articles/offline-database.md
@@ -132,9 +132,9 @@ const replicationState = await replicateRxCollection({
         async handler(checkpoint, batchSize) {
             const updatedAt = checkpoint ? checkpoint.updatedAt : 0;
             const id = checkpoint ? checkpoint.id : '';
-            const response = await fetch(
-                `https://example.com/api/sync/pull?updatedAt=${updatedAt}&id=${id}&limit=${batchSize}`
-            );
+            const url = 'https://example.com/api/sync/pull' +
+                `?updatedAt=${updatedAt}&id=${id}&limit=${batchSize}`;
+            const response = await fetch(url);
             const data = await response.json();
             return {
                 documents: data.documents,


### PR DESCRIPTION
## This PR contains:
- IMPROVED DOCS

## Describe the problem you have without this PR

The `articles/offline-database.md` page was outdated. Its sync section described the replication only vaguely (and mentioned PouchDB), the content was thin on what an offline database is, and it gave no guidance on how to improve a setup beyond the basics. This PR fully rewrites the page:

- New structure: what an offline database is (vs a cache), why apps need one, RxDB intro, setup example, sync, encryption, improvement guide, FAQ, Follow Up.
- The sync section now describes the modern RxDB Sync Engine: the git-like document-level protocol, the three backend endpoints (pull handler, push handler, pull stream), checkpoint iteration and event observation modes, client-side conflict resolution, batched transfers, multi-tab leader election, and the current replication plugin list (HTTP, GraphQL, WebSocket, CouchDB, Firestore, MongoDB, Supabase, Appwrite, NATS, WebRTC/P2P, RxServer). The code sample uses realistic fetch-based pull/push handlers instead of empty placeholders.
- A new "How to Improve Your Offline Database Setup" section with eight concrete steps: storage choice, partial sync, cleanup of deleted documents, key compression, worker/shared-worker storages, schema migrations, deliberate conflict handling, and knowing the tradeoffs.
- The FAQ is rewritten to target real search queries with verdict-first answers.

The docs build (`npm run docs:build`) passes with no broken links on this page.

## Todos
- [x] Documentation

---
_Generated by [Claude Code](https://claude.ai/code/session_01FunfQhtwvQumvwSbU2k8gF)_