### PR TITLE
docs(jobs): two separate adverts as tiles, full text in a modal

### DIFF
--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 const FILE_EVENT_ID = 'jobs-link-clicked';
 
 import { triggerTrackingEvent } from '../components/trigger-event';
-import { IframeFormModal } from '../components/modal';
+import { IframeFormModal, Modal } from '../components/modal';
 import { Button } from '../components/button';
 
 /**
@@ -16,14 +16,29 @@ import { Button } from '../components/button';
 const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ';
 
 /**
+ * The conditions are identical for both positions, so they live in one place
+ * and are rendered into each advert. Each advert has to stand on its own,
+ * because a visitor reads one of them and never the other.
+ */
+const CONDITIONS = [
+    '20 € pro Stunde',
+    '10 bis 20 Stunden pro Woche, flexibel nach Vorlesungsplan',
+    'überwiegend remote, gelegentlich vor Ort in Stuttgart',
+    'Eintritt nach Absprache, auch mitten im Semester',
+    'deine Arbeit ist Open Source und bleibt unter deinem Namen sichtbar'
+];
+
+/**
  * This page is in German on purpose. Both positions are German
  * Werkstudenten jobs in Stuttgart, so the page sets its own lang
  * attribute instead of inheriting the site default.
  */
 const JOBS = [
     {
-        title: 'Schwerpunkt Frontend-Entwicklung',
-        lead: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
+        id: 'frontend',
+        title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Frontend',
+        short: 'Schwerpunkt Frontend',
+        teaser: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
         tasks: [
             'Analyse, woran Entwickler beim Einstieg in RxDB hängen bleiben, und Behebung der Ursachen im Code',
             'Mitarbeit an der öffentlichen Schnittstelle der Bibliothek, damit sie sich vorhersehbar verhält',
@@ -37,8 +52,10 @@ const JOBS = [
         ]
     },
     {
-        title: 'Schwerpunkt Video und Social Media',
-        lead: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
+        id: 'video',
+        title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Video und Social Media',
+        short: 'Schwerpunkt Video und Social Media',
+        teaser: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
         tasks: [
             'Produktion kurzer Videos zur Arbeit mit RxDB, von der Konzeption über Aufnahme und Schnitt bis zu Titel und Thumbnail',
             'Aufbereitung der Videos als Shorts und Reels für YouTube, LinkedIn, Instagram und TikTok',
@@ -61,10 +78,10 @@ function Section(props: { title: string; items: string[]; }) {
             letterSpacing: '0.08em',
             textTransform: 'uppercase',
             opacity: 0.65,
-            marginTop: 20,
+            marginTop: 24,
             marginBottom: 8
         }}>{props.title}</div>
-        <ul style={{ lineHeight: '24px', fontSize: 14, marginBottom: 0 }}>
+        <ul style={{ lineHeight: '24px', fontSize: 14, fontWeight: 500, marginBottom: 0 }}>
             {props.items.map((item, i) => <li key={'i-' + i}>{item}</li>)}
         </ul>
     </>;
@@ -77,12 +94,25 @@ export default function Jobs() {
         })();
     });
 
+    const [openJob, setOpenJob] = useState<number | null>(null);
     const [openForm, setOpenForm] = useState(false);
 
+    const showJob = (index: number) => {
+        setOpenJob(index);
+        triggerTrackingEvent('jobs_detail_open_' + JOBS[index].id, 0.3);
+    };
+
+    /**
+     * Applying happens from inside an advert. Close that one first so the two
+     * modals never stack on top of each other.
+     */
     const openApplicationForm = () => {
+        setOpenJob(null);
         setOpenForm(true);
         triggerTrackingEvent('jobs_form_open', 0.5);
     };
+
+    const job = openJob === null ? null : JOBS[openJob];
 
     return (
         <>
@@ -100,7 +130,7 @@ export default function Jobs() {
                     <div className="block first centered">
                         <div className="content">
                             <h1 style={{ textAlign: 'center' }}>
-                                Werkstudent (m/w/d) für <b>Developer Experience</b>
+                                Arbeite an <b>RxDB</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
@@ -112,13 +142,8 @@ export default function Jobs() {
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
                                     Die Developer Experience entscheidet darüber, ob Entwickler nach
                                     der ersten Stunde mit RxDB weiterarbeiten. Für diesen Bereich
-                                    besetzen wir <b>zwei Werkstudentenstellen</b>, eine mit Schwerpunkt
-                                    Frontend-Entwicklung und eine mit Schwerpunkt Video und Social Media.
-                                </p>
-                                <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
-                                    Konditionen für beide Stellen: <b>20 € pro Stunde</b>, 10 bis 20
-                                    Stunden pro Woche, flexibel nach Vorlesungsplan. Überwiegend remote,
-                                    gelegentlich vor Ort in Stuttgart. Eintritt nach Absprache.
+                                    besetzen wir <b>zwei Werkstudentenstellen</b>. Klick auf eine
+                                    Stelle für die vollständige Anzeige.
                                 </p>
                             </div>
                         </div>
@@ -128,9 +153,19 @@ export default function Jobs() {
                         <div className="content">
                             <div className="inner" style={{ flexWrap: 'wrap', alignItems: 'stretch' }}>
                                 {
-                                    JOBS.map((job, i) => {
+                                    JOBS.map((entry, i) => {
                                         return <div
-                                            key={'job-' + i}
+                                            key={entry.id}
+                                            role='button'
+                                            tabIndex={0}
+                                            aria-label={'Stellenanzeige öffnen: ' + entry.short}
+                                            onClick={() => showJob(i)}
+                                            onKeyDown={(event) => {
+                                                if (event.key === 'Enter' || event.key === ' ') {
+                                                    event.preventDefault();
+                                                    showJob(i);
+                                                }
+                                            }}
                                             style={{
                                                 backgroundColor: 'var(--bg-color)',
                                                 borderRadius: 10,
@@ -138,7 +173,8 @@ export default function Jobs() {
                                                 margin: 8,
                                                 flex: '1 1 420px',
                                                 display: 'flex',
-                                                flexDirection: 'column'
+                                                flexDirection: 'column',
+                                                cursor: 'pointer'
                                             }}
                                         >
                                             <div style={{
@@ -146,19 +182,29 @@ export default function Jobs() {
                                                 fontWeight: 700,
                                                 lineHeight: '28px',
                                                 marginBottom: 10
-                                            }}>{job.title}</div>
+                                            }}>{entry.short}</div>
                                             <div style={{
                                                 fontSize: 15,
-                                                lineHeight: '23px'
-                                            }}>{job.lead}</div>
-
-                                            <Section title='Aufgaben' items={job.tasks} />
-                                            <Section title='Anforderungen' items={job.requirements} />
-
-                                            <div style={{ flexGrow: 1, minHeight: 28 }}></div>
-                                            <div style={{ textAlign: 'center' }}>
-                                                <Button primary onClick={openApplicationForm}>
-                                                    Jetzt bewerben
+                                                lineHeight: '23px',
+                                                marginBottom: 20
+                                            }}>{entry.teaser}</div>
+                                            <div style={{
+                                                fontSize: 13,
+                                                fontWeight: 500,
+                                                opacity: 0.7,
+                                                flexGrow: 1
+                                            }}>
+                                                20 € pro Stunde, 10 bis 20 Stunden pro Woche,
+                                                Stuttgart und remote
+                                            </div>
+                                            <div style={{ textAlign: 'center', marginTop: 28 }}>
+                                                <Button primary onClick={(event) => {
+                                                    // the whole tile is clickable, so the
+                                                    // button must not trigger it a second time
+                                                    event.stopPropagation();
+                                                    showJob(i);
+                                                }}>
+                                                    Zur Stellenanzeige
                                                 </Button>
                                             </div>
                                         </div>;
@@ -167,6 +213,41 @@ export default function Jobs() {
                             </div>
                         </div>
                     </div>
+
+                    <Modal
+                        open={job !== null}
+                        onCancel={() => setOpenJob(null)}
+                        title={job ? job.title : ''}
+                    >
+                        {
+                            job ? <>
+                                {/*
+                                  * The advert scrolls, the button does not. Keeping the
+                                  * button out of the scroll container stops the browser
+                                  * from scrolling the advert to the bottom when the modal
+                                  * is opened by keyboard and focus lands on the button.
+                                  */}
+                                <div style={{
+                                    padding: '0 20px',
+                                    maxHeight: '60vh',
+                                    overflowY: 'auto'
+                                }}>
+                                    <div style={{ fontSize: 15, lineHeight: '23px' }}>{job.teaser}</div>
+                                    <Section title='Aufgaben' items={job.tasks} />
+                                    <Section title='Anforderungen' items={job.requirements} />
+                                    <Section title='Konditionen' items={CONDITIONS} />
+                                </div>
+                                <div style={{
+                                    textAlign: 'center',
+                                    padding: '20px 20px 4px 20px'
+                                }}>
+                                    <Button primary onClick={openApplicationForm}>
+                                        Jetzt bewerben
+                                    </Button>
+                                </div>
+                            </> : null
+                        }
+                    </Modal>
 
                     <IframeFormModal
                         iframeUrl={JOBS_FORM_IFRAME_URL}


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS (a change to the /jobs page added in pubkey/rxdb#9022, no source-code change)

## Describe the problem you have without this PR

`/jobs` presented the two open positions as one combined advert: a shared hero carried the conditions and each tile carried only a task list. A visitor interested in one position had to read around the other one, and neither tile was a complete job advert on its own.

### What changes

- **Two separate adverts.** Each tile is a teaser (short title, one line, the key conditions). Clicking it opens that position's **complete** advert in a modal: intro, Aufgaben, Anforderungen and Konditionen.
- **Each advert stands alone.** The conditions now live in both adverts rather than only in the hero, because a visitor reads one of them and never the other. They come from one `CONDITIONS` constant so the two cannot drift apart.
- **The whole tile is the target**, not just the button, and it is reachable by keyboard (`role="button"`, `tabIndex`, Enter and Space). The button inside calls `stopPropagation` so a click does not fire the handler twice.
- **The modals never stack.** Applying closes the advert first, then opens the Pipedrive form.
- **Per-advert tracking**, `jobs_detail_open_frontend` and `jobs_detail_open_video`, so it becomes visible which of the two positions people actually open.

### One bug found and fixed while testing this

The apply button was originally inside the advert's scrolling area. Opening the modal **by keyboard** moved focus to that button, and the browser scrolled the advert to the bottom to bring it into view, hiding the intro and the "Aufgaben" heading. Measured, not guessed: content 756px in a 650px viewport, `scrollTop` at the end.

Moving the button out of the scroll container fixes it and keeps the call to action visible at all times.

### How this was verified

`npx eslint`, `codespell` with the repo's ignore file and skip list, and `npx docusaurus build` (`[SUCCESS] Generated static files in "build"`).

Driven in Chromium against the built site, opening each advert by mouse and by keyboard:

| open | scrollTop | first line visible | button visible |
| --- | --- | --- | --- |
| mouse, Frontend | 0 | yes | yes |
| keyboard, Frontend | 0 | yes | yes |
| keyboard, Video und Social Media | 0 | yes | yes |

Also confirmed that a tile click opens the matching advert, that exactly **one** modal is visible after pressing "Jetzt bewerben", and that its iframe carries the real Pipedrive form URL.

## Todos

- [ ] Tests: not applicable, this is a documentation page with no source-code change
- [x] Documentation: this PR is the documentation
- [ ] Typings: not applicable
- [ ] Changelog: not applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw)_