### PR TITLE
Fix useLiveRxQuery leaking the live query subscription on unmount

### DIFF
--- a/orga/changelog/fix-use-live-rx-query-unsubscribe.md
+++ b/orga/changelog/fix-use-live-rx-query-unsubscribe.md
@@ -1,0 +1,1 @@
+- FIX `useLiveRxQuery` never unsubscribed from the live query because `useEffect` dropped the cleanup returned by the async `runQuery` callback. Added an unmount test in `test/react/react-hooks.test.tsx`. [#8964](https://github.com/pubkey/rxdb/issues/8964)

--- a/src/plugins/react/hooks/use-rx-query.ts
+++ b/src/plugins/react/hooks/use-rx-query.ts
@@ -105,7 +105,7 @@ export function useRxQueryBase<
         }
     };
 
-    const runQuery = useCallback(async () => {
+    const runQuery = useCallback(() => {
         if (dbCollection == null) {
             return;
         }
@@ -122,11 +122,10 @@ export function useRxQueryBase<
                 subscription.unsubscribe();
             };
         } else {
-            try {
-                emitResults(await rxQuery.exec());
-            } catch (e) {
-                emitError(e as Error);
-            }
+            rxQuery.exec().then(
+                (res) => emitResults(res),
+                (e) => emitError(e as Error)
+            );
         }
     }, [dbCollection, query]);
 
@@ -135,7 +134,7 @@ export function useRxQueryBase<
             return;
         }
 
-        runQuery();
+        return runQuery();
     }, [runQuery]);
 
     return { results, loading, error };

--- a/src/plugins/react/hooks/use-rx-query.ts
+++ b/src/plugins/react/hooks/use-rx-query.ts
@@ -134,7 +134,10 @@ export function useRxQueryBase<
             return;
         }
 
-        return runQuery();
+        const cleanup = runQuery();
+        if (typeof cleanup === 'function') {
+            return cleanup;
+        }
     }, [runQuery]);
 
     return { results, loading, error };

--- a/test/react/react-hooks.test.tsx
+++ b/test/react/react-hooks.test.tsx
@@ -13,6 +13,7 @@ import {
     addRxPlugin,
     RxDatabase,
     RxCollection,
+    countRxQuerySubscribers,
 } from '../../plugins/core/index.mjs';
 
 import { RxDBDevModePlugin } from '../../plugins/dev-mode/index.mjs';
@@ -244,6 +245,39 @@ describe('react-hooks.test.tsx', () => {
                 assert.strictEqual(result.current.results.length, 1);
             });
             assert.strictEqual(result.current.error, null);
+
+            await db.close();
+        });
+
+        /**
+         * useLiveRxQuery must return unsubscribe from useEffect.
+         * If the subscription is created inside an async callback,
+         * React drops that cleanup and the live query stays subscribed
+         * after unmount.
+         * @link https://github.com/pubkey/rxdb/issues/8964
+         */
+        it('should unsubscribe from the live query when the hook is unmounted', async () => {
+            const db = await createDatabase();
+            const collection: RxCollection<SimpleHumanDocumentType> = db.collections.humans;
+
+            const { result, unmount } = renderHook(
+                () => useLiveRxQuery({
+                    collection,
+                    query: allDocsQuery
+                }),
+                { wrapper: createWrapper(db) }
+            );
+
+            await waitFor(() => {
+                assert.strictEqual(result.current.loading, false);
+            });
+
+            const rxQuery = collection.find(allDocsQuery);
+            assert.strictEqual(countRxQuerySubscribers(rxQuery), 1);
+
+            unmount();
+
+            assert.strictEqual(countRxQuerySubscribers(rxQuery), 0);
 
             await db.close();
         });


### PR DESCRIPTION
## This PR contains:

A BUGFIX and IMPROVED TESTS.

Reported by [chris-rnwbl](https://github.com/chris-rnwbl) in #8964.

Fixes #8964.

## Describe the problem you have without this PR

`useLiveRxQuery` / `useRxQueryBase` subscribed to `rxQuery.$` inside an `async` `runQuery` callback and returned `() => subscription.unsubscribe()` from that callback. React `useEffect` only uses a function returned synchronously as cleanup. The Promise resolved value was ignored, so unmount (and query changes) never unsubscribed.

`useRxDocument` in the same plugin already returns cleanup from `useEffect` correctly.

## Fix

Drop `async` from `runQuery` so the live path can return unsubscribe synchronously. `useEffect` now `return runQuery()`. The non-live `exec()` path uses `.then()` / rejection handler instead of `await`.

This does not change the `useRxDocument` first-paint `loading` behavior from #8965.

## Test case

`should unsubscribe from the live query when the hook is unmounted` in `test/react/react-hooks.test.tsx`:

1. mount `useLiveRxQuery`
2. wait until the query settles
3. assert `countRxQuerySubscribers(rxQuery) === 1`
4. unmount
5. assert `countRxQuerySubscribers(rxQuery) === 0`

That assertion failed on unmodified `master` (`1 !== 0`) and passes with this change.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Typings
- [x] Changelog
