### PR TITLE
docs(jobs): rewrite the page in English

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -511,9 +511,9 @@ jobs:
         uses: codespell-project/actions-codespell@v2.2
         with:
           ignore_words_file: config/codespellignore.txt
-          # jobs.tsx is German, like privacy.tsx, and codespell only knows
-          # English misspellings, so it flags ordinary German words.
-          skip: legal-notice.tsx,privacy.tsx,jobs.tsx,custom.css
+          # legal-notice.tsx and privacy.tsx are German, and codespell only
+          # knows English misspellings, so it flags ordinary German words.
+          skip: legal-notice.tsx,privacy.tsx,custom.css
           path: docs-src/src
       - name: spelling docs-src/releases
         uses: codespell-project/actions-codespell@v2.2

--- a/docs-src/src/constants.ts
+++ b/docs-src/src/constants.ts
@@ -12,7 +12,7 @@ export const HOME_TITLE = 'RxDB - JavaScript Database';
  * Title of the /jobs/ page. Like HOME_TITLE it already names the brand, so the
  * swizzled TitleFormatter must not append the ` | RxDB` suffix to it.
  */
-export const JOBS_TITLE = 'Jobs & Stellenangebote bei RxDB';
+export const JOBS_TITLE = 'Jobs & Open Positions at RxDB';
 
 /**
  * Premium tier prices in dollars per month, billed annually.

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -18,7 +18,7 @@ import { JOBS_TITLE } from '../constants';
 const CONDITIONS = [
     '20 € per hour',
     '10 to 20 hours per week, flexible around your lecture timetable',
-    'regularly on site in Stuttgart, part of the time from home',
+    'regularly on site in Stuttgart, Germany 🇩🇪, part of the time from home',
     'start by arrangement, mid-semester is fine',
     'your work is open source and stays visible under your name'
 ];
@@ -55,7 +55,7 @@ const JOBS = [
         id: 'video',
         title: 'Working Student (m/f/d) Developer Experience, Video and Social Media',
         formUrl: 'https://webforms.pipedrive.com/f/6ULD69TOWMqORnAypjPo1bdwhsesN2fDV6KxV3qLLYIPaJhOP8rNnznmTTk7Pojq39',
-        teaser: 'You make the work coming out of the frontend role visible.',
+        teaser: 'You run RxDB\'s YouTube channel and its social media, and decide what gets made next.',
         tasks: [
             'producing short videos about working with RxDB, from the concept through recording and editing to the title and the thumbnail',
             'cutting them into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
@@ -139,8 +139,8 @@ export default function Jobs() {
                                     RxDB is a local-first database for JavaScript applications. It
                                     keeps working when the network drops and syncs again once the
                                     connection is back. Companies like Readwise, Nutrien, MoreApp and
-                                    myAgro run RxDB in production. Both open positions are German
-                                    Werkstudent roles based in Stuttgart.
+                                    myAgro run RxDB in production. Both open positions are
+                                    Werkstudent roles based in Stuttgart, Germany 🇩🇪.
                                 </p>
                             </div>
                         </div>
@@ -202,7 +202,7 @@ export default function Jobs() {
                                                 flexGrow: 1
                                             }}>
                                                 20 € per hour, 10 to 20 hours per week,
-                                                on site in Stuttgart
+                                                on site in Stuttgart, Germany 🇩🇪
                                             </div>
                                             <div style={{ textAlign: 'center', marginTop: 28 }}>
                                                 <Button primary onClick={(event) => {

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -17,10 +17,10 @@ import { JOBS_TITLE } from '../constants';
  */
 const CONDITIONS = [
     '20 € per hour',
-    '10 to 20 hours per week, flexible around your lecture timetable',
-    'regularly on site in Stuttgart, Germany 🇩🇪, part of the time from home',
-    'start by arrangement, mid-semester is fine',
-    'your work is open source and stays visible under your name'
+    '10 to 20 hours per week, scheduled around the lecture timetable',
+    'Regularly on site in Stuttgart, Germany 🇩🇪, part of the time from home',
+    'Start date by arrangement, mid-semester is possible',
+    'All work is open source and credited by name'
 ];
 
 /**
@@ -38,34 +38,35 @@ const JOBS = [
          * to ask which one it is for.
          */
         formUrl: 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ',
-        teaser: 'You work on RxDB itself, and on getting developers productive with it faster.',
+        teaser: 'Development work on the RxDB library itself, with a focus on the experience of the developers who build with it.',
         tasks: [
-            'finding where developers get stuck when they start with RxDB, and fixing the causes in the code',
-            'working on the public interface of the library so that it behaves predictably',
-            'improving what RxDB tells you when something goes wrong',
-            'feeding recurring questions from the community back into the product and the documentation'
+            'Identifying where developers get stuck when they start with RxDB, and resolving the causes in the code',
+            'Working on the public API of the library so that it behaves predictably',
+            'Improving the messages and diagnostics RxDB produces when something goes wrong',
+            'Feeding recurring questions from the community back into the product and the documentation'
         ],
         requirements: [
-            'studies in computer science, software engineering, media informatics or a comparable subject',
-            'confident with TypeScript, experience with a frontend framework is an advantage',
-            'published projects of your own. A GitHub profile replaces the cover letter here.'
+            'Enrolled in computer science, software engineering, media informatics or a comparable subject',
+            'Confident command of TypeScript, experience with a frontend framework is an advantage',
+            'Own published projects. A GitHub profile takes the place of a cover letter.'
         ]
     },
     {
         id: 'video',
         title: 'Working Student (m/f/d) Developer Experience, Video and Social Media',
         formUrl: 'https://webforms.pipedrive.com/f/6ULD69TOWMqORnAypjPo1bdwhsesN2fDV6KxV3qLLYIPaJhOP8rNnznmTTk7Pojq39',
-        teaser: 'You make the videos yourself, from the idea to the finished cut.',
+        teaser: 'Production of video content about RxDB, from the concept through filming and editing to publication.',
         tasks: [
-            'planning and filming your own short videos about working with RxDB',
-            'doing the whole edit yourself, cut, sound, titles and thumbnails',
-            'turning each video into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
-            'running the YouTube channel, answering the comments, and deciding from the reach numbers what to film next'
+            'Planning and filming short-form videos about working with RxDB',
+            'Editing them end to end, including cut, sound, titles and thumbnails',
+            'Adapting each video into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
+            'Running the YouTube channel, including community management',
+            'Evaluating reach and engagement data to decide which topics to produce next'
         ],
         requirements: [
-            'studies in audiovisual media, online media, advertising and market communication, media informatics or a comparable subject',
-            'you shoot and cut independently, shown by work samples',
-            'basic knowledge of software development. You do not write the code, but you should understand what happens in a video and be able to read a snippet of it.'
+            'Enrolled in audiovisual media, online media, advertising and market communication, media informatics or a comparable subject',
+            'Independent filming and editing, demonstrated by work samples',
+            'Basic understanding of software development. Writing code is not part of the role, but the content requires following what happens on screen and reading a short snippet of it.'
         ]
     }
 ];
@@ -240,7 +241,7 @@ export default function Jobs() {
                                     overflowY: 'auto'
                                 }}>
                                     <div style={{ fontSize: 15, lineHeight: '23px' }}>{job.teaser}</div>
-                                    <Section title='Tasks' items={job.tasks} />
+                                    <Section title='Responsibilities' items={job.tasks} />
                                     <Section title='Requirements' items={job.requirements} />
                                     <Section title='Conditions' items={CONDITIONS} />
                                 </div>

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -55,16 +55,16 @@ const JOBS = [
         id: 'video',
         title: 'Working Student (m/f/d) Developer Experience, Video and Social Media',
         formUrl: 'https://webforms.pipedrive.com/f/6ULD69TOWMqORnAypjPo1bdwhsesN2fDV6KxV3qLLYIPaJhOP8rNnznmTTk7Pojq39',
-        teaser: 'You run RxDB\'s YouTube channel and its social media, and decide what gets made next.',
+        teaser: 'You make the videos yourself, from the idea to the finished cut.',
         tasks: [
-            'producing short videos about working with RxDB, from the concept through recording and editing to the title and the thumbnail',
-            'cutting them into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
-            'running the YouTube channel and the social media channels, including community management',
-            'reading the reach numbers and deciding what to cover next'
+            'planning and filming your own short videos about working with RxDB',
+            'doing the whole edit yourself, cut, sound, titles and thumbnails',
+            'turning each video into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
+            'running the YouTube channel, answering the comments, and deciding from the reach numbers what to film next'
         ],
         requirements: [
             'studies in audiovisual media, online media, advertising and market communication, media informatics or a comparable subject',
-            'you edit independently, shown by work samples',
+            'you shoot and cut independently, shown by work samples',
             'basic knowledge of software development. You do not write the code, but you should understand what happens in a video and be able to read a snippet of it.'
         ]
     }

--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -16,56 +16,56 @@ import { JOBS_TITLE } from '../constants';
  * because a visitor reads one of them and never the other.
  */
 const CONDITIONS = [
-    '20 € pro Stunde',
-    '10 bis 20 Stunden pro Woche, flexibel nach Vorlesungsplan',
-    'regelmäßig vor Ort in Stuttgart, zeitweise auch aus dem Homeoffice',
-    'Eintritt nach Absprache, auch mitten im Semester',
-    'deine Arbeit ist Open Source und bleibt unter deinem Namen sichtbar'
+    '20 € per hour',
+    '10 to 20 hours per week, flexible around your lecture timetable',
+    'regularly on site in Stuttgart, part of the time from home',
+    'start by arrangement, mid-semester is fine',
+    'your work is open source and stays visible under your name'
 ];
 
 /**
- * This page is in German on purpose. Both positions are German
- * Werkstudenten jobs in Stuttgart, so the page sets its own lang
- * attribute instead of inheriting the site default.
+ * Both positions are German Werkstudent jobs based in Stuttgart. The page is
+ * in English like the rest of the site, so the job titles keep the German
+ * term, which is the actual employment status rather than a translation.
  */
 const JOBS = [
     {
         id: 'frontend',
-        title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Frontend',
+        title: 'Working Student (m/f/d) Developer Experience, Frontend',
         /**
          * Each position has its own Pipedrive webform, so an application
          * arrives already assigned to a position and the form does not have
          * to ask which one it is for.
          */
         formUrl: 'https://webforms.pipedrive.com/f/czK0WxW1wnP2HOdt6VkTVENuSfO4WvZsVeFXTCAy1a6wazfJcSa0BHBiWNoj1YKZTZ',
-        teaser: 'Du arbeitest an RxDB selbst und daran, dass Entwickler schneller damit zurechtkommen.',
+        teaser: 'You work on RxDB itself, and on getting developers productive with it faster.',
         tasks: [
-            'Analyse, woran Entwickler beim Einstieg in RxDB hängen bleiben, und Behebung der Ursachen im Code',
-            'Mitarbeit an der öffentlichen Schnittstelle der Bibliothek, damit sie sich vorhersehbar verhält',
-            'Verbesserung der Rückmeldungen, die RxDB im Fehlerfall gibt',
-            'Rückführung wiederkehrender Fragen aus der Community in Produkt und Dokumentation'
+            'finding where developers get stuck when they start with RxDB, and fixing the causes in the code',
+            'working on the public interface of the library so that it behaves predictably',
+            'improving what RxDB tells you when something goes wrong',
+            'feeding recurring questions from the community back into the product and the documentation'
         ],
         requirements: [
-            'Studium der Informatik, Softwaretechnik, Medieninformatik oder eines vergleichbaren Fachs',
-            'sicherer Umgang mit TypeScript, Erfahrung mit einem Frontend-Framework ist von Vorteil',
-            'eigene veröffentlichte Projekte, ein GitHub-Profil ersetzt bei uns das Anschreiben'
+            'studies in computer science, software engineering, media informatics or a comparable subject',
+            'confident with TypeScript, experience with a frontend framework is an advantage',
+            'published projects of your own. A GitHub profile replaces the cover letter here.'
         ]
     },
     {
         id: 'video',
-        title: 'Werkstudent (m/w/d) Developer Experience, Schwerpunkt Video und Social Media',
+        title: 'Working Student (m/f/d) Developer Experience, Video and Social Media',
         formUrl: 'https://webforms.pipedrive.com/f/6ULD69TOWMqORnAypjPo1bdwhsesN2fDV6KxV3qLLYIPaJhOP8rNnznmTTk7Pojq39',
-        teaser: 'Du machst die Arbeit sichtbar, die im Frontend-Bereich entsteht.',
+        teaser: 'You make the work coming out of the frontend role visible.',
         tasks: [
-            'Produktion kurzer Videos zur Arbeit mit RxDB, von der Konzeption über Aufnahme und Schnitt bis zu Titel und Thumbnail',
-            'Aufbereitung der Videos als Shorts und Reels für YouTube, LinkedIn, Instagram und TikTok',
-            'Betreuung des YouTube-Kanals und der Social-Media-Kanäle einschließlich Community-Management',
-            'Auswertung der Reichweiten und Ableitung der nächsten Themen'
+            'producing short videos about working with RxDB, from the concept through recording and editing to the title and the thumbnail',
+            'cutting them into shorts and reels for YouTube, LinkedIn, Instagram and TikTok',
+            'running the YouTube channel and the social media channels, including community management',
+            'reading the reach numbers and deciding what to cover next'
         ],
         requirements: [
-            'Studium der Audiovisuellen Medien, Onlinemedien, Werbung und Marktkommunikation, Medieninformatik oder eines vergleichbaren Fachs',
-            'eigenständige Schnittarbeit, belegt durch Arbeitsproben',
-            'Grundkenntnisse in der Softwareentwicklung. Du entwickelst nicht selbst, solltest aber verstehen, was in einem Video passiert, und einen Codeausschnitt lesen können.'
+            'studies in audiovisual media, online media, advertising and market communication, media informatics or a comparable subject',
+            'you edit independently, shown by work samples',
+            'basic knowledge of software development. You do not write the code, but you should understand what happens in a video and be able to read a snippet of it.'
         ]
     }
 ];
@@ -120,27 +120,27 @@ export default function Jobs() {
     return (
         <>
             <Head>
-                <html lang="de" />
                 <body className="homepage jobs-page" />
                 <link rel="canonical" href="/jobs/" />
             </Head>
             <Layout
                 title={JOBS_TITLE}
-                description="Offene Werkstudentenstellen bei RxDB in Stuttgart, 20 € pro Stunde."
+                description="Open working student positions at RxDB in Stuttgart, Germany. 20 € per hour."
             >
                 <main>
 
                     <div className="block first centered">
                         <div className="content">
                             <h1 style={{ textAlign: 'center' }}>
-                                Karriere bei <b>RxDB</b>
+                                Careers at <b>RxDB</b>
                             </h1>
                             <div className="inner centered" style={{ flexDirection: 'column' }}>
                                 <p className="centered-mobile-p" style={{ maxWidth: 780 }}>
-                                    RxDB ist eine Local-First-Datenbank für JavaScript-Anwendungen.
-                                    Sie arbeitet weiter, wenn die Netzverbindung ausfällt, und
-                                    synchronisiert, sobald sie wiederhergestellt ist. Unternehmen wie
-                                    Readwise, Nutrien, MoreApp und myAgro setzen RxDB in Produktion ein.
+                                    RxDB is a local-first database for JavaScript applications. It
+                                    keeps working when the network drops and syncs again once the
+                                    connection is back. Companies like Readwise, Nutrien, MoreApp and
+                                    myAgro run RxDB in production. Both open positions are German
+                                    Werkstudent roles based in Stuttgart.
                                 </p>
                             </div>
                         </div>
@@ -165,7 +165,7 @@ export default function Jobs() {
                                             key={entry.id}
                                             role='button'
                                             tabIndex={0}
-                                            aria-label={'Stellenanzeige öffnen: ' + entry.title}
+                                            aria-label={'Open the job advert: ' + entry.title}
                                             onClick={() => showJob(i)}
                                             onKeyDown={(event) => {
                                                 if (event.key === 'Enter' || event.key === ' ') {
@@ -201,8 +201,8 @@ export default function Jobs() {
                                                 opacity: 0.7,
                                                 flexGrow: 1
                                             }}>
-                                                20 € pro Stunde, 10 bis 20 Stunden pro Woche,
-                                                vor Ort in Stuttgart
+                                                20 € per hour, 10 to 20 hours per week,
+                                                on site in Stuttgart
                                             </div>
                                             <div style={{ textAlign: 'center', marginTop: 28 }}>
                                                 <Button primary onClick={(event) => {
@@ -211,7 +211,7 @@ export default function Jobs() {
                                                     event.stopPropagation();
                                                     showJob(i);
                                                 }}>
-                                                    Zur Stellenanzeige
+                                                    Read the full advert
                                                 </Button>
                                             </div>
                                         </div>;
@@ -240,9 +240,9 @@ export default function Jobs() {
                                     overflowY: 'auto'
                                 }}>
                                     <div style={{ fontSize: 15, lineHeight: '23px' }}>{job.teaser}</div>
-                                    <Section title='Aufgaben' items={job.tasks} />
-                                    <Section title='Anforderungen' items={job.requirements} />
-                                    <Section title='Konditionen' items={CONDITIONS} />
+                                    <Section title='Tasks' items={job.tasks} />
+                                    <Section title='Requirements' items={job.requirements} />
+                                    <Section title='Conditions' items={CONDITIONS} />
                                 </div>
                                 <div style={{
                                     textAlign: 'center',
@@ -253,7 +253,7 @@ export default function Jobs() {
                                             openApplicationForm(openJob);
                                         }
                                     }}>
-                                        Jetzt bewerben
+                                        Apply now
                                     </Button>
                                 </div>
                             </> : null

--- a/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/docs-src/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -13,7 +13,7 @@ import { HOME_TITLE, JOBS_TITLE } from '../../../constants';
  * equal to `siteConfig.title`. That is too narrow for us: the homepage and
  * /consulting/ carry the longer descriptive HOME_TITLE, and /jobs/ carries
  * JOBS_TITLE. Both already contain the brand, so appending the suffix would
- * render `RxDB - JavaScript Database | RxDB` and `Jobs & Stellenangebote bei
+ * render `RxDB - JavaScript Database | RxDB` and `Jobs & Open Positions at
  * RxDB | RxDB`. Treat them the way Docusaurus treats the site title.
  *
  * This is an explicit list rather than a rule such as `ends with RxDB`, because


### PR DESCRIPTION
`/jobs` was the only German page on the site apart from the legal notice and the privacy policy, and it set its own `lang="de"` to say so. It is now English like everything else, and that attribute is gone, so the page inherits the site default.

## What changes

- **The page text**, headline, intro, both adverts (teaser, tasks, requirements), the shared conditions, the section headings and the buttons.
- **The page title**, `JOBS_TITLE` in `constants.ts`, from `Jobs & Stellenangebote bei RxDB` to `Jobs & Open Positions at RxDB`. It still names the brand, so it stays on the `TitleFormatter` list that suppresses the sitewide ` | RxDB` suffix.
- **`jobs.tsx` comes off the codespell skip list.** It was only there because the page was German and codespell flags ordinary German words as English misspellings. The page is English now, so its spelling should be checked, and the comment above the list no longer claims otherwise.
- **Both adverts are written as job descriptions rather than as a pitch.** The first English draft addressed the reader directly (`You make the videos yourself`). Each teaser is now a role summary, responsibilities and requirements are stated as neutral phrases, and the section heading `Tasks` becomes `Responsibilities`.
- **The video role describes production, not posting.** Its responsibilities lead with planning, filming and the full edit (cut, sound, titles, thumbnails) before distribution and channel work, and the requirement asks for independent filming and editing shown by work samples.

## Two things deliberately stay German

- **`Werkstudent`.** It is a specific German employment status, not a job title, so translating it would name something that does not exist. The job titles read `Working Student (m/f/d) Developer Experience, ...` and the intro now says outright that both positions are German Werkstudent roles based in Stuttgart, which an English-reading visitor otherwise has to infer from the currency and the city.
- **The gender marker**, in its English form `(m/f/d)` instead of `(m/w/d)`.

## Verified

- Built the docs and read the rendered output: the title carries no suffix, the headline is `Careers at RxDB`, and the meta description is the new English one
- `codespell --ignore-words=config/codespellignore.txt --skip="legal-notice.tsx,privacy.tsx,custom.css" docs-src/src` exits 0, so removing the skip entry does not turn `test-code-style` red
- Drove the built page with Playwright: each advert still opens its own Pipedrive form, switching between the two adverts swaps the iframe, one visible modal each time, and both adverts open scrolled to the top (`scrollTop: 0`)
- Opened both adverts after the rewrite and read the full modal text back, so every responsibility, requirement and condition renders as intended
- `npx eslint` clean on all changed source files

Screenshots are delivered in chat rather than committed, per the repo's no-binary-assets rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw