### PR TITLE
FIX document not found after cleanup() and re-insert of the same primary key

### DIFF
--- a/orga/changelog/fix-doc-cache-stale-tombstone-after-cleanup.md
+++ b/orga/changelog/fix-doc-cache-stale-tombstone-after-cleanup.md
@@ -1,0 +1,1 @@
+- FIX `DocumentCache`: a document that is re-inserted after the cleanup purged its tombstone was no longer found by `findOne()` and by primary key queries, because the new revision chain starts at height `1` and the out-of-order protection kept the cached tombstone. [#8948](https://github.com/pubkey/rxdb/pull/8948)

--- a/src/doc-cache.ts
+++ b/src/doc-cache.ts
@@ -136,7 +136,7 @@ export class DocumentCache<RxDocType, OrmMethods> {
                         const currentLatest = cacheItem[1];
                         if (
                             !currentLatest ||
-                            !isOlderDocumentState(documentData._rev, currentLatest._rev)
+                            isNewerDocumentState(documentData, currentLatest)
                         ) {
                             cacheItem[1] = documentData;
                         }
@@ -200,6 +200,31 @@ export class DocumentCache<RxDocType, OrmMethods> {
             return cacheItem[1];
         }
     }
+}
+
+/**
+ * Determines if the given document state has to overwrite
+ * the currently cached latest state of that document.
+ */
+function isNewerDocumentState<RxDocType>(
+    checkState: RxDocumentData<RxDocType>,
+    currentLatest: RxDocumentData<RxDocType>
+): boolean {
+    /**
+     * When the cleanup has purged the tombstone of a deleted document,
+     * a write to the same primary key starts a new revision chain at height 1.
+     * That state has a lower revision height than the cached tombstone
+     * while still being the newer state, so here we compare by the write time
+     * instead of by the revision.
+     */
+    if (
+        currentLatest._deleted &&
+        !checkState._deleted &&
+        checkState._meta.lwt > currentLatest._meta.lwt
+    ) {
+        return true;
+    }
+    return !isOlderDocumentState(checkState._rev, currentLatest._rev);
 }
 
 /**

--- a/test/unit/cleanup.test.ts
+++ b/test/unit/cleanup.test.ts
@@ -205,6 +205,41 @@ describe('cleanup.test.js', () => {
         });
     });
     describe('issues', () => {
+        it('#8948 must find a document that was re-inserted after the cleanup purged its tombstone', async () => {
+            const db = await createRxDatabase({
+                name: randomToken(10),
+                storage: config.storage.getStorage(),
+                eventReduce: true
+            });
+            const cols = await db.addCollections({
+                humans: {
+                    schema: schemas.human
+                }
+            });
+            const collection: RxCollection<HumanDocumentType> = cols.humans;
+
+            const docData = schemaObjects.humanData('foobar');
+            await collection.insert(docData);
+            const doc = await collection.findOne(docData.passportId).exec(true);
+            await doc.remove();
+            await collection.cleanup(0);
+
+            // the cleanup purged the tombstone, so this write starts a new revision chain
+            await collection.insert(docData);
+
+            const byId = await collection.findOne(docData.passportId).exec();
+            assert.ok(byId, 'findOne() by primary key must return the re-inserted document');
+
+            const bySelector = await collection.find({
+                selector: { passportId: docData.passportId }
+            }).exec();
+            assert.strictEqual(bySelector.length, 1);
+
+            const latest = collection._docCache.getLatestDocumentDataIfExists(docData.passportId);
+            assert.strictEqual(ensureNotFalsy(latest)._deleted, false);
+
+            await db.close();
+        });
         it('minimumDeletedTime not respected', async () => {
             const dbName = 'test-cleanup-' + Date.now() + '-' + randomToken(10);
             try {

--- a/test/unit/doc-cache.test.ts
+++ b/test/unit/doc-cache.test.ts
@@ -240,6 +240,55 @@ describe('doc-cache.test.ts', () => {
                 assert.strictEqual(latest.name, 'Bob');
                 assert.strictEqual(latest._rev, EXAMPLE_REVISION_2);
             });
+            it('should accept a re-insert that restarts the revision chain after a cleanup', () => {
+                /**
+                 * When the cleanup purges the tombstone of a deleted document,
+                 * a re-insert of the same primary key starts a new revision chain
+                 * at height 1. The out-of-order protection must not treat that
+                 * state as older than the cached tombstone.
+                 * @link https://github.com/pubkey/rxdb/pull/8948
+                 */
+                const { cache, changes$ } = createDocumentCache();
+                const tombstone = createFakeDocData('doc1', EXAMPLE_REVISION_2, 2, 'Alice', 30);
+                tombstone._deleted = true;
+                cache.getCachedRxDocuments([tombstone]);
+
+                const reInserted = createFakeDocData('doc1', EXAMPLE_REVISION_1, 3, 'Bob', 31);
+                changes$.next([{
+                    documentId: 'doc1',
+                    documentData: reInserted,
+                    previousDocumentData: undefined,
+                    operation: 'INSERT',
+                    isLocal: false
+                } as any]);
+
+                cache.processTasks();
+                const latest = cache.getLatestDocumentData('doc1');
+                assert.strictEqual(latest._deleted, false);
+                assert.strictEqual(latest.name, 'Bob');
+                assert.strictEqual(latest._rev, EXAMPLE_REVISION_1);
+            });
+            it('should not resurrect a deleted document by an older change event', () => {
+                const { cache, changes$ } = createDocumentCache();
+                const tombstone = createFakeDocData('doc1', EXAMPLE_REVISION_2, 2, 'Alice', 30);
+                tombstone._deleted = true;
+                cache.getCachedRxDocuments([tombstone]);
+
+                // the insert happened before the delete, so it must not win
+                const staleInsert = createFakeDocData('doc1', EXAMPLE_REVISION_1, 1, 'Bob', 31);
+                changes$.next([{
+                    documentId: 'doc1',
+                    documentData: staleInsert,
+                    previousDocumentData: undefined,
+                    operation: 'INSERT',
+                    isLocal: false
+                } as any]);
+
+                cache.processTasks();
+                const latest = cache.getLatestDocumentData('doc1');
+                assert.strictEqual(latest._deleted, true);
+                assert.strictEqual(latest._rev, EXAMPLE_REVISION_2);
+            });
             it('should ignore change events for documents not in cache', () => {
                 const { cache, changes$ } = createDocumentCache();
                 const docData = createFakeDocData('unknown', EXAMPLE_REVISION_1);


### PR DESCRIPTION
## This PR contains:

A BUGFIX and IMPROVED TESTS.

## Describe the problem you have without this PR

Fixes the bug reported by the failing test in https://github.com/pubkey/rxdb/pull/8948.

The sequence `insert` → `remove()` → `cleanup(0)` → insert the same primary key again writes the second document correctly, but the live instance does not find it:

```ts
await collection.insert({ passportId: 'foobar' });
const doc = await collection.findOne('foobar').exec(true);
await doc.remove();
await collection.cleanup(0);

await collection.insert({ passportId: 'foobar' });

await collection.findOne('foobar').exec();                        // null
await collection.find({ selector: { passportId: 'foobar' } }).exec(); // []
await collection.find().exec();                                   // [doc]
await collection.count().exec();                                  // 1
```

### Root cause

The out-of-order protection of the `DocumentCache` (from #8609) compares document states by revision height only. When the cleanup purges the tombstone, the re-insert starts a new revision chain at height `1`, which is lower than the height `2` of the cached tombstone. So the change event of the re-insert is rejected and the cache keeps the tombstone as the latest known state of that document.

`findOne(primaryKey)` and the primary key fast-path of `find()` read the latest state through the doc-cache, so they see the tombstone and return nothing. `find()` without a selector and `count()` go to the storage and are therefore correct, which is why this does not look like query-cache staleness. Reopening the database creates a fresh cache and the document shows up again.

### The fix

The cached latest state may now also be overwritten when the cached state is deleted, the incoming state is not deleted, and the incoming state was written later (`_meta.lwt`). Across a cleanup boundary the revision height is meaningless, but the write time still orders the two states.

Comparing the write time keeps the out-of-order protection intact: a stale `INSERT` event that arrives after the delete carries a lower `lwt` than the tombstone, so it still does not resurrect the document.

An alternative fix would be to evict deleted entries from `cacheItemByDocId` after a cleanup pass. That was not taken because it drops the cache item while `RxDocument` instances for that document can still be alive, and `RxDocument.getLatest()` throws when the cache item is gone. It also only repairs the instance that ran the cleanup, while the fix here works for every instance that receives the change event.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Typings
- [x] Changelog

Two regression tests, both verified to fail on `master` and pass with the fix:

- `cleanup.test.ts`: `#8948 must find a document that was re-inserted after the cleanup purged its tombstone` covers the whole reported sequence.
- `doc-cache.test.ts`: one test for the re-insert that restarts the revision chain, one that asserts an older change event still does not resurrect a deleted document.

`npm run lint`, `npm run check-types`, `npm run test:fast:memory` and `npm run test:fast:dexie` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGzhxpqmBaCeNkqfh3tZj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGzhxpqmBaCeNkqfh3tZj5)_