### PR TITLE
docs(jobs): set the working student rate to 17 € per hour

### DIFF
--- a/docs-src/src/pages/jobs.tsx
+++ b/docs-src/src/pages/jobs.tsx
@@ -16,7 +16,7 @@ import { JOBS_TITLE } from '../constants';
  * because a visitor reads one of them and never the other.
  */
 const CONDITIONS = [
-    '18 € per hour',
+    '17 € per hour',
     '10 to 20 hours per week, scheduled around the lecture timetable',
     'Regularly on site in Stuttgart, Germany 🇩🇪, part of the time from home',
     'Start date by arrangement, mid-semester is possible',
@@ -126,7 +126,7 @@ export default function Jobs() {
             </Head>
             <Layout
                 title={JOBS_TITLE}
-                description="Open working student positions at RxDB in Stuttgart, Germany. 18 € per hour."
+                description="Open working student positions at RxDB in Stuttgart, Germany. 17 € per hour."
             >
                 <main>
 
@@ -202,7 +202,7 @@ export default function Jobs() {
                                                 opacity: 0.7,
                                                 flexGrow: 1
                                             }}>
-                                                18 € per hour, 10 to 20 hours per week,
+                                                17 € per hour, 10 to 20 hours per week,
                                                 on site in Stuttgart, Germany 🇩🇪
                                             </div>
                                             <div style={{ textAlign: 'center', marginTop: 28 }}>


### PR DESCRIPTION
The advertised rate moves from **18 €** to **17 € per hour** for both working student positions. Follows pubkey/rxdb#9057, which took it from 20 € to 18 €.

## Why 17 still works

| Benchmark | Rate |
| --- | --- |
| Statutory minimum wage (since 2026-01-01) | 13.90 € |
| Werkstudent Informatik, national average | 14.96 € |
| Werkstudent Stuttgart, all fields | 15.52 € |
| Werkstudent Medienbranche, national | 14.00 € |
| Local Stuttgart-region ads that name a rate, media and social | 15 € to 19 € |

17 € stays above every measured average and inside the band of the local adverts that publish a number at all.

## What changes

Three occurrences in `docs-src/src/pages/jobs.tsx`, no structural change:

- the shared conditions list
- the tile summary line under each advert
- the page meta description

## Verified

- Built the docs and read the rendered page: `17 € per hour` appears four times in the output, no `18 €` remains anywhere, and the meta description reads `Open working student positions at RxDB in Stuttgart, Germany. 17 € per hour.`
- `npx eslint docs-src/src/pages/jobs.tsx` clean
- `codespell --ignore-words=config/codespellignore.txt --skip="legal-notice.tsx,privacy.tsx,custom.css" docs-src/src` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw

---
_Generated by [Claude Code](https://claude.ai/code/session_016EbHjqojSWyuVwVFk4HDjw)_