### PR TITLE
Update discord invite link and harden the chat redirect

### DIFF
--- a/docs-src/src/components/trophy.tsx
+++ b/docs-src/src/components/trophy.tsx
@@ -5,7 +5,7 @@ export const SOCIAL_PROOF_VALUES = {
     github: 22869,
     // @link https://x.com/rxdbjs
     twitter: 3039,
-    // @link https://discord.gg/krNZtjZtpu
+    // @link https://discord.gg/AdqM4ckqVF
     discord: 1321
 } as const;
 

--- a/docs-src/src/pages/chat.tsx
+++ b/docs-src/src/pages/chat.tsx
@@ -2,10 +2,18 @@ import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 import { triggerTrackingEvent } from '../components/trigger-event';
 
+export const DISCORD_INVITE_URL = 'https://discord.gg/AdqM4ckqVF';
+
 export default function Chat() {
 
     useEffect(() => {
         triggerTrackingEvent('join_chat', 0.40);
+        /**
+         * Replace the history entry instead of pushing one,
+         * so that going back from discord does not
+         * run the redirect again.
+         */
+        window.location.replace(DISCORD_INVITE_URL);
     });
 
     return (
@@ -25,9 +33,9 @@ export default function Chat() {
                         <b>You will be redirected in a few seconds.</b>
                     </p>
                     <p>
-                        <a href="https://discord.gg/krNZtjZtpu">Click here to open Chat</a>
+                        <a href={DISCORD_INVITE_URL}>Click here to open Chat</a>
                     </p>
-                    <meta httpEquiv="Refresh" content="1; url=https://discord.gg/krNZtjZtpu" />
+                    <meta httpEquiv="Refresh" content={'1; url=' + DISCORD_INVITE_URL} />
                 </div>
             </main>
         </Layout >


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS

## Describe the problem you have without this PR

The `/chat/` page still points at the old discord invite `https://discord.gg/krNZtjZtpu`. The new invite is `https://discord.gg/AdqM4ckqVF`.

Two things changed:

- The invite URL is updated in `docs-src/src/pages/chat.tsx` and in the social proof reference comment in `docs-src/src/components/trophy.tsx`. It now lives in a single exported constant so the next invite change is one line.
- The redirect runs via `window.location.replace()` right after the `join_chat` tracking event. Before, the only redirect was a `<meta http-equiv="Refresh" content="1; ...">`, which waits a second and pushes `/chat/` into the browser history. When a visitor pressed back from discord they landed on `/chat/` and got redirected again, so leaving the invite page was next to impossible without spamming the back button. The meta refresh stays in place as the fallback for visitors without JavaScript.

All other places in the repo (README badge, navbar, footer, docs pages) already link to `https://rxdb.info/chat/` instead of the raw discord URL, so they need no change and keep working. The old invite in `CHANGELOG.md` is a historical entry and was left as is.

Note: `npm run lint` and `npm run check-types` could not be run in this environment because the dependencies are not installed. The changed file was syntax-checked with a standalone `tsc` run, which reported only unresolved module imports and no other errors.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Typings
- [ ] Changelog

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb11g2ZZBidjJkaSGk1DbC)_