### PR TITLE
docs(jobs): set the working student rate to 18 € per hour

### DIFF
--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -16,7 +16,7 @@ import { JOBS_TITLE } from '../constants';
  * because a visitor reads one of them and never the other.
  */
 const CONDITIONS = [
-    '20 € per hour',
+    '18 € per hour',
     '10 to 20 hours per week, scheduled around the lecture timetable',
     'Regularly on site in Stuttgart, Germany 🇩🇪, part of the time from home',
     'Start date by arrangement, mid-semester is possible',
@@ -126,7 +126,7 @@ export default function Jobs() {
             </Head>
             <Layout
                 title={JOBS_TITLE}
-                description="Open working student positions at RxDB in Stuttgart, Germany. 20 € per hour."
+                description="Open working student positions at RxDB in Stuttgart, Germany. 18 € per hour."
             >
                 <main>
 
@@ -202,7 +202,7 @@ export default function Jobs() {
                                                 opacity: 0.7,
                                                 flexGrow: 1
                                             }}>
-                                                20 € per hour, 10 to 20 hours per week,
+                                                18 € per hour, 10 to 20 hours per week,
                                                 on site in Stuttgart, Germany 🇩🇪
                                             </div>
                                             <div style={{ textAlign: 'center', marginTop: 28 }}>


### PR DESCRIPTION
Both working student positions advertised **20 € per hour**. A wage benchmark put that above every measured average for 2026, and outside the band entirely for the video role, so the rate becomes **18 € for both**.

## Why 18

| Benchmark | Rate |
| --- | --- |
| Statutory minimum wage (since 2026-01-01) | 13.90 € |
| Werkstudent Informatik, national average | 14.96 € |
| Werkstudent Stuttgart, all fields | 15.52 € |
| Werkstudent Medienbranche, national | 14.00 € |
| The one Stuttgart-region social-media ad that states a rate | 17 to 19 € |

18 € stays above every one of those, so the rate is still an argument in a city where the competition for these students is Bosch, Mercedes and Porsche. It just stops being 43% above the media average for a role that is half media work.

Worth noting for anyone reading the diff: of about 75 live Stuttgart working student adverts surveyed, only 3 state a rate at all. Publishing one is the unusual part, which is why the number stays in the tile summary and the meta description rather than becoming "competitive pay".

## What changes

Three occurrences in `docs-src/src/pages/jobs.tsx`, no structural change:

- the shared conditions list, `20 € per hour` becomes `18 € per hour`
- the tile summary line under each advert
- the page meta description

## Verified

- Built the docs and read the rendered page: `18 € per hour` appears in the conditions and the tile summary, the meta description is `Open working student positions at RxDB in Stuttgart, Germany. 18 € per hour.`, and no `20 €` remains anywhere in the output
- `npx eslint docs-src/src/pages/jobs.tsx` clean
- `codespell --ignore-words=config/codespellignore.txt --skip="legal-notice.tsx,privacy.tsx,custom.css" docs-src/src` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw

---
_Generated by [Claude Code](https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw)_