### PR TITLE
docs: add a German /jobs page with the two open working-student positions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -511,7 +511,9 @@ jobs:
         uses: codespell-project/actions-codespell@v2.2
         with:
           ignore_words_file: config/codespellignore.txt
-          skip: legal-notice.tsx,privacy.tsx,custom.css
+          # jobs.tsx is German, like privacy.tsx, and codespell only knows
+          # English misspellings, so it flags ordinary German words.
+          skip: legal-notice.tsx,privacy.tsx,jobs.tsx,custom.css
           path: docs-src/src
       - name: spelling docs-src/releases
         uses: codespell-project/actions-codespell@v2.2

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -22,28 +22,53 @@ const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6
  */
 const JOBS = [
     {
-        title: 'Schwerpunkt Frontend',
-        lead: 'Du baust die Anwendungen, an denen Entwickler RxDB zum ersten Mal ausprobieren.',
-        bullets: [
-            'Demo-Apps in TypeScript bauen, die RxDB in React, Angular, Vue und Svelte zeigen',
-            'die bestehenden Beispiele zu jedem Release aktuell halten',
-            'die Doku aus der Sicht von jemandem lesen, der RxDB zum ersten Mal benutzt, und aufschreiben, wo es hakt',
-            'Entwicklerfragen auf GitHub, Discord und Stack Overflow beantworten'
+        title: 'Schwerpunkt Frontend-Entwicklung',
+        lead: 'Du entwickelst die Anwendungen, an denen Entwickler RxDB zum ersten Mal ausprobieren.',
+        tasks: [
+            'Entwicklung von Demo-Anwendungen in TypeScript, die den Einsatz von RxDB in React, Angular, Vue und Svelte zeigen',
+            'Pflege der bestehenden Beispielprojekte über die Releases hinweg',
+            'Prüfung der Dokumentation aus der Perspektive von Erstnutzern und Aufnahme der Schwachstellen',
+            'Beantwortung von Entwicklerfragen auf GitHub, Discord und Stack Overflow'
         ],
-        profile: 'Informatik, Softwaretechnik, Medieninformatik oder etwas Vergleichbares. Du kannst TypeScript und mindestens ein Frontend-Framework, und du hast schon etwas Eigenes veröffentlicht. Ein GitHub-Profil sagt uns mehr als ein Anschreiben.'
+        requirements: [
+            'Studium der Informatik, Softwaretechnik, Medieninformatik oder eines vergleichbaren Fachs',
+            'sicherer Umgang mit TypeScript und mindestens einem Frontend-Framework',
+            'eigene veröffentlichte Projekte, ein GitHub-Profil ersetzt bei uns das Anschreiben'
+        ]
     },
     {
         title: 'Schwerpunkt Video und Social Media',
-        lead: 'Du machst sichtbar, was die Entwicklerin oder der Entwickler nebenan gebaut hat.',
-        bullets: [
-            'kurze Videos produzieren, die zeigen, wie man mit RxDB etwas baut, von der Idee über Aufnahme und Schnitt bis zu Titel und Thumbnail',
-            'daraus Shorts und Reels für YouTube, LinkedIn, Instagram und TikTok schneiden',
-            'unseren YouTube-Kanal und die Social-Accounts betreuen, Kommentare eingeschlossen',
-            'anschauen, was funktioniert hat, und die nächsten Videos danach ausrichten'
+        lead: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
+        tasks: [
+            'Produktion kurzer Videos zur Arbeit mit RxDB, von der Konzeption über Aufnahme und Schnitt bis zu Titel und Thumbnail',
+            'Aufbereitung der Videos als Shorts und Reels für YouTube, LinkedIn, Instagram und TikTok',
+            'Betreuung des YouTube-Kanals und der Social-Media-Kanäle einschließlich Community-Management',
+            'Auswertung der Reichweiten und Ableitung der nächsten Themen'
         ],
-        profile: 'Audiovisuelle Medien, Onlinemedien, Werbung und Marktkommunikation, Medieninformatik oder etwas Vergleichbares. Du schneidest selbst und hast Sachen, die man sich ansehen kann. Programmieren musst du nicht können.'
+        requirements: [
+            'Studium der Audiovisuellen Medien, Onlinemedien, Werbung und Marktkommunikation, Medieninformatik oder eines vergleichbaren Fachs',
+            'eigenständige Schnittarbeit, belegt durch Arbeitsproben',
+            'Programmierkenntnisse sind nicht erforderlich'
+        ]
     }
 ];
+
+function Section(props: { title: string; items: string[]; }) {
+    return <>
+        <div style={{
+            fontSize: 13,
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            opacity: 0.65,
+            marginTop: 20,
+            marginBottom: 8
+        }}>{props.title}</div>
+        <ul style={{ lineHeight: '24px', fontSize: 14, marginBottom: 0 }}>
+            {props.items.map((item, i) => <li key={'i-' + i}>{item}</li>)}
+        </ul>
+    </>;
+}
 
 export default function Jobs() {
     useEffect(() => {
@@ -80,19 +105,20 @@ export default function Jobs() {
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
                                     RxDB ist eine Local-First-Datenbank für JavaScript-Anwendungen.
-                                    Sie funktioniert weiter, wenn das Netz ausfällt, und synchronisiert,
-                                    sobald die Verbindung zurück ist. Im Einsatz ist sie unter anderem
-                                    bei Readwise, Nutrien, MoreApp und myAgro.
+                                    Sie arbeitet weiter, wenn die Netzverbindung ausfällt, und
+                                    synchronisiert, sobald sie wiederhergestellt ist. Unternehmen wie
+                                    Readwise, Nutrien, MoreApp und myAgro setzen RxDB in Produktion ein.
                                 </p>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
-                                    Developer Experience heißt bei uns: die erste Stunde mit RxDB
-                                    entscheidet, ob jemand dabei bleibt. Daran arbeiten wir, und dafür
-                                    suchen wir <b>zwei Leute</b>. Eine Person baut, die andere zeigt es.
+                                    Die Developer Experience entscheidet darüber, ob Entwickler nach
+                                    der ersten Stunde mit RxDB weiterarbeiten. Für diesen Bereich
+                                    besetzen wir <b>zwei Werkstudentenstellen</b>, eine mit Schwerpunkt
+                                    Frontend-Entwicklung und eine mit Schwerpunkt Video und Social Media.
                                 </p>
-                                <p className="centered-mobile-p">
-                                    Beide Stellen: <b>20 € pro Stunde</b>, 10 bis 20 Stunden pro Woche,
-                                    flexibel nach Vorlesungsplan. Überwiegend remote, gelegentlich vor
-                                    Ort in Stuttgart. Start nach Absprache.
+                                <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
+                                    Konditionen für beide Stellen: <b>20 € pro Stunde</b>, 10 bis 20
+                                    Stunden pro Woche, flexibel nach Vorlesungsplan. Überwiegend remote,
+                                    gelegentlich vor Ort in Stuttgart. Eintritt nach Absprache.
                                 </p>
                             </div>
                         </div>
@@ -123,20 +149,13 @@ export default function Jobs() {
                                             }}>{job.title}</div>
                                             <div style={{
                                                 fontSize: 15,
-                                                lineHeight: '23px',
-                                                marginBottom: 20
+                                                lineHeight: '23px'
                                             }}>{job.lead}</div>
-                                            <ul style={{ lineHeight: '24px', fontSize: 14 }}>
-                                                {job.bullets.map((b, j) => <li key={'b-' + j}>{b}</li>)}
-                                            </ul>
-                                            <div style={{
-                                                fontSize: 14,
-                                                lineHeight: '21px',
-                                                opacity: 0.8,
-                                                marginTop: 12,
-                                                marginBottom: 28,
-                                                flexGrow: 1
-                                            }}>{job.profile}</div>
+
+                                            <Section title='Aufgaben' items={job.tasks} />
+                                            <Section title='Anforderungen' items={job.requirements} />
+
+                                            <div style={{ flexGrow: 1, minHeight: 28 }}></div>
                                             <div style={{ textAlign: 'center' }}>
                                                 <Button primary onClick={openApplicationForm}>
                                                     Jetzt bewerben

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -25,10 +25,10 @@ const JOBS = [
         title: 'Schwerpunkt Frontend-Entwicklung',
         lead: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
         tasks: [
-            'Weiterentwicklung der TypeScript-Typen, damit Autovervollständigung und Typprüfung im Editor der Nutzer greifen',
-            'Überarbeitung der Fehlermeldungen und der Dev-Mode-Prüfungen, sodass aus einem Fehler hervorgeht, was zu tun ist',
-            'Abbau von Reibung in den häufigen Abläufen, vom Setup bis zur ersten Query',
-            'Auswertung wiederkehrender Fragen aus GitHub, Discord und Stack Overflow und Rückführung in Code oder Dokumentation'
+            'Analyse, woran Entwickler beim Einstieg in RxDB hängen bleiben, und Behebung der Ursachen im Code',
+            'Mitarbeit an der öffentlichen Schnittstelle der Bibliothek, damit sie sich vorhersehbar verhält',
+            'Verbesserung der Rückmeldungen, die RxDB im Fehlerfall gibt',
+            'Rückführung wiederkehrender Fragen aus der Community in Produkt und Dokumentation'
         ],
         requirements: [
             'Studium der Informatik, Softwaretechnik, Medieninformatik oder eines vergleichbaren Fachs',

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -48,7 +48,7 @@ const JOBS = [
         requirements: [
             'Studium der Audiovisuellen Medien, Onlinemedien, Werbung und Marktkommunikation, Medieninformatik oder eines vergleichbaren Fachs',
             'eigenständige Schnittarbeit, belegt durch Arbeitsproben',
-            'Programmierkenntnisse sind nicht erforderlich'
+            'Grundkenntnisse in der Softwareentwicklung. Du entwickelst nicht selbst, solltest aber verstehen, was in einem Video passiert, und einen Codeausschnitt lesen können.'
         ]
     }
 ];

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -10,46 +10,38 @@ import { IframeFormModal } from '../components/modal';
 import { Button } from '../components/button';
 
 /**
- * Pipedrive webform for job applications.
- * TODO replace with the real form url once the form exists in Pipedrive,
- * the required fields are listed in the pull request that added this page.
+ * Pipedrive webform for job applications. Both positions use the same form,
+ * the applicant picks the position inside it.
+ * TODO replace with the real form url once the form exists in Pipedrive.
  */
 const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/REPLACE_ME';
 
 /**
- * This page is in German on purpose. The position is a German Werkstudenten
- * job in Stuttgart and the people it is written for study here, so the page
- * sets its own lang attribute instead of inheriting the site default.
+ * This page is in German on purpose. Both positions are German
+ * Werkstudenten jobs in Stuttgart, so the page sets its own lang
+ * attribute instead of inheriting the site default.
  */
-const TASKS = [
+const JOBS = [
     {
-        title: 'Demo-Anwendungen bauen',
-        text: 'Jedes RxDB-Feature braucht ein lauffähiges Beispiel. Du baust kleine Anwendungen in TypeScript, die RxDB in React, Angular, Vue und React Native zeigen, und hältst die bestehenden Beispiele zur jeweils neuesten Version aktuell.'
+        title: 'Werkstudent (m/w/d) Developer Content',
+        bullets: [
+            'Demo-Anwendungen in TypeScript bauen, die RxDB in React, Angular und Vue zeigen',
+            'die bestehenden Beispiele zu jedem Release aktuell halten',
+            'zu jeder Demo die passende Doku- oder Blogseite schreiben',
+            'Entwicklerfragen auf GitHub, Discord und Stack Overflow beantworten'
+        ],
+        profile: 'Informatik, Softwaretechnik oder Medieninformatik. Du bist sicher in TypeScript und hast schon etwas Eigenes veröffentlicht. Ein GitHub-Profil sagt uns mehr als ein Anschreiben.'
     },
     {
-        title: 'Die passende Seite dazu schreiben',
-        text: 'Eine Demo, die niemand findet, hilft niemandem. Zu jedem Beispiel entsteht eine Doku- oder Blogseite, die erklärt, was es tut und warum es so gebaut ist.'
-    },
-    {
-        title: 'Entwicklerfragen beantworten',
-        text: 'Fragen zu RxDB kommen über GitHub Discussions, Discord und Stack Overflow herein. Du beantwortest die, die du kannst, und gibst die anderen weiter.'
-    },
-    {
-        title: 'Die Beispiele ehrlich halten',
-        text: 'Wenn ein Release eine API ändert, gehen die Beispiele kaputt. Du merkst das vor unseren Nutzern.'
+        title: 'Werkstudent (m/w/d) Video und Content',
+        bullets: [
+            'unseren YouTube-Kanal übernehmen, von der Aufnahme über den Schnitt bis zu Titel und Thumbnail',
+            'aus jedem langen Video Shorts und einen LinkedIn-Clip schneiden',
+            'kurze Animationen, die Offline-First und Synchronisation erklären',
+            'Kommentare, Playlists und Kanalpflege'
+        ],
+        profile: 'Audiovisuelle Medien, Medieninformatik oder Werbung und Marktkommunikation. Wir wollen kein Anschreiben, sondern zwei bis drei Sachen, die du geschnitten hast.'
     }
-];
-
-const CUSTOMERS = [
-    { name: 'Readwise', country: 'USA' },
-    { name: 'Nutrien', country: 'Kanada' },
-    { name: 'SafeEx', country: 'Dänemark' },
-    { name: 'MoreApp', country: 'Deutschland' },
-    { name: 'myAgro', country: 'Afrika' },
-    { name: 'WooCommerce POS', country: 'Australien' },
-    { name: 'atroo GmbH', country: 'Deutschland' },
-    { name: 'WebWare', country: 'Italien' },
-    { name: 'ALTGRAS', country: 'Guinea' }
 ];
 
 export default function Jobs() {
@@ -75,7 +67,7 @@ export default function Jobs() {
             </Head>
             <Layout
                 title={'Jobs'}
-                description="Offene Stellen bei RxDB. Wir suchen einen Werkstudenten für Developer Content in Stuttgart, überwiegend remote."
+                description="Offene Stellen bei RxDB. Zwei Werkstudentenstellen in Stuttgart, überwiegend remote, 20 € pro Stunde."
             >
                 <main>
 
@@ -85,183 +77,63 @@ export default function Jobs() {
                                 Arbeite an <b>RxDB</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <p className="centered-mobile-p">
+                                <p className="centered-mobile-p" style={{ maxWidth: 760 }}>
                                     RxDB ist eine Local-First-Datenbank für JavaScript-Anwendungen.
-                                    Sie läuft im Browser, auf dem Handy und auf dem Server, sie
-                                    funktioniert weiter, wenn das Netz ausfällt, und sie synchronisiert,
-                                    sobald die Verbindung zurück ist. Unternehmen bauen darauf ihre
-                                    Außendienst-Apps, ihre Offline-Werkzeuge und ihre Produkte.
+                                    Sie funktioniert weiter, wenn das Netz ausfällt, und synchronisiert,
+                                    sobald die Verbindung zurück ist. Im Einsatz ist sie unter anderem
+                                    bei Readwise, Nutrien, MoreApp und myAgro.
                                 </p>
                                 <p className="centered-mobile-p">
-                                    Wir haben eine offene Stelle.
+                                    <b>Zwei offene Stellen</b>, beide 20 € pro Stunde, 10 bis 20 Stunden
+                                    pro Woche, flexibel nach Vorlesungsplan. Überwiegend remote,
+                                    gelegentlich vor Ort in Stuttgart. Start nach Absprache.
                                 </p>
                             </div>
                         </div>
                     </div>
 
-                    <div className="block dark">
+                    <div className="block dark" style={{ paddingBottom: 124 }}>
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>
-                                Werkstudent (m/w/d) <b>Developer Content</b>
-                            </h2>
-                            <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <p className="centered-mobile-p">
-                                    <b>20 € pro Stunde</b>, 10 bis 20 Stunden pro Woche, flexibel nach
-                                    deinem Vorlesungsplan. Überwiegend remote, gelegentlich vor Ort in
-                                    Stuttgart. Start nach Absprache, auch mitten im Semester.
-                                </p>
-                                <p className="centered-mobile-p">
-                                    Für eine Werkstudentenstelle musst du eingeschrieben sein.
-                                    Informatik, Softwaretechnik, Medieninformatik oder etwas
-                                    Vergleichbares.
-                                </p>
-                                <div className="text-center-mobile">
-                                    <Button primary onClick={openApplicationForm}>Jetzt bewerben</Button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="block">
-                        <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>Deine <b>Aufgaben</b></h2>
-                            <div className="inner" style={{ flexWrap: 'wrap' }}>
+                            <div className="inner" style={{ flexWrap: 'wrap', alignItems: 'stretch' }}>
                                 {
-                                    TASKS.map((task, i) => {
+                                    JOBS.map((job, i) => {
                                         return <div
-                                            key={'task-' + i}
+                                            key={'job-' + i}
                                             style={{
-                                                // the plain .block background is
-                                                // var(--bg-color), so a card has to
-                                                // use the darker tone to be visible
-                                                backgroundColor: 'var(--bg-color-dark)',
+                                                backgroundColor: 'var(--bg-color)',
                                                 borderRadius: 10,
-                                                padding: 24,
+                                                padding: 32,
                                                 margin: 8,
-                                                flex: '1 1 380px'
+                                                flex: '1 1 420px',
+                                                display: 'flex',
+                                                flexDirection: 'column'
                                             }}
                                         >
                                             <div style={{
-                                                fontSize: 16,
+                                                fontSize: 20,
                                                 fontWeight: 700,
-                                                lineHeight: '25px',
-                                                marginBottom: 12
-                                            }}>{task.title}</div>
+                                                lineHeight: '28px',
+                                                marginBottom: 20
+                                            }}>{job.title}</div>
+                                            <ul style={{ lineHeight: '24px', fontSize: 14 }}>
+                                                {job.bullets.map((b, j) => <li key={'b-' + j}>{b}</li>)}
+                                            </ul>
                                             <div style={{
                                                 fontSize: 14,
-                                                fontWeight: 500,
-                                                lineHeight: '21px'
-                                            }}>{task.text}</div>
+                                                lineHeight: '21px',
+                                                opacity: 0.8,
+                                                marginTop: 12,
+                                                marginBottom: 28,
+                                                flexGrow: 1
+                                            }}>{job.profile}</div>
+                                            <div style={{ textAlign: 'center' }}>
+                                                <Button primary onClick={openApplicationForm}>
+                                                    Jetzt bewerben
+                                                </Button>
+                                            </div>
                                         </div>;
                                     })
                                 }
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="block dark">
-                        <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>Dein <b>Profil</b></h2>
-                            <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
-                                    <li>Du bist sicher in TypeScript.</li>
-                                    <li>
-                                        Du hast schon etwas Eigenes veröffentlicht, ein Nebenprojekt,
-                                        eine Library, eine App oder einen Pull Request in einem fremden
-                                        Repository. Ein GitHub-Profil sagt uns mehr als ein Anschreiben,
-                                        schick uns also das.
-                                    </li>
-                                    <li>
-                                        Du kannst eine technische Sache schriftlich erklären. Die Hälfte
-                                        dieses Jobs ist Code, die andere Hälfte ist der Text daneben.
-                                    </li>
-                                    <li>Deutsch oder Englisch, beides geht.</li>
-                                </ul>
-                                <p className="centered-mobile-p">
-                                    RxDB musst du noch nicht kennen. Das kennt vorher niemand.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="block">
-                        <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>Wer <b>nutzt</b>, was du baust</h2>
-                            <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <p className="centered-mobile-p">
-                                    RxDB läuft produktiv bei Unternehmen auf vier Kontinenten. Die
-                                    Beispiele, die du schreibst, sind das Erste, was deren Entwickler lesen.
-                                </p>
-                                <div style={{
-                                    display: 'flex',
-                                    flexWrap: 'wrap',
-                                    justifyContent: 'center',
-                                    maxWidth: 860
-                                }}>
-                                    {
-                                        CUSTOMERS.map((customer, i) => {
-                                            return <div
-                                                key={'customer-' + i}
-                                                style={{
-                                                    backgroundColor: 'var(--bg-color-dark)',
-                                                    borderRadius: 10,
-                                                    padding: '12px 20px',
-                                                    margin: 6,
-                                                    fontSize: 15,
-                                                    fontWeight: 600
-                                                }}
-                                            >
-                                                {customer.name}
-                                                <span style={{
-                                                    fontWeight: 400,
-                                                    opacity: 0.7,
-                                                    marginLeft: 8
-                                                }}>{customer.country}</span>
-                                            </div>;
-                                        })
-                                    }
-                                </div>
-                                <p className="centered-mobile-p" style={{ marginTop: 24 }}>
-                                    MongoDB und Supabase sind offizielle RxDB-Partner. Was die Firmen
-                                    oben über RxDB sagen, steht im <a href="/#reviews">Kundenbereich</a> der
-                                    Startseite.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="block dark">
-                        <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>Was wir <b>bieten</b></h2>
-                            <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
-                                    <li>20 € pro Stunde.</li>
-                                    <li>10 bis 20 Stunden pro Woche, geplant um deine Vorlesungen und deine Klausuren herum.</li>
-                                    <li>Überwiegend remote, gelegentlich gemeinsame Tage in Stuttgart.</li>
-                                    <li>
-                                        Deine Arbeit ist öffentlich und trägt deinen Namen. RxDB ist Open
-                                        Source unter der Apache License 2.0, jedes Beispiel und jede
-                                        Seite von dir bleibt also sichtbar, auch wenn du längst weg bist.
-                                    </li>
-                                    <li>
-                                        Kurze Wege. Du sprichst mit den Leuten, die das Produkt bauen,
-                                        denn das sind hier alle.
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="block centered" style={{ paddingBottom: 124 }}>
-                        <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>So <b>bewirbst</b> du dich</h2>
-                            <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <p className="centered-mobile-p">
-                                    Schick uns einen Link auf dein GitHub-Profil und zwei Sätze dazu, was
-                                    du dort gebaut hast. Kein Anschreiben, kein Foto, keine Noten.
-                                    Wir antworten auf jede Bewerbung.
-                                </p>
-                                <Button primary onClick={openApplicationForm}>Jetzt bewerben</Button>
                             </div>
                         </div>
                     </div>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -22,24 +22,26 @@ const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6
  */
 const JOBS = [
     {
-        title: 'Werkstudent (m/w/d) Developer Content',
+        title: 'Schwerpunkt Frontend',
+        lead: 'Du baust die Anwendungen, an denen Entwickler RxDB zum ersten Mal ausprobieren.',
         bullets: [
-            'Demo-Anwendungen in TypeScript bauen, die RxDB in React, Angular und Vue zeigen',
+            'Demo-Apps in TypeScript bauen, die RxDB in React, Angular, Vue und Svelte zeigen',
             'die bestehenden Beispiele zu jedem Release aktuell halten',
-            'zu jeder Demo die passende Doku- oder Blogseite schreiben',
+            'die Doku aus der Sicht von jemandem lesen, der RxDB zum ersten Mal benutzt, und aufschreiben, wo es hakt',
             'Entwicklerfragen auf GitHub, Discord und Stack Overflow beantworten'
         ],
-        profile: 'Informatik, Softwaretechnik oder Medieninformatik. Du bist sicher in TypeScript und hast schon etwas Eigenes veröffentlicht. Ein GitHub-Profil sagt uns mehr als ein Anschreiben.'
+        profile: 'Informatik, Softwaretechnik, Medieninformatik oder etwas Vergleichbares. Du kannst TypeScript und mindestens ein Frontend-Framework, und du hast schon etwas Eigenes veröffentlicht. Ein GitHub-Profil sagt uns mehr als ein Anschreiben.'
     },
     {
-        title: 'Werkstudent (m/w/d) Video und Content',
+        title: 'Schwerpunkt Video und Social Media',
+        lead: 'Du machst sichtbar, was die Entwicklerin oder der Entwickler nebenan gebaut hat.',
         bullets: [
-            'unseren YouTube-Kanal übernehmen, von der Aufnahme über den Schnitt bis zu Titel und Thumbnail',
-            'aus jedem langen Video Shorts und einen LinkedIn-Clip schneiden',
-            'kurze Animationen, die Offline-First und Synchronisation erklären',
-            'Kommentare, Playlists und Kanalpflege'
+            'kurze Videos produzieren, die zeigen, wie man mit RxDB etwas baut, von der Idee über Aufnahme und Schnitt bis zu Titel und Thumbnail',
+            'daraus Shorts und Reels für YouTube, LinkedIn, Instagram und TikTok schneiden',
+            'unseren YouTube-Kanal und die Social-Accounts betreuen, Kommentare eingeschlossen',
+            'anschauen, was funktioniert hat, und die nächsten Videos danach ausrichten'
         ],
-        profile: 'Audiovisuelle Medien, Medieninformatik oder Werbung und Marktkommunikation. Wir wollen kein Anschreiben, sondern zwei bis drei Sachen, die du geschnitten hast.'
+        profile: 'Audiovisuelle Medien, Onlinemedien, Werbung und Marktkommunikation, Medieninformatik oder etwas Vergleichbares. Du schneidest selbst und hast Sachen, die man sich ansehen kann. Programmieren musst du nicht können.'
     }
 ];
 
@@ -66,26 +68,31 @@ export default function Jobs() {
             </Head>
             <Layout
                 title={'Jobs'}
-                description="Offene Stellen bei RxDB. Zwei Werkstudentenstellen in Stuttgart, überwiegend remote, 20 € pro Stunde."
+                description="Zwei Werkstudentenstellen für Developer Experience bei RxDB. Stuttgart, überwiegend remote, 20 € pro Stunde."
             >
                 <main>
 
                     <div className="block first centered">
                         <div className="content">
                             <h1 style={{ textAlign: 'center' }}>
-                                Arbeite an <b>RxDB</b>
+                                Werkstudent (m/w/d) für <b>Developer Experience</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
-                                <p className="centered-mobile-p" style={{ maxWidth: 760 }}>
+                                <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
                                     RxDB ist eine Local-First-Datenbank für JavaScript-Anwendungen.
                                     Sie funktioniert weiter, wenn das Netz ausfällt, und synchronisiert,
                                     sobald die Verbindung zurück ist. Im Einsatz ist sie unter anderem
                                     bei Readwise, Nutrien, MoreApp und myAgro.
                                 </p>
+                                <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
+                                    Developer Experience heißt bei uns: die erste Stunde mit RxDB
+                                    entscheidet, ob jemand dabei bleibt. Daran arbeiten wir, und dafür
+                                    suchen wir <b>zwei Leute</b>. Eine Person baut, die andere zeigt es.
+                                </p>
                                 <p className="centered-mobile-p">
-                                    <b>Zwei offene Stellen</b>, beide 20 € pro Stunde, 10 bis 20 Stunden
-                                    pro Woche, flexibel nach Vorlesungsplan. Überwiegend remote,
-                                    gelegentlich vor Ort in Stuttgart. Start nach Absprache.
+                                    Beide Stellen: <b>20 € pro Stunde</b>, 10 bis 20 Stunden pro Woche,
+                                    flexibel nach Vorlesungsplan. Überwiegend remote, gelegentlich vor
+                                    Ort in Stuttgart. Start nach Absprache.
                                 </p>
                             </div>
                         </div>
@@ -112,8 +119,13 @@ export default function Jobs() {
                                                 fontSize: 20,
                                                 fontWeight: 700,
                                                 lineHeight: '28px',
-                                                marginBottom: 20
+                                                marginBottom: 10
                                             }}>{job.title}</div>
+                                            <div style={{
+                                                fontSize: 15,
+                                                lineHeight: '23px',
+                                                marginBottom: 20
+                                            }}>{job.lead}</div>
                                             <ul style={{ lineHeight: '24px', fontSize: 14 }}>
                                                 {job.bullets.map((b, j) => <li key={'b-' + j}>{b}</li>)}
                                             </ul>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -23,16 +23,16 @@ const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6
 const JOBS = [
     {
         title: 'Schwerpunkt Frontend-Entwicklung',
-        lead: 'Du entwickelst die Anwendungen, an denen Entwickler RxDB zum ersten Mal ausprobieren.',
+        lead: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
         tasks: [
-            'Entwicklung von Demo-Anwendungen in TypeScript, die den Einsatz von RxDB in React, Angular, Vue und Svelte zeigen',
-            'Pflege der bestehenden Beispielprojekte über die Releases hinweg',
-            'Prüfung der Dokumentation aus der Perspektive von Erstnutzern und Aufnahme der Schwachstellen',
-            'Beantwortung von Entwicklerfragen auf GitHub, Discord und Stack Overflow'
+            'Weiterentwicklung der TypeScript-Typen, damit Autovervollständigung und Typprüfung im Editor der Nutzer greifen',
+            'Überarbeitung der Fehlermeldungen und der Dev-Mode-Prüfungen, sodass aus einem Fehler hervorgeht, was zu tun ist',
+            'Abbau von Reibung in den häufigen Abläufen, vom Setup bis zur ersten Query',
+            'Auswertung wiederkehrender Fragen aus GitHub, Discord und Stack Overflow und Rückführung in Code oder Dokumentation'
         ],
         requirements: [
             'Studium der Informatik, Softwaretechnik, Medieninformatik oder eines vergleichbaren Fachs',
-            'sicherer Umgang mit TypeScript und mindestens einem Frontend-Framework',
+            'sicherer Umgang mit TypeScript, Erfahrung mit einem Frontend-Framework ist von Vorteil',
             'eigene veröffentlichte Projekte, ein GitHub-Profil ersetzt bei uns das Anschreiben'
         ]
     },

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -12,9 +12,8 @@ import { Button } from '../components/button';
 /**
  * Pipedrive webform for job applications. Both positions use the same form,
  * the applicant picks the position inside it.
- * TODO replace with the real form url once the form exists in Pipedrive.
  */
-const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/REPLACE_ME';
+const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ';
 
 /**
  * This page is in German on purpose. Both positions are German

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -125,7 +125,10 @@ export default function Jobs() {
                                         return <div
                                             key={'task-' + i}
                                             style={{
-                                                backgroundColor: '#20293C',
+                                                // the plain .block background is
+                                                // var(--bg-color), so a card has to
+                                                // use the darker tone to be visible
+                                                backgroundColor: 'var(--bg-color-dark)',
                                                 borderRadius: 10,
                                                 padding: 24,
                                                 margin: 8,
@@ -193,7 +196,7 @@ export default function Jobs() {
                                             return <div
                                                 key={'customer-' + i}
                                                 style={{
-                                                    backgroundColor: '#20293C',
+                                                    backgroundColor: 'var(--bg-color-dark)',
                                                     borderRadius: 10,
                                                     padding: '12px 20px',
                                                     margin: 6,

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -1,0 +1,270 @@
+import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
+
+import React, { useEffect, useState } from 'react';
+
+const FILE_EVENT_ID = 'jobs-link-clicked';
+
+import { triggerTrackingEvent } from '../components/trigger-event';
+import { IframeFormModal } from '../components/modal';
+import { Button } from '../components/button';
+
+/**
+ * Pipedrive webform for job applications.
+ * TODO replace with the real form url once the form exists in Pipedrive,
+ * the required fields are listed in the pull request that added this page.
+ */
+const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/REPLACE_ME';
+
+const TASKS = [
+    {
+        title: 'Build the demo apps',
+        text: 'Every RxDB feature needs a running example. You build small applications in TypeScript that show RxDB inside React, Angular, Vue and React Native, and you keep the existing examples working against the latest release.'
+    },
+    {
+        title: 'Write the page that goes with it',
+        text: 'A demo nobody can find does not help anyone. Each example gets a documentation or blog page that explains what it does and why it is built that way.'
+    },
+    {
+        title: 'Answer developers',
+        text: 'RxDB questions come in through GitHub Discussions, Discord and Stack Overflow. You answer the ones you can and you escalate the ones you cannot.'
+    },
+    {
+        title: 'Keep the examples honest',
+        text: 'When a release changes an API, the examples break. You find that before our users do.'
+    }
+];
+
+const CUSTOMERS = [
+    { name: 'Readwise', country: 'USA' },
+    { name: 'Nutrien', country: 'Canada' },
+    { name: 'SafeEx', country: 'Denmark' },
+    { name: 'MoreApp', country: 'Germany' },
+    { name: 'myAgro', country: 'Africa' },
+    { name: 'WooCommerce POS', country: 'Australia' },
+    { name: 'atroo GmbH', country: 'Germany' },
+    { name: 'WebWare', country: 'Italy' },
+    { name: 'ALTGRAS', country: 'Guinea' }
+];
+
+export default function Jobs() {
+    useEffect(() => {
+        (() => {
+            triggerTrackingEvent(FILE_EVENT_ID, 0.5);
+        })();
+    });
+
+    const [openForm, setOpenForm] = useState(false);
+
+    const openApplicationForm = () => {
+        setOpenForm(true);
+        triggerTrackingEvent('jobs_form_open', 0.5);
+    };
+
+    return (
+        <>
+            <Head>
+                <body className="homepage jobs-page" />
+                <link rel="canonical" href="/jobs/" />
+            </Head>
+            <Layout
+                title={'Jobs'}
+                description="Open positions at RxDB. We are hiring a working student for developer content in Stuttgart, Germany, remote friendly."
+            >
+                <main>
+
+                    <div className="block first centered">
+                        <div className="content">
+                            <h1 style={{ textAlign: 'center' }}>
+                                Work on <b>RxDB</b>
+                            </h1>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <p className="centered-mobile-p">
+                                    RxDB is a local-first database for JavaScript applications.
+                                    It runs inside the browser, on mobile and on the server, it keeps
+                                    working when the network does not, and it synchronizes once the
+                                    connection comes back. Companies build their field apps, their
+                                    offline tools and their products on top of it.
+                                </p>
+                                <p className="centered-mobile-p">
+                                    We have one open position.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block dark">
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>
+                                Working Student <b>Developer Content</b>
+                            </h2>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <p className="centered-mobile-p">
+                                    <b>20 € per hour</b>, 10 to 20 hours per week, flexible around your
+                                    lecture schedule. Mostly remote with occasional days in Stuttgart,
+                                    Germany. Start whenever you are ready, the middle of a semester is fine.
+                                </p>
+                                <p className="centered-mobile-p">
+                                    This is a Werkstudent position, so you have to be enrolled at a
+                                    university. Computer science, software engineering, media informatics
+                                    or something close to it.
+                                </p>
+                                <div className="text-center-mobile">
+                                    <Button primary onClick={openApplicationForm}>Apply now</Button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block">
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>What you will <b>do</b></h2>
+                            <div className="inner" style={{ flexWrap: 'wrap' }}>
+                                {
+                                    TASKS.map((task, i) => {
+                                        return <div
+                                            key={'task-' + i}
+                                            style={{
+                                                backgroundColor: '#20293C',
+                                                borderRadius: 10,
+                                                padding: 24,
+                                                margin: 8,
+                                                flex: '1 1 380px'
+                                            }}
+                                        >
+                                            <div style={{
+                                                fontSize: 16,
+                                                fontWeight: 700,
+                                                lineHeight: '25px',
+                                                marginBottom: 12
+                                            }}>{task.title}</div>
+                                            <div style={{
+                                                fontSize: 14,
+                                                fontWeight: 500,
+                                                lineHeight: '21px'
+                                            }}>{task.text}</div>
+                                        </div>;
+                                    })
+                                }
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block dark">
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>What you <b>bring</b></h2>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
+                                    <li>You are comfortable in TypeScript.</li>
+                                    <li>
+                                        You have published something of your own, a side project, a library,
+                                        an app or a pull request to somebody else's repository.
+                                        A GitHub profile tells us more than a cover letter, so send that.
+                                    </li>
+                                    <li>
+                                        You can explain a technical thing in writing. Half of this job is
+                                        code and the other half is the text next to it.
+                                    </li>
+                                    <li>English is enough. German is welcome and not required.</li>
+                                </ul>
+                                <p className="centered-mobile-p">
+                                    You do not need to know RxDB yet. Nobody does before they start.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block">
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>Who <b>uses</b> what you build</h2>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <p className="centered-mobile-p">
+                                    RxDB runs in production at companies on four continents. The examples
+                                    you write are the first thing their developers read.
+                                </p>
+                                <div style={{
+                                    display: 'flex',
+                                    flexWrap: 'wrap',
+                                    justifyContent: 'center',
+                                    maxWidth: 860
+                                }}>
+                                    {
+                                        CUSTOMERS.map((customer, i) => {
+                                            return <div
+                                                key={'customer-' + i}
+                                                style={{
+                                                    backgroundColor: '#20293C',
+                                                    borderRadius: 10,
+                                                    padding: '12px 20px',
+                                                    margin: 6,
+                                                    fontSize: 15,
+                                                    fontWeight: 600
+                                                }}
+                                            >
+                                                {customer.name}
+                                                <span style={{
+                                                    fontWeight: 400,
+                                                    opacity: 0.7,
+                                                    marginLeft: 8
+                                                }}>{customer.country}</span>
+                                            </div>;
+                                        })
+                                    }
+                                </div>
+                                <p className="centered-mobile-p" style={{ marginTop: 24 }}>
+                                    MongoDB and Supabase are official RxDB partners. What the companies
+                                    above say about RxDB is on the <a href="/#reviews">customer section</a> of
+                                    the homepage.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block dark">
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>What we <b>offer</b></h2>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
+                                    <li>20 € per hour.</li>
+                                    <li>10 to 20 hours per week, planned around your lectures and your exams.</li>
+                                    <li>Mostly remote, with occasional days together in Stuttgart.</li>
+                                    <li>
+                                        Your work is public and carries your name. RxDB is open source under
+                                        the Apache License 2.0, so every example and every page you write
+                                        stays visible after you leave.
+                                    </li>
+                                    <li>
+                                        Short decisions. You talk to the people who build the product,
+                                        because that is everyone here.
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="block centered" style={{ paddingBottom: 124 }}>
+                        <div className="content">
+                            <h2 style={{ textAlign: 'center' }}>How to <b>apply</b></h2>
+                            <div className="inner centered" style={{ flexDirection: 'column' }}>
+                                <p className="centered-mobile-p">
+                                    Send a link to your GitHub profile and two sentences about what you
+                                    built there. No cover letter, no photo, no grades.
+                                    We answer every application.
+                                </p>
+                                <Button primary onClick={openApplicationForm}>Apply now</Button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <IframeFormModal
+                        iframeUrl={JOBS_FORM_IFRAME_URL}
+                        open={openForm}
+                        onClose={() => setOpenForm(false)}
+                        eventId='jobs_form'
+                        focusEventType='jobs_form_focus'
+                    />
+                </main>
+            </Layout>
+        </>
+    );
+}

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -16,34 +16,39 @@ import { Button } from '../components/button';
  */
 const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/REPLACE_ME';
 
+/**
+ * This page is in German on purpose. The position is a German Werkstudenten
+ * job in Stuttgart and the people it is written for study here, so the page
+ * sets its own lang attribute instead of inheriting the site default.
+ */
 const TASKS = [
     {
-        title: 'Build the demo apps',
-        text: 'Every RxDB feature needs a running example. You build small applications in TypeScript that show RxDB inside React, Angular, Vue and React Native, and you keep the existing examples working against the latest release.'
+        title: 'Demo-Anwendungen bauen',
+        text: 'Jedes RxDB-Feature braucht ein lauffähiges Beispiel. Du baust kleine Anwendungen in TypeScript, die RxDB in React, Angular, Vue und React Native zeigen, und hältst die bestehenden Beispiele zur jeweils neuesten Version aktuell.'
     },
     {
-        title: 'Write the page that goes with it',
-        text: 'A demo nobody can find does not help anyone. Each example gets a documentation or blog page that explains what it does and why it is built that way.'
+        title: 'Die passende Seite dazu schreiben',
+        text: 'Eine Demo, die niemand findet, hilft niemandem. Zu jedem Beispiel entsteht eine Doku- oder Blogseite, die erklärt, was es tut und warum es so gebaut ist.'
     },
     {
-        title: 'Answer developers',
-        text: 'RxDB questions come in through GitHub Discussions, Discord and Stack Overflow. You answer the ones you can and you escalate the ones you cannot.'
+        title: 'Entwicklerfragen beantworten',
+        text: 'Fragen zu RxDB kommen über GitHub Discussions, Discord und Stack Overflow herein. Du beantwortest die, die du kannst, und gibst die anderen weiter.'
     },
     {
-        title: 'Keep the examples honest',
-        text: 'When a release changes an API, the examples break. You find that before our users do.'
+        title: 'Die Beispiele ehrlich halten',
+        text: 'Wenn ein Release eine API ändert, gehen die Beispiele kaputt. Du merkst das vor unseren Nutzern.'
     }
 ];
 
 const CUSTOMERS = [
     { name: 'Readwise', country: 'USA' },
-    { name: 'Nutrien', country: 'Canada' },
-    { name: 'SafeEx', country: 'Denmark' },
-    { name: 'MoreApp', country: 'Germany' },
-    { name: 'myAgro', country: 'Africa' },
-    { name: 'WooCommerce POS', country: 'Australia' },
-    { name: 'atroo GmbH', country: 'Germany' },
-    { name: 'WebWare', country: 'Italy' },
+    { name: 'Nutrien', country: 'Kanada' },
+    { name: 'SafeEx', country: 'Dänemark' },
+    { name: 'MoreApp', country: 'Deutschland' },
+    { name: 'myAgro', country: 'Afrika' },
+    { name: 'WooCommerce POS', country: 'Australien' },
+    { name: 'atroo GmbH', country: 'Deutschland' },
+    { name: 'WebWare', country: 'Italien' },
     { name: 'ALTGRAS', country: 'Guinea' }
 ];
 
@@ -64,30 +69,31 @@ export default function Jobs() {
     return (
         <>
             <Head>
+                <html lang="de" />
                 <body className="homepage jobs-page" />
                 <link rel="canonical" href="/jobs/" />
             </Head>
             <Layout
                 title={'Jobs'}
-                description="Open positions at RxDB. We are hiring a working student for developer content in Stuttgart, Germany, remote friendly."
+                description="Offene Stellen bei RxDB. Wir suchen einen Werkstudenten für Developer Content in Stuttgart, überwiegend remote."
             >
                 <main>
 
                     <div className="block first centered">
                         <div className="content">
                             <h1 style={{ textAlign: 'center' }}>
-                                Work on <b>RxDB</b>
+                                Arbeite an <b>RxDB</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p">
-                                    RxDB is a local-first database for JavaScript applications.
-                                    It runs inside the browser, on mobile and on the server, it keeps
-                                    working when the network does not, and it synchronizes once the
-                                    connection comes back. Companies build their field apps, their
-                                    offline tools and their products on top of it.
+                                    RxDB ist eine Local-First-Datenbank für JavaScript-Anwendungen.
+                                    Sie läuft im Browser, auf dem Handy und auf dem Server, sie
+                                    funktioniert weiter, wenn das Netz ausfällt, und sie synchronisiert,
+                                    sobald die Verbindung zurück ist. Unternehmen bauen darauf ihre
+                                    Außendienst-Apps, ihre Offline-Werkzeuge und ihre Produkte.
                                 </p>
                                 <p className="centered-mobile-p">
-                                    We have one open position.
+                                    Wir haben eine offene Stelle.
                                 </p>
                             </div>
                         </div>
@@ -96,21 +102,21 @@ export default function Jobs() {
                     <div className="block dark">
                         <div className="content">
                             <h2 style={{ textAlign: 'center' }}>
-                                Working Student <b>Developer Content</b>
+                                Werkstudent (m/w/d) <b>Developer Content</b>
                             </h2>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p">
-                                    <b>20 € per hour</b>, 10 to 20 hours per week, flexible around your
-                                    lecture schedule. Mostly remote with occasional days in Stuttgart,
-                                    Germany. Start whenever you are ready, the middle of a semester is fine.
+                                    <b>20 € pro Stunde</b>, 10 bis 20 Stunden pro Woche, flexibel nach
+                                    deinem Vorlesungsplan. Überwiegend remote, gelegentlich vor Ort in
+                                    Stuttgart. Start nach Absprache, auch mitten im Semester.
                                 </p>
                                 <p className="centered-mobile-p">
-                                    This is a Werkstudent position, so you have to be enrolled at a
-                                    university. Computer science, software engineering, media informatics
-                                    or something close to it.
+                                    Für eine Werkstudentenstelle musst du eingeschrieben sein.
+                                    Informatik, Softwaretechnik, Medieninformatik oder etwas
+                                    Vergleichbares.
                                 </p>
                                 <div className="text-center-mobile">
-                                    <Button primary onClick={openApplicationForm}>Apply now</Button>
+                                    <Button primary onClick={openApplicationForm}>Jetzt bewerben</Button>
                                 </div>
                             </div>
                         </div>
@@ -118,7 +124,7 @@ export default function Jobs() {
 
                     <div className="block">
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>What you will <b>do</b></h2>
+                            <h2 style={{ textAlign: 'center' }}>Deine <b>Aufgaben</b></h2>
                             <div className="inner" style={{ flexWrap: 'wrap' }}>
                                 {
                                     TASKS.map((task, i) => {
@@ -155,23 +161,24 @@ export default function Jobs() {
 
                     <div className="block dark">
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>What you <b>bring</b></h2>
+                            <h2 style={{ textAlign: 'center' }}>Dein <b>Profil</b></h2>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
-                                    <li>You are comfortable in TypeScript.</li>
+                                    <li>Du bist sicher in TypeScript.</li>
                                     <li>
-                                        You have published something of your own, a side project, a library,
-                                        an app or a pull request to somebody else's repository.
-                                        A GitHub profile tells us more than a cover letter, so send that.
+                                        Du hast schon etwas Eigenes veröffentlicht, ein Nebenprojekt,
+                                        eine Library, eine App oder einen Pull Request in einem fremden
+                                        Repository. Ein GitHub-Profil sagt uns mehr als ein Anschreiben,
+                                        schick uns also das.
                                     </li>
                                     <li>
-                                        You can explain a technical thing in writing. Half of this job is
-                                        code and the other half is the text next to it.
+                                        Du kannst eine technische Sache schriftlich erklären. Die Hälfte
+                                        dieses Jobs ist Code, die andere Hälfte ist der Text daneben.
                                     </li>
-                                    <li>English is enough. German is welcome and not required.</li>
+                                    <li>Deutsch oder Englisch, beides geht.</li>
                                 </ul>
                                 <p className="centered-mobile-p">
-                                    You do not need to know RxDB yet. Nobody does before they start.
+                                    RxDB musst du noch nicht kennen. Das kennt vorher niemand.
                                 </p>
                             </div>
                         </div>
@@ -179,11 +186,11 @@ export default function Jobs() {
 
                     <div className="block">
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>Who <b>uses</b> what you build</h2>
+                            <h2 style={{ textAlign: 'center' }}>Wer <b>nutzt</b>, was du baust</h2>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p">
-                                    RxDB runs in production at companies on four continents. The examples
-                                    you write are the first thing their developers read.
+                                    RxDB läuft produktiv bei Unternehmen auf vier Kontinenten. Die
+                                    Beispiele, die du schreibst, sind das Erste, was deren Entwickler lesen.
                                 </p>
                                 <div style={{
                                     display: 'flex',
@@ -215,9 +222,9 @@ export default function Jobs() {
                                     }
                                 </div>
                                 <p className="centered-mobile-p" style={{ marginTop: 24 }}>
-                                    MongoDB and Supabase are official RxDB partners. What the companies
-                                    above say about RxDB is on the <a href="/#reviews">customer section</a> of
-                                    the homepage.
+                                    MongoDB und Supabase sind offizielle RxDB-Partner. Was die Firmen
+                                    oben über RxDB sagen, steht im <a href="/#reviews">Kundenbereich</a> der
+                                    Startseite.
                                 </p>
                             </div>
                         </div>
@@ -225,20 +232,20 @@ export default function Jobs() {
 
                     <div className="block dark">
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>What we <b>offer</b></h2>
+                            <h2 style={{ textAlign: 'center' }}>Was wir <b>bieten</b></h2>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <ul style={{ maxWidth: 720, lineHeight: '28px' }}>
-                                    <li>20 € per hour.</li>
-                                    <li>10 to 20 hours per week, planned around your lectures and your exams.</li>
-                                    <li>Mostly remote, with occasional days together in Stuttgart.</li>
+                                    <li>20 € pro Stunde.</li>
+                                    <li>10 bis 20 Stunden pro Woche, geplant um deine Vorlesungen und deine Klausuren herum.</li>
+                                    <li>Überwiegend remote, gelegentlich gemeinsame Tage in Stuttgart.</li>
                                     <li>
-                                        Your work is public and carries your name. RxDB is open source under
-                                        the Apache License 2.0, so every example and every page you write
-                                        stays visible after you leave.
+                                        Deine Arbeit ist öffentlich und trägt deinen Namen. RxDB ist Open
+                                        Source unter der Apache License 2.0, jedes Beispiel und jede
+                                        Seite von dir bleibt also sichtbar, auch wenn du längst weg bist.
                                     </li>
                                     <li>
-                                        Short decisions. You talk to the people who build the product,
-                                        because that is everyone here.
+                                        Kurze Wege. Du sprichst mit den Leuten, die das Produkt bauen,
+                                        denn das sind hier alle.
                                     </li>
                                 </ul>
                             </div>
@@ -247,14 +254,14 @@ export default function Jobs() {
 
                     <div className="block centered" style={{ paddingBottom: 124 }}>
                         <div className="content">
-                            <h2 style={{ textAlign: 'center' }}>How to <b>apply</b></h2>
+                            <h2 style={{ textAlign: 'center' }}>So <b>bewirbst</b> du dich</h2>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p">
-                                    Send a link to your GitHub profile and two sentences about what you
-                                    built there. No cover letter, no photo, no grades.
-                                    We answer every application.
+                                    Schick uns einen Link auf dein GitHub-Profil und zwei Sätze dazu, was
+                                    du dort gebaut hast. Kein Anschreiben, kein Foto, keine Noten.
+                                    Wir antworten auf jede Bewerbung.
                                 </p>
-                                <Button primary onClick={openApplicationForm}>Apply now</Button>
+                                <Button primary onClick={openApplicationForm}>Jetzt bewerben</Button>
                             </div>
                         </div>
                     </div>

--- a/docs-src/src/theme/Footer/index.js
+++ b/docs-src/src/theme/Footer/index.js
@@ -70,6 +70,10 @@ export default function FooterWrapper() {
         label: 'Become a Partner',
         href: '/consulting#become-partner',
       },
+      {
+        label: 'Jobs',
+        href: '/jobs/',
+      },
       // {
       //   label: 'About us',
       //   target: '_blank',


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (a new page on the documentation site, no source-code change)

## Describe the problem you have without this PR

There is no page on rxdb.info that describes an open position, so a job posting has nowhere to link to. This adds one at `/jobs/` and links it from the footer.

### What the page contains

The page is deliberately small: a hero and two tiles, one per open position.

- **Shared terms, stated once in the hero:** 20 € per hour, 10 to 20 hours per week, flexible around lectures, mostly remote with occasional days in Stuttgart, start by arrangement.
- **Tile 1, Werkstudent Developer Content:** building the TypeScript demo apps for React, Angular and Vue, keeping the existing examples current against each release, writing the documentation page that goes with each demo, and answering developers on GitHub, Discord and Stack Overflow.
- **Tile 2, Werkstudent Video und Content:** running the YouTube channel end to end, cutting shorts and LinkedIn clips out of each long video, short animations that explain offline-first and replication, and channel upkeep.
- Both tiles open the **same** Pipedrive application form, so the form itself asks which position the application is for.
- The hero names four customers who already run RxDB in production (Readwise, Nutrien, MoreApp, myAgro). All four are taken from the "Used by Thousands Worldwide" section of the homepage, so this page introduces no new claim.

### Implementation notes

- `docs-src/src/pages/jobs.tsx` follows the block layout of `consulting.tsx`: `block` / `block dark` sections, `content` and `inner` wrappers, the shared `Button`, a canonical link in `Head`, and `triggerTrackingEvent` on page view and on form open. The application form uses the existing `IframeFormModal`, the same Pipedrive webform mechanism `/consulting/` and `/premium/` already use.
- **The page is in German**, because both positions are German Werkstudenten jobs in Stuttgart and the people it is written for study here. It therefore sets its own `lang="de"` on the html element through `Head` rather than inheriting the site default.
- Because of that, `.github/workflows/main.yml` adds `jobs.tsx` to the `skip` list of the `spelling docs-src/src` step. codespell only knows English misspellings and flagged 28 ordinary German words (`oder`, `ist`, `vor`, `Deine`, `Foto` and so on). `privacy.tsx`, the German privacy policy, is already on that list for exactly this reason. No other spelling step is touched.
- Cards use `var(--bg-color-dark)`, not `#20293C`. `#20293C` **is** `var(--bg-color)`, the background of a plain `.block`, so cards in that colour are invisible on this page. `consulting.tsx` gets away with it because its cards sit inside a `block dark` section.
- `docs-src/src/theme/Footer/index.js` gains one `policyLinks` entry, "Jobs", next to "Become a Partner".

### How this was verified

`npm install`, `npm run build`, `(cd docs-src && npm install)` and `npx docusaurus build`, in the order `.github/workflows/build.yml` uses.

- The docs build finishes with `[SUCCESS] Generated static files in "build"` and generates `build/jobs/index.html` with the expected content and the German lang attribute.
- The page was rendered in Chromium at 1440px and at 390px, and the footer link renders on every page.
- `npx eslint` and `codespell` with the repo's ignore file and the new skip list: both clean.
- The application form url returns HTTP 200.
- The broken-anchor warnings the docs build prints are pre-existing and on other pages, none on `/jobs/`.

### CI

`example-react` fails and `example-vue` is cancelled by its own 30 minute timeout. Both behave identically on `master` at `af6fb65`, the commit this branch is based on, both live in `examples/`, which this PR does not touch, and both are explained in the comments below. Every check that covers this PR's changes is green, including `test-code-style`.

## Todos

- [ ] Tests: not applicable, this is a documentation page with no source-code change
- [x] Documentation: this PR is the documentation
- [ ] Typings: not applicable
- [ ] Changelog: not applicable