### PR TITLE
docs(jobs): full job titles on the tiles, and a page title worth indexing

### DIFF
--- a/docs-src/src/constants.ts
+++ b/docs-src/src/constants.ts
@@ -9,6 +9,12 @@ export const NON_PREMIUM_COLLECTION_LIMIT = 13;
 export const HOME_TITLE = 'RxDB - JavaScript Database';
 
 /**
+ * Title of the /jobs/ page. Like HOME_TITLE it already names the brand, so the
+ * swizzled TitleFormatter must not append the ` | RxDB` suffix to it.
+ */
+export const JOBS_TITLE = 'Jobs & Stellenangebote bei RxDB';
+
+/**
  * Premium tier prices in dollars per month, billed annually.
  * Shown on the premium page and used to calculate
  * the lead value on the premium-submitted pages.

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -8,6 +8,7 @@ const FILE_EVENT_ID = 'jobs-link-clicked';
 import { triggerTrackingEvent } from '../components/trigger-event';
 import { IframeFormModal, Modal } from '../components/modal';
 import { Button } from '../components/button';
+import { JOBS_TITLE } from '../constants';
 
 /**
  * Pipedrive webform for job applications. Both positions use the same form,
@@ -120,8 +121,8 @@ export default function Jobs() {
                 <link rel="canonical" href="/jobs/" />
             </Head>
             <Layout
-                title={'Jobs'}
-                description="Zwei Werkstudentenstellen für Developer Experience bei RxDB. Stuttgart, überwiegend remote, 20 € pro Stunde."
+                title={JOBS_TITLE}
+                description="Offene Werkstudentenstellen bei RxDB. Stuttgart, überwiegend remote, 20 € pro Stunde."
             >
                 <main>
 
@@ -138,10 +139,8 @@ export default function Jobs() {
                                     Readwise, Nutrien, MoreApp und myAgro setzen RxDB in Produktion ein.
                                 </p>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
-                                    Die Developer Experience entscheidet darüber, ob Entwickler nach
-                                    der ersten Stunde mit RxDB weiterarbeiten. Für diesen Bereich
-                                    besetzen wir <b>zwei Werkstudentenstellen</b>. Klick auf eine
-                                    Stelle für die vollständige Anzeige.
+                                    Aktuell besetzen wir <b>zwei Werkstudentenstellen</b> in
+                                    Stuttgart. Klick auf eine Stelle für die vollständige Anzeige.
                                 </p>
                             </div>
                         </div>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -37,7 +37,6 @@ const JOBS = [
     {
         id: 'frontend',
         title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Frontend',
-        short: 'Schwerpunkt Frontend',
         teaser: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
         tasks: [
             'Analyse, woran Entwickler beim Einstieg in RxDB hängen bleiben, und Behebung der Ursachen im Code',
@@ -54,7 +53,6 @@ const JOBS = [
     {
         id: 'video',
         title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Video und Social Media',
-        short: 'Schwerpunkt Video und Social Media',
         teaser: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
         tasks: [
             'Produktion kurzer Videos zur Arbeit mit RxDB, von der Konzeption über Aufnahme und Schnitt bis zu Titel und Thumbnail',
@@ -151,14 +149,24 @@ export default function Jobs() {
 
                     <div className="block dark" style={{ paddingBottom: 124 }}>
                         <div className="content">
-                            <div className="inner" style={{ flexWrap: 'wrap', alignItems: 'stretch' }}>
+                            {/*
+                              * Plain flex row instead of the shared .inner
+                              * class, which turns column-reverse on small
+                              * screens and would show the second advert first.
+                              */}
+                            <div style={{
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                justifyContent: 'center',
+                                alignItems: 'stretch'
+                            }}>
                                 {
                                     JOBS.map((entry, i) => {
                                         return <div
                                             key={entry.id}
                                             role='button'
                                             tabIndex={0}
-                                            aria-label={'Stellenanzeige öffnen: ' + entry.short}
+                                            aria-label={'Stellenanzeige öffnen: ' + entry.title}
                                             onClick={() => showJob(i)}
                                             onKeyDown={(event) => {
                                                 if (event.key === 'Enter' || event.key === ' ') {
@@ -181,8 +189,8 @@ export default function Jobs() {
                                                 fontSize: 20,
                                                 fontWeight: 700,
                                                 lineHeight: '28px',
-                                                marginBottom: 10
-                                            }}>{entry.short}</div>
+                                                marginBottom: 14
+                                            }}>{entry.title}</div>
                                             <div style={{
                                                 fontSize: 15,
                                                 lineHeight: '23px',

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -140,7 +140,7 @@ export default function Jobs() {
                                 </p>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
                                     Aktuell besetzen wir <b>zwei Werkstudentenstellen</b> in
-                                    Stuttgart. Klick auf eine Stelle für die vollständige Anzeige.
+                                    Stuttgart.
                                 </p>
                             </div>
                         </div>

--- a/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from 'react';
 import { TitleFormatterProvider } from '@docusaurus/theme-common/internal';
-import { HOME_TITLE } from '../../../constants';
+import { HOME_TITLE, JOBS_TITLE } from '../../../constants';
 
 /**
  * Swizzled title formatter.
@@ -11,9 +11,14 @@ import { HOME_TITLE } from '../../../constants';
  *
  * The default formatter skips the suffix only when the page title is exactly
  * equal to `siteConfig.title`. That is too narrow for us: the homepage and
- * /consulting/ carry the longer descriptive HOME_TITLE, which already contains
- * the brand, so appending the suffix would render `RxDB - JavaScript Database
- * | RxDB`. Treat HOME_TITLE the same way Docusaurus treats the site title.
+ * /consulting/ carry the longer descriptive HOME_TITLE, and /jobs/ carries
+ * JOBS_TITLE. Both already contain the brand, so appending the suffix would
+ * render `RxDB - JavaScript Database | RxDB` and `Jobs & Stellenangebote bei
+ * RxDB | RxDB`. Treat them the way Docusaurus treats the site title.
+ *
+ * This is an explicit list rather than a rule such as `ends with RxDB`, because
+ * 13 documentation pages already end with the brand (`Partial Sync with RxDB`
+ * and similar) and rely on the suffix being appended.
  *
  * NOTE: `ThemeProvider/TitleFormatter` is a real theme component (shipped by
  * theme-classic at lib/theme/ThemeProvider/TitleFormatter) but it is not in
@@ -29,8 +34,10 @@ import { HOME_TITLE } from '../../../constants';
 const formatter: React.ComponentProps<
     typeof TitleFormatterProvider
 >['formatter'] = (params) => {
-    if (params.title?.trim() === HOME_TITLE) {
-        return HOME_TITLE;
+    const ownTitle = [HOME_TITLE, JOBS_TITLE]
+        .find((title) => title === params.title?.trim());
+    if (ownTitle) {
+        return ownTitle;
     }
     return params.defaultFormatter(params);
 };


### PR DESCRIPTION
Follow-up to #9028, which introduced the two tiles on `/jobs`.

## What changes

**The tiles now carry the full job title.** They showed a short label, `Schwerpunkt Frontend` and `Schwerpunkt Video und Social Media`, so a visitor scanning the page never saw what the position is actually called until they opened the modal. Both tiles now show the same heading the advert does:

- Werkstudent (m/w/d) Developer Experience, Schwerpunkt Frontend
- Werkstudent (m/w/d) Developer Experience, Schwerpunkt Video und Social Media

The `short` field is gone from the data, since the title covers both the tile heading and the `aria-label`.

**The page title is now `Jobs & Stellenangebote bei RxDB`.** It was `Jobs`, which says nothing in a search result and matches nothing anyone types. Because the new title already carries the brand, the swizzled `TitleFormatter` has to skip the sitewide ` | RxDB` suffix for it, exactly as it already does for `HOME_TITLE`, otherwise the tab reads `... bei RxDB | RxDB`. It stays an explicit list rather than a rule such as "ends with RxDB", because 13 documentation pages (`Partial Sync with RxDB` and similar) end with the brand and do rely on the suffix being appended.

**The developer-experience framing is out of the page-level text.** Both the meta description and the intro paragraph presented the whole page as being about developer experience. That belongs to the two adverts, which say it in their own titles, not to a page that lists whatever happens to be open.

**Mobile order fix.** The tile row used the shared `.inner` class, which becomes `flex-direction: column-reverse` below the mobile breakpoint. On a phone the video advert therefore appeared above the frontend one, in the opposite order to the desktop layout. The row is now a plain flex container with the same desktop behaviour (centered, wrapping, stretched), so both viewports read top to bottom in the same order. `.column-mobile` does not help here, it has lower specificity than `.block .inner` and loses.

## Verified

Built the docs and drove the built page with Playwright at 1440x1000 and 390x844:

- `<title>` on `/jobs/` is `Jobs & Stellenangebote bei RxDB`, with no suffix, and `og:title` matches
- the homepage title is unchanged, and all 13 docs titles that end with the brand still get ` | RxDB`
- both tiles render the full title, 2 and 3 lines, and stay equal height (344px each)
- the modal heading matches the tile that opened it
- mobile order is frontend first, video second
- the advert still opens scrolled to the top (`scrollTop` 0), so the earlier keyboard-focus fix is intact
- eslint clean on all three changed files

Screenshots are in the review thread rather than the repo.