### PR TITLE
docs: update the A/B variations of the gadxie2 and gadxie3 SEM pages

### DIFF
--- a/docs-src/src/pages/sem/gadxie2.tsx
+++ b/docs-src/src/pages/sem/gadxie2.tsx
@@ -52,14 +52,30 @@ const variations = {
     //         <>Battle-tested replication</>
     //     ]
     // },
-    d: {
-        title: <>Queries That <b>Re-Render</b> Your <b>UI</b></>,
-        text: <>Define a schema, query your local data, and RxDB keeps every subscribed component up to date as the data changes, in every open tab and on every device. Storage is IndexedDB, OPFS or SQLite, whichever fits your app.</>,
+    /**
+     * Variation 'd' was retired on 2026-09-02 after the second A/B readout on
+     * this page: variation 'b' stayed ahead on every engagement signal.
+     * Kept on record (commented out, not deleted) so its letter and copy stay
+     * reserved and are never reused for different copy.
+     */
+    // d: {
+    //     title: <>Queries That <b>Re-Render</b> Your <b>UI</b></>,
+    //     text: <>Define a schema, query your local data, and RxDB keeps every subscribed component up to date as the data changes, in every open tab and on every device. Storage is IndexedDB, OPFS or SQLite, whichever fits your app.</>,
+    //     bulletpoints: [
+    //         <>Observable queries, no refetching</>,
+    //         <>Every open tab stays consistent</>,
+    //         <>IndexedDB, OPFS or SQLite storage</>,
+    //         <>Replication to your own backend</>
+    //     ]
+    // },
+    e: {
+        title: <>Change Your <b>Schema</b> Without Losing <b>Local Data</b></>,
+        text: <>RxDB versions your schema. When you ship a new app version, the migration strategies you define transform the documents already stored on the user's device, so an update never starts from an empty database. Schema validation catches bad writes before they reach storage.</>,
         bulletpoints: [
-            <>Observable queries, no refetching</>,
-            <>Every open tab stays consistent</>,
-            <>IndexedDB, OPFS or SQLite storage</>,
-            <>Replication to your own backend</>
+            <>Versioned schemas with migrations</>,
+            <>Existing device data is migrated</>,
+            <>Validation before every write</>,
+            <>TypeScript types from your schema</>
         ]
     }
 };

--- a/docs-src/src/pages/sem/gadxie3.tsx
+++ b/docs-src/src/pages/sem/gadxie3.tsx
@@ -36,28 +36,38 @@ const variations = {
             <>No BroadcastChannel plumbing</>
         ]
     },
-    c: {
-        title: <><b>Offline Edits</b> Without <b>Lost Data</b></>,
-        text: <>Users edit offline, reconnect, and expect nothing to be lost. RxDB stores writes locally, replicates them when the network returns, and resolves conflicts with a strategy you control.</>,
-        bulletpoints: [
-            <>Local-first writes, zero latency</>,
-            <>Automatic replication on reconnect</>,
-            <>Custom conflict strategies</>,
-            <>Data survives page reloads</>
-        ]
-    }
+    /**
+     * Variation 'c' was retired on 2026-09-02 after the A/B readout on this
+     * page: variations 'a' and 'b' both beat it on engagement. Kept on record
+     * (commented out, not deleted) so its letter and copy stay reserved and
+     * are never reused for different copy.
+     */
+    // c: {
+    //     title: <><b>Offline Edits</b> Without <b>Lost Data</b></>,
+    //     text: <>Users edit offline, reconnect, and expect nothing to be lost. RxDB stores writes locally, replicates them when the network returns, and resolves conflicts with a strategy you control.</>,
+    //     bulletpoints: [
+    //         <>Local-first writes, zero latency</>,
+    //         <>Automatic replication on reconnect</>,
+    //         <>Custom conflict strategies</>,
+    //         <>Data survives page reloads</>
+    //     ]
+    // }
 };
+
+const variationKeys = Object.keys(variations) as (keyof typeof variations)[];
 
 export default function Page() {
     /**
-     * Render variation "a" on the server and on the first client render
-     * to avoid a hydration mismatch, then swap to the assigned variation.
+     * Render the first live variation on the server and on the first client
+     * render to avoid a hydration mismatch, then swap to the assigned one.
+     * The key comes from Object.keys(), never a hardcoded 'a': once variation
+     * 'a' is retired a hardcoded default renders nothing.
      */
-    const [variationKey, setVariationKey] = useState('a');
+    const [variationKey, setVariationKey] = useState(variationKeys[0] as string);
     useEffect(() => {
-        setVariationKey(getSemVariation(Object.keys(variations)));
+        setVariationKey(getSemVariation(variationKeys));
     }, []);
-    const variation = variations[variationKey as keyof typeof variations] ?? variations.a;
+    const variation = variations[variationKey as keyof typeof variations] ?? variations[variationKeys[0]];
 
     return Home({
         sem: {


### PR DESCRIPTION
## This PR contains:

Improved docs (SEM landing pages only, `docs-src/src/pages/sem/`).

## Describe the problem you have without this PR

The two SEM landing pages `gadxie2` and `gadxie3` still serve A/B variations that lost their test, so a share of the traffic keeps landing on copy that is known to perform worse than the copy next to it.

This PR updates the variation sets on both pages:

- **`gadxie2`**: variation `d` is retired and a new variation `e` takes its place, "Change Your Schema Without Losing Local Data" (schema versioning, migration strategies running on the user's device, validation before writes). Variation `b` is unchanged and stays live.
- **`gadxie3`**: variation `c` is retired. Variations `a` and `b` are unchanged, so the page keeps a two-way test.
- **`gadxie3`** also gets the same server-render fix the other updated pages already have: the variation key rendered on the server comes from `Object.keys(variations)[0]` instead of a hardcoded `'a'`, so the page keeps working the day variation `a` is retired.

Retired variations are commented out rather than deleted, so their letters stay reserved and can never be reused for different copy, and new variations take the next unused letter. Both `metaTitle`s still name copy that is live on their page, so neither changes.

## Todos

- [ ] ~~Tests~~ landing-page copy, no behavior to test
- [x] Documentation
- [ ] ~~Typings~~ unchanged
- [ ] ~~Changelog~~ not a fix or a feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CD78DR7dB8NTrWXfwBGVD

---
_Generated by [Claude Code](https://claude.ai/code/session_012CD78DR7dB8NTrWXfwBGVD)_