### PR TITLE
fix: mark unused schema parameter

### DIFF
--- a/src/rx-query-helper.ts
+++ b/src/rx-query-helper.ts
@@ -186,7 +186,7 @@ export function normalizeMangoQuery<RxDocType>(
  * a query over the db would do.
  */
 export function getSortComparator<RxDocType>(
-    schema: RxJsonSchema<RxDocumentData<RxDocType>>,
+    _schema: RxJsonSchema<RxDocumentData<RxDocType>>,
     query: FilledMangoQuery<RxDocType>
 ): DeterministicSortComparator<RxDocType> {
     if (!query.sort) {


### PR DESCRIPTION
The schema parameter in getSortComparator() is not used.

This change prefixes it with _ to explicitly indicate that the parameter is intentionally unused, matching the convention already used by getQueryMatcher().