### PR TITLE
docs: link TanStack DB integration to the internal RxDB collection page

### DIFF
--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -504,12 +504,9 @@ const sidebars = {
           label: 'React'
         },
         {
-          type: 'link',
-          label: 'TanStack DB',
-          href: 'https://tanstack.com/db/latest/docs/collections/rxdb-collection',
-          customProps: {
-            target: '_blank'
-          }
+          type: 'ref',
+          id: 'articles/tanstack-db/rxdb-collection-for-tanstack-db',
+          label: 'TanStack DB'
         }
       ]
     },


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS

## Describe the problem you have without this PR

In the docs sidebar, the `Integrations` category listed `TanStack DB` as an external link to `https://tanstack.com/db/latest/docs/collections/rxdb-collection` opening in a new tab. Every other integration entry points to a page on rxdb.info, and the repo already has a full internal page for this integration at `docs-src/docs/articles/tanstack-db/rxdb-collection-for-tanstack-db.md`, plus a whole TanStack DB article cluster under it. Sending users off-site from the sidebar loses them before they see any of that.

The entry now points to the internal page:

```js
{
  type: 'ref',
  id: 'articles/tanstack-db/rxdb-collection-for-tanstack-db',
  label: 'TanStack DB'
}
```

`ref` is used instead of `doc` because the same document is already part of the `Articles > TanStack DB` category, and `ref` links to it without claiming a second sidebar association for the page. The official TanStack collection docs are not lost: the internal page links to them in its "How the Integration Works" section.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [ ] Changelog

---
_Generated by [Claude Code](https://claude.ai/code/session_0143KS4RfYxJPK6zqabyjPo4)_