### PR TITLE
docs: update the a/b variations of three SEM landingpages

### DIFF
--- a/docs-src/src/pages/sem/gadxie2.tsx
+++ b/docs-src/src/pages/sem/gadxie2.tsx
@@ -4,7 +4,7 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * SEM landingpage for "gadxie2".
- * A/b tests 3 variations of the title, description and bulletpoints.
+ * A/b tests multiple variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
@@ -16,16 +16,22 @@ import { getSemVariation } from '../../components/a-b-tests';
  *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
-    a: {
-        title: <>The <b>Open-Source</b> Database With <b>Self-Hosted Sync</b></>,
-        text: <>RxDB is an open-source, local-first NoSQL database for JavaScript. Replication works with CouchDB, GraphQL, HTTP, WebRTC, and more, all self-hostable. Your data stays on your infrastructure, with no proprietary sync cloud.</>,
-        bulletpoints: [
-            <>Apache-2.0 licensed core</>,
-            <>Sync to any backend you control</>,
-            <>No proprietary cloud required</>,
-            <>Large plugin ecosystem</>
-        ]
-    },
+    /**
+     * Variations 'a' and 'c' were retired on 2026-08-18 after the first A/B
+     * readout: variation 'b' beat both of them on engagement. Kept on record
+     * (commented out, not deleted) so their letters and copy stay reserved
+     * and are never reused for different copy.
+     */
+    // a: {
+    //     title: <>The <b>Open-Source</b> Database With <b>Self-Hosted Sync</b></>,
+    //     text: <>RxDB is an open-source, local-first NoSQL database for JavaScript. Replication works with CouchDB, GraphQL, HTTP, WebRTC, and more, all self-hostable. Your data stays on your infrastructure, with no proprietary sync cloud.</>,
+    //     bulletpoints: [
+    //         <>Apache-2.0 licensed core</>,
+    //         <>Sync to any backend you control</>,
+    //         <>No proprietary cloud required</>,
+    //         <>Large plugin ecosystem</>
+    //     ]
+    // },
     b: {
         title: <>One <b>Local Database</b> for Your Whole <b>Stack</b></>,
         text: <>RxDB runs in the browser, Electron, Node.js, and React Native, with bindings for React, Angular, Vue, and Svelte. You define a schema once and get reactive queries, migrations, and sync on every platform.</>,
@@ -36,33 +42,45 @@ const variations = {
             <>TypeScript support included</>
         ]
     },
-    c: {
-        title: <>A <b>Local Database</b> Ready for <b>Production</b></>,
-        text: <>RxDB ships the features production apps need: schema validation, data migrations, encryption, compression, and attachment handling. Reactive queries keep the UI consistent and replication keeps every device in sync.</>,
+    // c: {
+    //     title: <>A <b>Local Database</b> Ready for <b>Production</b></>,
+    //     text: <>RxDB ships the features production apps need: schema validation, data migrations, encryption, compression, and attachment handling. Reactive queries keep the UI consistent and replication keeps every device in sync.</>,
+    //     bulletpoints: [
+    //         <>Schema validation and migrations</>,
+    //         <>Encryption and compression</>,
+    //         <>Reactive queries everywhere</>,
+    //         <>Battle-tested replication</>
+    //     ]
+    // },
+    d: {
+        title: <>Queries That <b>Re-Render</b> Your <b>UI</b></>,
+        text: <>Define a schema, query your local data, and RxDB keeps every subscribed component up to date as the data changes, in every open tab and on every device. Storage is IndexedDB, OPFS or SQLite, whichever fits your app.</>,
         bulletpoints: [
-            <>Schema validation and migrations</>,
-            <>Encryption and compression</>,
-            <>Reactive queries everywhere</>,
-            <>Battle-tested replication</>
+            <>Observable queries, no refetching</>,
+            <>Every open tab stays consistent</>,
+            <>IndexedDB, OPFS or SQLite storage</>,
+            <>Replication to your own backend</>
         ]
     }
 };
 
+const variationKeys = Object.keys(variations) as (keyof typeof variations)[];
+
 export default function Page() {
     /**
-     * Render variation "a" on the server and on the first client render
-     * to avoid a hydration mismatch, then swap to the assigned variation.
+     * Render the first live variation on the server and on the first client
+     * render to avoid a hydration mismatch, then swap to the assigned one.
      */
-    const [variationKey, setVariationKey] = useState('a');
+    const [variationKey, setVariationKey] = useState(variationKeys[0] as string);
     useEffect(() => {
-        setVariationKey(getSemVariation(Object.keys(variations)));
+        setVariationKey(getSemVariation(variationKeys));
     }, []);
-    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+    const variation = variations[variationKey as keyof typeof variations] ?? variations[variationKeys[0]];
 
     return Home({
         sem: {
             id: 'gads',
-            metaTitle: 'RxDB: Open-Source Local Database With Self-Hosted Sync',
+            metaTitle: 'RxDB: One Local Database for Your Whole JavaScript Stack',
             title: variation.title,
             text: variation.text,
             bulletpoints: variation.bulletpoints

--- a/docs-src/src/pages/sem/gaidxdb1.tsx
+++ b/docs-src/src/pages/sem/gaidxdb1.tsx
@@ -4,7 +4,7 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * SEM landingpage for "gaidxdb1".
- * A/b tests 3 variations of the title, description and bulletpoints.
+ * A/b tests multiple variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
@@ -26,16 +26,22 @@ const variations = {
             <>All JavaScript Runtimes Supported</>
         ]
     },
-    b: {
-        title: <><b>IndexedDB</b> Without the <b>Pain</b></>,
-        text: <>RxDB gives you a clean NoSQL API on top of IndexedDB. No transaction boilerplate, no callback chains, just schemas, queries and observables that keep your UI in sync with your data.</>,
-        bulletpoints: [
-            <>No IndexedDB boilerplate</>,
-            <>Reactive queries out of the box</>,
-            <>JSON schemas and migrations</>,
-            <>Free and open source</>
-        ]
-    }
+    /**
+     * Variation 'b' was retired on 2026-08-18 after the second A/B readout:
+     * it lost to variation 'a' on every measured engagement signal. Kept on
+     * record (commented out, not deleted) so its letter and copy stay
+     * reserved and 'b' is never reused for different copy.
+     */
+    // b: {
+    //     title: <><b>IndexedDB</b> Without the <b>Pain</b></>,
+    //     text: <>RxDB gives you a clean NoSQL API on top of IndexedDB. No transaction boilerplate, no callback chains, just schemas, queries and observables that keep your UI in sync with your data.</>,
+    //     bulletpoints: [
+    //         <>No IndexedDB boilerplate</>,
+    //         <>Reactive queries out of the box</>,
+    //         <>JSON schemas and migrations</>,
+    //         <>Free and open source</>
+    //     ]
+    // },
     /**
      * Variation 'c' was removed on 2026-07-27 after its first A/B readout:
      * it was the weakest of the three on engagement. Kept on record (commented
@@ -51,24 +57,36 @@ const variations = {
     //         <>Optimized IndexedDB storage</>,
     //         <>Observable realtime queries</>
     //     ]
-    // }
+    // },
+    d: {
+        title: <><b>IndexedDB</b> With Queries, Schemas and <b>Sync</b></>,
+        text: <>RxDB stores your data in IndexedDB and adds what an app actually needs on top: a NoSQL query API, JSON schemas with migrations, results that update themselves when the data changes, and replication to your own backend.</>,
+        bulletpoints: [
+            <>NoSQL queries over IndexedDB</>,
+            <>JSON schemas and migrations</>,
+            <>Results that update themselves</>,
+            <>Replication to your own backend</>
+        ]
+    }
 };
+
+const variationKeys = Object.keys(variations) as (keyof typeof variations)[];
 
 export default function Page() {
     /**
-     * Render variation "a" on the server and on the first client render
-     * to avoid a hydration mismatch, then swap to the assigned variation.
+     * Render the first live variation on the server and on the first client
+     * render to avoid a hydration mismatch, then swap to the assigned one.
      */
-    const [variationKey, setVariationKey] = useState('a');
+    const [variationKey, setVariationKey] = useState(variationKeys[0] as string);
     useEffect(() => {
-        setVariationKey(getSemVariation(Object.keys(variations)));
+        setVariationKey(getSemVariation(variationKeys));
     }, []);
-    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+    const variation = variations[variationKey as keyof typeof variations] ?? variations[variationKeys[0]];
 
     return Home({
         sem: {
             id: 'gads',
-            metaTitle: 'RxDB: IndexedDB Without the Pain',
+            metaTitle: 'RxDB: The JavaScript Database on Top of IndexedDB',
             appName: 'JavaScript',
             title: variation.title,
             text: variation.text,

--- a/docs-src/src/pages/sem/galocal1.tsx
+++ b/docs-src/src/pages/sem/galocal1.tsx
@@ -4,7 +4,7 @@ import { getSemVariation } from '../../components/a-b-tests';
 
 /**
  * SEM landingpage for "galocal1".
- * A/b tests 3 variations of the title, description and bulletpoints.
+ * A/b tests multiple variations of the title, description and bulletpoints.
  * The variation is picked randomly per visitor and kept stable via localStorage.
  */
 
@@ -16,16 +16,22 @@ import { getSemVariation } from '../../components/a-b-tests';
  *   stay on record and cannot be re-assigned by accident.
  */
 const variations = {
-    a: {
-        title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
-        text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
-        bulletpoints: [
-            <>Build apps that work offline</>,
-            <>Sync with any Backend</>,
-            <>Observable Realtime Queries</>,
-            <>All JavaScript Runtimes Supported</>
-        ]
-    },
+    /**
+     * Variations 'a' and 'c' were retired on 2026-08-18 after the first A/B
+     * readout: variation 'b' beat both of them on engagement. Kept on record
+     * (commented out, not deleted) so their letters and copy stay reserved
+     * and are never reused for different copy.
+     */
+    // a: {
+    //     title: <>The <b>Local-First</b> Database for <b>JavaScript</b> Apps</>,
+    //     text: <>RxDB is a NoSQL database for JavaScript that runs directly in your app. With a local-first design, it delivers zero-latency queries even offline, and syncs seamlessly with any backend.</>,
+    //     bulletpoints: [
+    //         <>Build apps that work offline</>,
+    //         <>Sync with any Backend</>,
+    //         <>Observable Realtime Queries</>,
+    //         <>All JavaScript Runtimes Supported</>
+    //     ]
+    // },
     b: {
         title: <><b>Zero Latency</b>. Your Data Is <b>Already There</b>.</>,
         text: <>RxDB keeps your app's data on the device, so every query answers instantly. No request waterfalls, no loading spinners. The network is only used for sync, and your app works with or without it.</>,
@@ -36,28 +42,40 @@ const variations = {
             <>Open source, works with any backend</>
         ]
     },
-    c: {
-        title: <><b>Local-First</b> Is the Future. Build It With <b>RxDB</b>.</>,
-        text: <>You own your data, in spite of the cloud. RxDB brings the local-first architecture to JavaScript: data lives on the device, syncs to any backend you choose, and your app keeps working offline.</>,
+    // c: {
+    //     title: <><b>Local-First</b> Is the Future. Build It With <b>RxDB</b>.</>,
+    //     text: <>You own your data, in spite of the cloud. RxDB brings the local-first architecture to JavaScript: data lives on the device, syncs to any backend you choose, and your app keeps working offline.</>,
+    //     bulletpoints: [
+    //         <>Local-first architecture, ready today</>,
+    //         <>You own your data and your backend</>,
+    //         <>Conflict handling built in</>,
+    //         <>Works with React, Vue, and Angular</>
+    //     ]
+    // },
+    d: {
+        title: <>Writes That Survive a <b>Lost Connection</b></>,
+        text: <>RxDB saves every write to the device first, then replicates it to your backend once the network is back. Conflicts are resolved by a handler you define, and every open tab and every device converges on the same data.</>,
         bulletpoints: [
-            <>Local-first architecture, ready today</>,
-            <>You own your data and your backend</>,
-            <>Conflict handling built in</>,
-            <>Works with React, Vue, and Angular</>
+            <>Offline writes replicate later</>,
+            <>Conflict handling you define</>,
+            <>Tabs and devices stay in sync</>,
+            <>Open source, works with any backend</>
         ]
     }
 };
 
+const variationKeys = Object.keys(variations) as (keyof typeof variations)[];
+
 export default function Page() {
     /**
-     * Render variation "a" on the server and on the first client render
-     * to avoid a hydration mismatch, then swap to the assigned variation.
+     * Render the first live variation on the server and on the first client
+     * render to avoid a hydration mismatch, then swap to the assigned one.
      */
-    const [variationKey, setVariationKey] = useState('a');
+    const [variationKey, setVariationKey] = useState(variationKeys[0] as string);
     useEffect(() => {
-        setVariationKey(getSemVariation(Object.keys(variations)));
+        setVariationKey(getSemVariation(variationKeys));
     }, []);
-    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+    const variation = variations[variationKey as keyof typeof variations] ?? variations[variationKeys[0]];
 
     return Home({
         sem: {


### PR DESCRIPTION
## This PR contains:

Improved docs (SEM landingpage copy), plus a small correctness fix to how those pages pick which variation to render.

## Describe the problem you have without this PR

Three SEM landingpages (`gaidxdb1`, `gadxie2`, `galocal1`) were each running an a/b test over three copy variations. Some of those variations have finished their run and are being retired, and each page needs a fresh challenger so it keeps testing more than one copy instead of collapsing to a single variation.

Retiring variation `a` also exposes two problems in the existing pages:

1. **The server render defaulted to a hardcoded `'a'`.** `Page()` used `useState('a')` and `?? variations.a`. On a page where variation `a` is retired, that resolves to `undefined` and the page renders nothing on the server and on the first client render. Fixed by taking the first live key from `Object.keys(variations)`, which is exactly what `getSemVariation()` already uses as its own fallback, so the two now agree.
2. **The `metaTitle` was copied from one variation's title.** On `gaidxdb1` and `gadxie2` that variation is now retired, so the browser tab and the search-result title advertised copy the page no longer shows. Both were rewritten to match the copy that is still live.

## What changed per page

| Page | Retired | Still live | Added |
| --- | --- | --- | --- |
| `gaidxdb1` | `b` | `a` | `d` |
| `gadxie2` | `a`, `c` | `b` | `d` |
| `galocal1` | `a`, `c` | `b` | `d` |

Retired variations are **commented out, not deleted**, per the rules documented in `getSemVariation()`: a letter is never reused for different copy, so tracking events stay comparable over time. New variations take the next unused letter, which is `d` on all three pages since `c` is retired everywhere.

## Todos

- [x] Tests <!-- no source-code change; these are landingpage copy files with no test coverage in this repo -->
- [x] Documentation
- [x] Typings
- [ ] Changelog <!-- SEM landingpages are neither a testcase nor a fix, so the changelog rule does not apply -->

## Verification

`node_modules` was not installed in this environment, so `npm run check-types` and `npm run lint` were not run. Note that the root `tsconfig.json` lists `docs-src` in both `include` and `exclude`, and `exclude` wins, so `npm run check-types` does not cover these files either way. Instead the three changed files were type-checked with a standalone `tsc 5.7.2` under `--strict`, filtering the module-resolution errors caused by the missing dependencies. The same check was run against the unmodified originals as a control, and the changed files are clean at the same level as the originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hkkM8BihS5Z2zKX1mjGuX

---
_Generated by [Claude Code](https://claude.ai/code/session_013hkkM8BihS5Z2zKX1mjGuX)_