### PR TITLE
FIX typos and a stale link reported by the rxdb.info site check

### DIFF
--- a/docs-src/docs/articles/javascript-vector-database.md
+++ b/docs-src/docs/articles/javascript-vector-database.md
@@ -596,7 +596,7 @@ await myDatabase.addCollections({
 
 For now our vector database works and we are good to go. However there are some things to consider for the future:
 
-- **WebGPU** is [not fully supported](https://caniuse.com/webgpu) yet. When this changes, creating embeddings in the browser have the potential to become faster. You can check if your current chrome supports WebGPU by opening `chrome://gpu/`. Notice that WebGPU has been reported to sometimes be [even slower](https://github.com/xenova/transformers.js/issues/894#issuecomment-2323897485) compared to WASM but likely it will be faster in the long term.
+- **WebGPU** is [not fully supported](https://caniuse.com/webgpu) yet. When this changes, creating embeddings in the browser have the potential to become faster. You can check if your current chrome supports WebGPU by opening `chrome://gpu/`. Notice that WebGPU has been reported to sometimes be [even slower](https://github.com/huggingface/transformers.js/issues/894) compared to WASM but likely it will be faster in the long term.
 - **Cross-Modal AI Models**: While progress is being made, AI models that can understand and integrate multiple modalities are still in development. For example you could query for an **image** together with a **text** prompt to get a more detailed output.
 - **Multi-Step queries**: In this article we only talked about having a single query as input and an ordered list of outputs. But there is big potential in chaining models or queries together where you take the results of one query and input them into a different model with different embeddings or outputs.
 

--- a/docs-src/docs/articles/json-database.md
+++ b/docs-src/docs/articles/json-database.md
@@ -27,7 +27,7 @@ Storing data as **JSON documents** in a **[NoSQL](./in-memory-nosql-database.md)
 ## Storage and Access Options for JSON Documents
 When incorporating JSON documents into your application, you have several storage and access options to consider:
 
-- **Local In-App Database with In-Memory Storage**: Ideal for lightweight applications or temporary data storage, this option keeps data in memory, ensuring fast read and write operations. However, data is not persistet beyond the current application session, making it suitable for temporary data storage. With RxDB, the [memory RxStorage](../rx-storage-memory.md) can be utilized to create an in-memory database.
+- **Local In-App Database with In-Memory Storage**: Ideal for lightweight applications or temporary data storage, this option keeps data in memory, ensuring fast read and write operations. However, data is not persisted beyond the current application session, making it suitable for temporary data storage. With RxDB, the [memory RxStorage](../rx-storage-memory.md) can be utilized to create an in-memory database.
 
 - **Local In-App Database with Persistent Storage**: Suitable for applications requiring data retention across sessions. Data is stored on the user's device or inside of the Node.js application, offering persistence between application sessions. It balances speed and data retention, making it versatile for various applications. With RxDB, a whole range of persistent storages is available. As example, for browser there is the [IndexedDB storage](../rx-storage-indexeddb.md). For server side applications, the [Node.js Filesystem storage](../rx-storage-filesystem-node.md) can be used. There are [many more storages](../rx-storage.md) for React-Native, Flutter, Capacitors.js and others.
 
@@ -87,7 +87,7 @@ Certainly! Let's delve deeper into the performance aspects of RxDB when it comes
 
 2. **Scalability:** As your application grows and your [JSON dataset](./json-based-database.md) expands, RxDB scales gracefully. Its performance remains consistent, enabling you to handle increasingly larger volumes of data without compromising on speed or responsiveness. This scalability is essential for applications that need to accommodate growing user bases and evolving data needs.
 
-3. **Reduced Latency:** RxDB's streamlined data access mechanisms significantly reduce latency when working with JSON data. Whether you're reading from the database, making updates, or synchronizing data between clients and servers, RxDB's optimized operations help minimize the delays often associated with data access. Observed queries are optimized with the [EventReduce algorithm](https://github.com/pubkey/event-reduce) to provide nearly-instand UI updates on data changes.
+3. **Reduced Latency:** RxDB's streamlined data access mechanisms significantly reduce latency when working with JSON data. Whether you're reading from the database, making updates, or synchronizing data between clients and servers, RxDB's optimized operations help minimize the delays often associated with data access. Observed queries are optimized with the [EventReduce algorithm](https://github.com/pubkey/event-reduce) to provide nearly instant UI updates on data changes.
 
 4. **RxStorage Layer**: Because RxDB allows you to swap out the storage layer. A storage with the most optimal performance can be chosen for each runtime while not touching other database code. Depending on the access patterns, you can pick exactly the storage that is best:
 

--- a/docs-src/docs/articles/localstorage-indexeddb-cookies-opfs-sqlite-wasm.md
+++ b/docs-src/docs/articles/localstorage-indexeddb-cookies-opfs-sqlite-wasm.md
@@ -304,7 +304,7 @@ Here we can notice a few things:
 
 ## Performance Conclusions
 
-- LocalStorage is really fast but remember that is has some downsides:
+- LocalStorage is really fast but remember that it has some downsides:
   - It blocks the main JavaScript process and therefore should not be used for big bulk operations.
   - Only Key-Value assignments are possible, you cannot use it efficiently when you need to do index based range queries on your data.
 - OPFS is way faster when used in the WebWorker with the `createSyncAccessHandle()` method compare to using it directly in the main thread.
@@ -315,10 +315,10 @@ Here we can notice a few things:
 ## Possible Improvements
 
 There is a wide range of possible improvements and performance hacks to speed up the operations.
-- For IndexedDB I have made a list of [performance hacks here](../slow-indexeddb.md). For example you can do sharding between multiple database and webworkers or use a custom index strategy.
+- For IndexedDB I have made a list of [performance hacks here](../slow-indexeddb.md). For example you can do sharding between multiple database and WebWorkers or use a custom index strategy.
 - OPFS is slow in writing one file per document. But you do not have to do that and instead you can store everything at a single file like a normal database would do. This improves performance dramatically like it was done with the RxDB [OPFS RxStorage](../rx-storage-opfs.md).
 - You can mix up the technologies to optimize for multiple scenarios at once. For example in RxDB there is the [localstorage meta optimizer](../rx-storage-localstorage-meta-optimizer.md) which stores initial metadata in localstorage and "normal" documents inside of IndexedDB. This improves the initial startup time while still having the documents stored in a way to query them efficiently.
-- There is the [memory-mapped](../rx-storage-memory-mapped.md) storage plugin in RxDB which maps data directly to memory. Using this in combination with a shared worker can improve pageloads and query time significantly.
+- There is the [memory-mapped](../rx-storage-memory-mapped.md) storage plugin in RxDB which maps data directly to memory. Using this in combination with a shared worker can improve page loads and query time significantly.
 - [Compressing](../key-compression.md) data before storing it might improve the performance for some of the storages.
 - Splitting work up between [multiple WebWorkers](../rx-storage-worker.md) via [sharding](../rx-storage-sharding.md) can improve performance by utilizing the whole capacity of your users device.
 

--- a/docs-src/docs/downsides-of-offline-first.md
+++ b/docs-src/docs/downsides-of-offline-first.md
@@ -24,7 +24,7 @@ In the following I will point out the limitations you need to know before you de
 ## It only works with small datasets
 
 Making data available offline means it must be loaded from the server and then stored at the clients device.
-You need to load the full dataset on the first pageload and on every ongoing load you need to download the new changes to that set.
+You need to load the full dataset on the first page load and on every ongoing load you need to download the new changes to that set.
 While in theory you could download in infinite amount of data, in practice you have a limit how long the user can wait before having an up-to-date state.
 You want to display chat messages like Whatsapp? No problem. Syncing all the messages a user could write, can be done with a few HTTP requests.
 Want to make a tool that displays server logs? Good luck downloading terabytes of data to the client just to search for a single string. This will not work.

--- a/docs-src/docs/nodejs-database.md
+++ b/docs-src/docs/nodejs-database.md
@@ -52,7 +52,7 @@ const result = await db.users.find({
 
 ```
 
-Another alternative storage is the [SQLite RxStorage](./rx-storage-sqlite.md) that stores the data inside of a SQLite filebased database. The SQLite storage is faster than FoundationDB and does not require to set up a cluster or anything because SQLite directly stores and reads the data inside of the filesystem. The downside of that is that it only scales vertically.
+Another alternative storage is the [SQLite RxStorage](./rx-storage-sqlite.md) that stores the data inside of a SQLite file-based database. The SQLite storage is faster than FoundationDB and does not require to set up a cluster or anything because SQLite directly stores and reads the data inside of the filesystem. The downside of that is that it only scales vertically.
 
 ```ts
 import { createRxDatabase } from 'rxdb';

--- a/docs-src/docs/reactivity.md
+++ b/docs-src/docs/reactivity.md
@@ -197,7 +197,7 @@ const todosSignal = db.todos.find().$$;
 
 ## Accessing custom reactivity objects
 
-All observable data in RxDB is marked by the single dollar sign `$` like [RxCollection](./rx-collection.md).$ for events or `RxDocument.myField$` to get the observable for a document field. To make custom reactivity objects distinguable, they are marked with double-dollar signs `$$` instead. Here are some example on how to get custom reactivity objects from RxDB specific instances:
+All observable data in RxDB is marked by the single dollar sign `$` like [RxCollection](./rx-collection.md).$ for events or `RxDocument.myField$` to get the observable for a document field. To make custom reactivity objects distinguishable, they are marked with double-dollar signs `$$` instead. Here are some example on how to get custom reactivity objects from RxDB specific instances:
 
 ```ts
 // RxDocument

--- a/docs-src/docs/releases/13.0.0.md
+++ b/docs-src/docs/releases/13.0.0.md
@@ -8,7 +8,7 @@ image: /headers/13.0.0.jpg
 # 13.0.0
 
 So in the last major RxDB versions, the focus was set to **improvements of the storage engine**. This is done. RxDB has now [multiple RxStorage implementations](../rx-storage.md), a better query planner and an improved test suite to ensure everything works correct.
-This let to huge improvements in write and query performance and decreased the initial pageload of RxDB based applications.
+This let to huge improvements in write and query performance and decreased the initial page load of RxDB based applications.
 
 In the new major version `13.0.0`, the focus was set to improvements to the **replication protocol**.
 When I first implemented the [GraphQL replication](../replication-graphql.md) a few years ago, I had a specific use case in mind and designed the whole protocol and replication plugins around that use case.

--- a/docs-src/docs/rx-state.md
+++ b/docs-src/docs/rx-state.md
@@ -54,7 +54,7 @@ await myState.set('myField', v => v + 1);
 await myState.set('myField', v => 42);
 ```
 
-The modifier is used instead of a direct assignment to ensure correct behavior when other JavaScript realms write to the state at the same time, like other browser tabs or webworkers. On conflicts, the modifier will just be run again to ensure deterministic and correct behavior. Therefore mutation is `async`, you have to `await` the call to the set function when you care about the moment when the change actually happened.
+The modifier is used instead of a direct assignment to ensure correct behavior when other JavaScript realms write to the state at the same time, like other browser tabs or WebWorkers. On conflicts, the modifier will just be run again to ensure deterministic and correct behavior. Therefore mutation is `async`, you have to `await` the call to the set function when you care about the moment when the change actually happened.
 
 
 ## Get State Data
@@ -95,7 +95,7 @@ observable.subscribe(newValue => {
     // update the UI
 });
 ```
-Subscription works across multiple JavaScript realms like browser tabs or Webworkers.
+Subscription works across multiple JavaScript realms like browser tabs or WebWorkers.
 
 ## RxState with signals and hooks
 

--- a/docs-src/docs/rx-storage-localstorage-meta-optimizer.md
+++ b/docs-src/docs/rx-storage-localstorage-meta-optimizer.md
@@ -11,7 +11,7 @@ import {PremiumBlock} from '@site/src/components/premium-block';
 
 The [RxStorage](./rx-storage.md) Localstorage Meta Optimizer is a wrapper around any other RxStorage. The wrapper uses the original RxStorage for normal collection documents. But to optimize the initial page load time, it uses [localstorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage?retiredLocale=de) to store the plain key-value metadata that RxDB needs to create databases and collections. This plugin can only be used in browsers.
 
-Depending on your database usage and the collection amount, this can save about 200 milliseconds on the initial pageload. It is recommended to use this when you create more than 4 [RxCollections](./rx-collection.md).
+Depending on your database usage and the collection amount, this can save about 200 milliseconds on the initial page load. It is recommended to use this when you create more than 4 [RxCollections](./rx-collection.md).
 
 <PremiumBlock />
 

--- a/docs-src/docs/slow-indexeddb.md
+++ b/docs-src/docs/slow-indexeddb.md
@@ -133,7 +133,7 @@ RxDB uses batched cursors in the [IndexedDB RxStorage](./rx-storage-indexeddb.md
 
 Sharding is a technique, normally used in server side databases, where the database is partitioned horizontally. Instead of storing all documents at one table/collection, the documents are split into so called **shards** and each shard is stored on one table/collection. This is done in server side architectures to spread the load between multiple physical servers which **increases scalability**.
 
-When you use IndexedDB in a browser, there is of course no way to split the load between the client and other servers. But you can still benefit from sharding. Partitioning the documents horizontally into **multiple IndexedDB stores**, has shown to have a big performance improvement in write- and read operations while only increasing initial pageload slightly.
+When you use IndexedDB in a browser, there is of course no way to split the load between the client and other servers. But you can still benefit from sharding. Partitioning the documents horizontally into **multiple IndexedDB stores**, has shown to have a big performance improvement in write- and read operations while only increasing initial page load slightly.
 
 <p align="center">
   <img src="./files/indexeddb-sharding-performance.png" alt="IndexedDB sharding performance" width="100%" />
@@ -189,10 +189,10 @@ myIndexedDBObjectStore.createIndex(
 
 ```
 
-To iterate over the index, you also use a custom crafted keyrange, depending on the last batched cursor checkpoint. Therefore the `maxLength` of `id` must be known.
+To iterate over the index, you also use a custom crafted key range, depending on the last batched cursor checkpoint. Therefore the `maxLength` of `id` must be known.
 
 ```ts
-// keyrange for normal index
+// key range for normal index
 const range = IDBKeyRange.bound(
     [25, ''],
     [Infinity, Infinity],
@@ -200,7 +200,7 @@ const range = IDBKeyRange.bound(
     false
 );
 
-// keyrange for custom index
+// key range for custom index
 const range = IDBKeyRange.bound(
     // combine both values to a single string
     25 + ''.padStart(idMaxLength, ' '),
@@ -250,7 +250,7 @@ There are some libraries that already do that:
 
 - LokiJS with the [IndexedDB Adapter](https://techfort.github.io/LokiJS/LokiIndexedAdapter.html)
 - [Absurd-SQL](https://github.com/jlongster/absurd-sql)
-- SQL.js with the [empscripten Filesystem API](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs)
+- SQL.js with the [Emscripten Filesystem API](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs)
 - [DuckDB Wasm](https://duckdb.org/2021/10/29/duckdb-wasm.html)
 
 ### In-Memory: Persistence

--- a/orga/changelog/fix-error-message-typos.md
+++ b/orga/changelog/fix-error-message-typos.md
@@ -1,0 +1,1 @@
+- FIX typos in the dev-mode error messages: `DB6` had the docs URL glued to the sentence (`Read thishttps://...`), `GDR18` said `exxeeded` instead of `exceeded`, and `MQ4` said `instanceof` instead of `instance of`.

--- a/src/plugins/dev-mode/error-messages.ts
+++ b/src/plugins/dev-mode/error-messages.ts
@@ -203,7 +203,7 @@ export const ERROR_MESSAGES = {
         docs: ''
     },
     MQ4: {
-        message: 'Invalid argument. Expected instanceof mquery or plain object',
+        message: 'Invalid argument. Expected instance of mquery or plain object',
         cause: '',
         fix: '',
         docs: ''
@@ -265,7 +265,7 @@ export const ERROR_MESSAGES = {
         docs: 'https://rxdb.info/rx-collection.html?console=errors&code=DB5'
     },
     DB6: {
-        message: 'RxDatabase.addCollections(): another instance created this collection with a different schema. Read thishttps://rxdb.info/rx-schema.html?console=qa#faq ',
+        message: 'RxDatabase.addCollections(): another instance created this collection with a different schema. Read this: https://rxdb.info/rx-schema.html?console=qa#faq',
         cause: 'The schema hash does not match the schema stored in the internal database.',
         fix: 'If you changed the schema, you must increment the version number. If not, check why the hash is different.',
         docs: 'https://rxdb.info/rx-schema.html?console=errors&code=DB6#faq'
@@ -1292,7 +1292,7 @@ export const ERROR_MESSAGES = {
         docs: 'https://rxdb.info/replication-google-drive.html?console=errors&code=GDR11'
     },
     GDR18: {
-        message: 'Max batch size exxeeded for google drive sync',
+        message: 'Max batch size exceeded for google drive sync',
         cause: '',
         fix: 'Reduce the batchSize to be lower',
         docs: 'https://rxdb.info/replication-google-drive.html?console=errors&code=GDR18'


### PR DESCRIPTION
## This PR contains:

- IMPROVED DOCS
- A BUGFIX (three wrong strings in the dev-mode error messages)

## Describe the problem you have without this PR

A site check over rxdb.info reported 18 spelling/grammar findings and one broken link. All of them were real.

**Dev-mode error messages** (`src/plugins/dev-mode/error-messages.ts`), these are the strings users see in the console:

- `DB6`: the docs URL was glued to the sentence, so it read `Read thishttps://rxdb.info/rx-schema.html?console=qa#faq`.
- `GDR18`: `Max batch size exxeeded for google drive sync`.
- `MQ4`: `Expected instanceof mquery or plain object` -> `instance of`.

**Documentation typos:**

- `reactivity.md`: `distinguable` -> `distinguishable`
- `slow-indexeddb.md`: `empscripten` -> `Emscripten`, `keyrange` -> `key range` (`IDBKeyRange` untouched)
- `nodejs-database.md`: `filebased` -> `file-based`
- `articles/json-database.md`: `persistet` -> `persisted`, `nearly-instand` -> `nearly instant`
- `articles/localstorage-indexeddb-cookies-opfs-sqlite-wasm.md`: `remember that is has` -> `remember that it has`
- `rx-state.md` and the localstorage article: `webworkers`/`Webworkers` -> `WebWorkers`, matching the casing used everywhere else
- `pageload`/`pageloads` -> `page load`/`page loads` in `slow-indexeddb.md`, `downsides-of-offline-first.md`, `rx-storage-localstorage-meta-optimizer.md`, `releases/13.0.0.md` and the localstorage article

**Broken link** in `articles/javascript-vector-database.md`: it pointed at `github.com/xenova/transformers.js/issues/894#issuecomment-2323897485`. The repository moved to the `huggingface` org and the linked comment no longer exists, so the link now goes to the issue under its current owner: `github.com/huggingface/transformers.js/issues/894`. The issue itself still carries the WebGPU vs WASM benchmark numbers the sentence refers to.

## Todos

- [ ] Tests <!-- no behavior change, only message strings and prose -->
- [x] Documentation
- [ ] Typings
- [x] Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrLHccTueiN5SVHE2bnF3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrLHccTueiN5SVHE2bnF3x)_