### PR TITLE
docs(jobs): headline, intro, working location, and one form per position

### DIFF
--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -129,7 +129,7 @@ export default function Jobs() {
                     <div className="block first centered">
                         <div className="content">
                             <h1 style={{ textAlign: 'center' }}>
-                                Arbeite an <b>RxDB</b>
+                                Karriere bei <b>RxDB</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -138,10 +138,6 @@ export default function Jobs() {
                                     synchronisiert, sobald sie wiederhergestellt ist. Unternehmen wie
                                     Readwise, Nutrien, MoreApp und myAgro setzen RxDB in Produktion ein.
                                 </p>
-                                <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
-                                    Aktuell besetzen wir <b>zwei Werkstudentenstellen</b> in
-                                    Stuttgart.
-                                </p>
                             </div>
                         </div>
                     </div>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -11,12 +11,6 @@ import { Button } from '../components/button';
 import { JOBS_TITLE } from '../constants';
 
 /**
- * Pipedrive webform for job applications. Both positions use the same form,
- * the applicant picks the position inside it.
- */
-const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ';
-
-/**
  * The conditions are identical for both positions, so they live in one place
  * and are rendered into each advert. Each advert has to stand on its own,
  * because a visitor reads one of them and never the other.
@@ -38,6 +32,12 @@ const JOBS = [
     {
         id: 'frontend',
         title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Frontend',
+        /**
+         * Each position has its own Pipedrive webform, so an application
+         * arrives already assigned to a position and the form does not have
+         * to ask which one it is for.
+         */
+        formUrl: 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ',
         teaser: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
         tasks: [
             'Analyse, woran Entwickler beim Einstieg in RxDB hängen bleiben, und Behebung der Ursachen im Code',
@@ -54,6 +54,7 @@ const JOBS = [
     {
         id: 'video',
         title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Video und Social Media',
+        formUrl: 'https://webforms.pipedrive.com/f/6ULD69TOWMqORnAypjPo1bdwhsesN2fDV6KxV3qLLYIPaJhOP8rNnznmTTk7Pojq39',
         teaser: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
         tasks: [
             'Produktion kurzer Videos zur Arbeit mit RxDB, von der Konzeption über Aufnahme und Schnitt bis zu Titel und Thumbnail',
@@ -94,7 +95,9 @@ export default function Jobs() {
     });
 
     const [openJob, setOpenJob] = useState<number | null>(null);
-    const [openForm, setOpenForm] = useState(false);
+    // which position's form to show, kept after closing so the modal can fade out
+    const [formJob, setFormJob] = useState<number | null>(null);
+    const [formOpen, setFormOpen] = useState(false);
 
     const showJob = (index: number) => {
         setOpenJob(index);
@@ -105,10 +108,11 @@ export default function Jobs() {
      * Applying happens from inside an advert. Close that one first so the two
      * modals never stack on top of each other.
      */
-    const openApplicationForm = () => {
+    const openApplicationForm = (index: number) => {
         setOpenJob(null);
-        setOpenForm(true);
-        triggerTrackingEvent('jobs_form_open', 0.5);
+        setFormJob(index);
+        setFormOpen(true);
+        triggerTrackingEvent('jobs_form_open_' + JOBS[index].id, 0.5);
     };
 
     const job = openJob === null ? null : JOBS[openJob];
@@ -244,7 +248,11 @@ export default function Jobs() {
                                     textAlign: 'center',
                                     padding: '20px 20px 4px 20px'
                                 }}>
-                                    <Button primary onClick={openApplicationForm}>
+                                    <Button primary onClick={() => {
+                                        if (openJob !== null) {
+                                            openApplicationForm(openJob);
+                                        }
+                                    }}>
                                         Jetzt bewerben
                                     </Button>
                                 </div>
@@ -252,13 +260,17 @@ export default function Jobs() {
                         }
                     </Modal>
 
-                    <IframeFormModal
-                        iframeUrl={JOBS_FORM_IFRAME_URL}
-                        open={openForm}
-                        onClose={() => setOpenForm(false)}
-                        eventId='jobs_form'
-                        focusEventType='jobs_form_focus'
-                    />
+                    {
+                        formJob === null ? null : <IframeFormModal
+                            // remount when the visitor switches position
+                            key={JOBS[formJob].id}
+                            iframeUrl={JOBS[formJob].formUrl}
+                            open={formOpen}
+                            onClose={() => setFormOpen(false)}
+                            eventId={'jobs_form_' + JOBS[formJob].id}
+                            focusEventType={'jobs_form_focus_' + JOBS[formJob].id}
+                        />
+                    }
                 </main>
             </Layout>
         </>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -24,7 +24,7 @@ const JOBS_FORM_IFRAME_URL = 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6
 const CONDITIONS = [
     '20 € pro Stunde',
     '10 bis 20 Stunden pro Woche, flexibel nach Vorlesungsplan',
-    'überwiegend remote, gelegentlich vor Ort in Stuttgart',
+    'regelmäßig vor Ort in Stuttgart, zeitweise auch aus dem Homeoffice',
     'Eintritt nach Absprache, auch mitten im Semester',
     'deine Arbeit ist Open Source und bleibt unter deinem Namen sichtbar'
 ];
@@ -122,7 +122,7 @@ export default function Jobs() {
             </Head>
             <Layout
                 title={JOBS_TITLE}
-                description="Offene Werkstudentenstellen bei RxDB. Stuttgart, überwiegend remote, 20 € pro Stunde."
+                description="Offene Werkstudentenstellen bei RxDB in Stuttgart, 20 € pro Stunde."
             >
                 <main>
 
@@ -198,7 +198,7 @@ export default function Jobs() {
                                                 flexGrow: 1
                                             }}>
                                                 20 € pro Stunde, 10 bis 20 Stunden pro Woche,
-                                                Stuttgart und remote
+                                                vor Ort in Stuttgart
                                             </div>
                                             <div style={{ textAlign: 'center', marginTop: 28 }}>
                                                 <Button primary onClick={(event) => {


### PR DESCRIPTION
Four corrections to `/jobs`.

**The headline is now `Karriere bei RxDB`.** It read `Arbeite an RxDB`, which described the work rather than naming the page. The new one matches the page title (`Jobs & Stellenangebote bei RxDB`) and the `Jobs` entry in the footer.

**The sentence counting the open positions is gone.** The tiles below already show which positions are open and where, so `Aktuell besetzen wir zwei Werkstudentenstellen in Stuttgart.` repeated them, and it would have gone stale the moment one of the two is filled.

**The working location was stated backwards.** The conditions said `überwiegend remote, gelegentlich vor Ort in Stuttgart` and the tiles said `Stuttgart und remote`. Both positions are expected in the office regularly, with some days from home. It now reads `regelmäßig vor Ort in Stuttgart, zeitweise auch aus dem Homeoffice`, the tile summary says `vor Ort in Stuttgart`, and the meta description, which carried the same claim, is corrected with it. Getting this wrong would have cost applications from people who cannot commute, and wasted the time of people who applied expecting remote work.

**Each position now has its own Pipedrive form.** There is a second webform for the video and social media position, so the form url moves out of a shared constant and into the job data, and the apply button opens the form belonging to the advert it was pressed in. An application therefore arrives already assigned to a position, and the tracking events (`jobs_form_open_*`, `jobs_form_*`) carry the position id. The form modal is keyed by position so the iframe is remounted when a visitor looks at both adverts, and it keeps the last url after closing so the close animation still runs.

## Verified

- Built the docs and read the rendered output: the headline, the corrected conditions line in both adverts, the tile summaries, and the new meta description
- Drove the built page with Playwright: opening `Jetzt bewerben` from the frontend advert loads the frontend form, from the video advert the video form, and switching back to the frontend advert loads the frontend form again, with one visible modal each time
- Both form urls answer HTTP 200
- Screenshots at 1440x1000 with a modal open, tiles and modal behaviour unaffected
- `npx eslint docs-src/src/pages/jobs.tsx` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw